### PR TITLE
Implement/integrate CI tools with the repo

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,26 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - javascript
+  eslint:
+    enabled: false
+  scss-lint:
+    enabled: true
+  fixme:
+    enabled: true
+
+ratings:
+  paths:
+    - "**.js"
+    - "**.scss"
+
+exclude_paths:
+  - test/
+  - "**.yml"
+  - "**.md"
+  - "**.html"
+  - "**.json"
+  - LICENSE
+  - Procfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /node_modules/
 /govuk_modules/
 /public/
+
+# Test coverage output files
 coverage.html
+lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+node_js:
+  - "8"
+cache:
+  directories:
+    - node_modules
+
+before_script:
+  - npm install -g gulp-cli
+
+script: gulp test-ci
+
+after_success:
+  - npm install -g codeclimate-test-reporter
+  - codeclimate-test-reporter < lcov.info
+
+addons:
+  code_climate:
+    repo_token: a2bef0f29bab992cca5a1394240dbbf6a336c930ed8d50e96426a3db947d2a0a

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -102,6 +102,12 @@ gulp.task('test', ['standard'], () => {
     .pipe(lab('--coverage --reporter console --output stdout --reporter html --output coverage.html --verbose'))
 })
 
+// Test task
+gulp.task('test-ci', ['standard'], () => {
+  return gulp.src('test')
+    .pipe(lab('--coverage --reporter console --output stdout --reporter lcov --output lcov.info --verbose'))
+})
+
 // Build task
 gulp.task('build', ['clean'], (done) => {
   runSequence(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Waste Permits Service
 
+[![NSP Status](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc/badge)](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc)
+[![dependencies Status](https://david-dm.org/defra/waste-permits/status.svg)](https://david-dm.org/defra/waste-permits)
+[![Dependency Status](https://dependencyci.com/github/DEFRA/waste-permits/badge)](https://dependencyci.com/github/DEFRA/waste-permits)
+
 You may need to apply to the [Environment Agency](https://www.gov.uk/government/organisations/environment-agency) for an environmental permit if your business uses, recycles, treats, stores or disposes of waste or mining waste. This permit can be for activities at one site or for mobile plant that can be used at many sites.
 
 The Waste Permits service will be a new, online way to apply for a waste permit.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Waste Permits Service
 
+[![Build Status](https://travis-ci.org/DEFRA/waste-permits.svg?branch=master)](https://travis-ci.org/DEFRA/waste-permits)
 [![NSP Status](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc/badge)](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc)
 [![dependencies Status](https://david-dm.org/defra/waste-permits/status.svg)](https://david-dm.org/defra/waste-permits)
+[![Code Climate](https://codeclimate.com/github/DEFRA/waste-permits/badges/gpa.svg)](https://codeclimate.com/github/DEFRA/waste-permits)
+[![Test Coverage](https://codeclimate.com/github/DEFRA/waste-permits/badges/coverage.svg)](https://codeclimate.com/github/DEFRA/waste-permits/coverage)
 [![Dependency Status](https://dependencyci.com/github/DEFRA/waste-permits/badge)](https://dependencyci.com/github/DEFRA/waste-permits)
 
 You may need to apply to the [Environment Agency](https://www.gov.uk/government/organisations/environment-agency) for an environmental permit if your business uses, recycles, treats, stores or disposes of waste or mining waste. This permit can be for activities at one site or for mobile plant that can be used at many sites.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-388

We believe it is good practise to hook up our projects to some form of [Continuous Integration](https://www.thoughtworks.com/continuous-integration) (CI) as early as possible.

This change covers implementing and integrating a number of tools we use across the majority of our Node.js projects, the most critical of which is [Travis-CI](https://travis-ci.org) as this will automate running our unit tests and build scripts for every change to the repo.