### PR TITLE
Feature/we 588 implement dotenv for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# You'll need to set the following in either your environment or in a .env
+# file in the root of the project
+#
+# The values in this file are purely examples to better help understand what it
+# is you need to add
+
+PORT=8000
+
+CRM_WEB_API_HOST="mycrminstance.api.crm4.dynamics.com"
+CRM_WEB_API_PATH="/api/data/v8.2/"
+
+# https://CRMORG...dynamics.com
+CRM_ORG="https://mycrminstance.crm4.dynamics.com"
+
+# Client ID for App registered with Azure AD
+CRM_CLIENT_ID="9lp164fn-4yh9-48ia-77ik-hdy87uuy79ui"
+
+# CRM Username
+CRM_USERNAME="myuser@mycrminstance.onmicrosoft.com"
+
+# CRM Password
+CRM_PASSWORD="Password1"
+
+# OAuth token endpoint for App registered with Azure AD
+CRM_TOKEN_ENDPOINT="login.microsoftonline.com/12345678-oi98-4321-8y8o-8y9456987123/oauth2/token"
+
+# CRM Tenant
+CRM_TENANT="mycrminstance.onmicrosoft.com"

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@
 # The application configuration is read using the Dotenv component
 # (see https://www.npmjs.com/package/dotenv)
 
+# The environment that the Waste Permits Hapi web server is running in.
+# Currently one of the following:
+# - DEVELOPMENT
+# - PRODUCTION
+NODE_ENV=DEVELOPMENT
+
 # The port that the Waste Permits Hapi web server runs on
 WASTE_PERMITS_APP_PORT=8000
 

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@
 #
 # The values in this file are purely examples to better help understand what it
 # is you need to add
+#
+# The application configuration is read using the Dotenv component
+# (see https://www.npmjs.com/package/dotenv)
 
-PORT=8000
+# The port that the Waste Permits Hapi web server runs on
+WASTE_PERMITS_APP_PORT=8000
 
 CRM_WEB_API_HOST="mycrminstance.api.crm4.dynamics.com"
 CRM_WEB_API_PATH="/api/data/v8.2/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 /node_modules/
 /govuk_modules/
 /public/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -126,14 +126,6 @@ gulp.task('browser-sync', ['nodemon'], () => {
   })
 })
 
-gulp.task('set-env', function () {
-  env({
-    vars: {
-      NODE_ENV: 'development'
-    }
-  })
-})
-
 gulp.task('nodemon', (done) => {
   let started = false
 
@@ -156,4 +148,4 @@ gulp.task('watch', () => {
 })
 
 // The default Gulp task starts the app in development mode
-gulp.task('default', ['set-env', 'watch', 'sass', 'browser-sync'])
+gulp.task('default', ['watch', 'sass', 'browser-sync'])

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const HapiAlive = require('hapi-alive')
 const HapiDevErrors = require('hapi-dev-errors')
 const server = new Hapi.Server()
 
+// Load application configuration using Dotenv (see https://www.npmjs.com/package/dotenv)
+require('dotenv').config()
+
 const environment = process.env.NODE_ENV
 
 server.connection({

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ require('dotenv').config()
 const environment = process.env.NODE_ENV
 
 server.connection({
-  port: 8000
+  port: process.env.PORT
 })
 
 // Create a session cookie in which to store a waste permit application token

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ require('dotenv').config()
 const environment = process.env.NODE_ENV
 
 server.connection({
-  port: process.env.PORT
+  port: process.env.WASTE_PERMITS_APP_PORT
 })
 
 // Create a session cookie in which to store a waste permit application token

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const server = new Hapi.Server()
 // Load application configuration using Dotenv (see https://www.npmjs.com/package/dotenv)
 require('dotenv').config()
 
-const environment = process.env.NODE_ENV
-
 server.connection({
   port: process.env.WASTE_PERMITS_APP_PORT
 })
@@ -66,16 +64,16 @@ server.register([
     options: {
       path: '/health',
       healthCheck: function (server, callback) {
-            // TODO: Here you should preform your health checks
-            // If something went wrong provide the callback with an error
+        // TODO: Here you should preform your health checks
+        // If something went wrong provide the callback with an error
         callback()
       }
     }
   }, {
-    // Plugin to return an error view for web request. Only used in development
+    // Plugin to return an error view for web request. Only used when the server is running in DEVELOPMENT mode.
     register: HapiDevErrors,
     options: {
-      showErrors: environment === 'development'
+      showErrors: process.env.NODE_ENV === 'DEVELOPMENT'
     }
   }], (err) => {
   if (err) {
@@ -91,9 +89,8 @@ server.start((err) => {
   if (err) {
     throw err
   }
-  if (environment) {
-    console.info('Server running in environment: [' + environment + ']')
-  }
+
+  console.info('Server running in environment: ' + process.env.NODE_ENV)
   console.info('Server running at:', server.info)
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1490,6 +1490,11 @@
         }
       }
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "blipp": "^2.3.0",
     "disinfect": "^0.2.1",
+    "dotenv": "^4.0.0",
     "govuk-elements-sass": "^3.1.1",
     "govuk_frontend_toolkit": "^7.0.1",
     "govuk_template_mustache": "^0.22.3",


### PR DESCRIPTION
The purpose of this PR is to use the Dotenv framework to read in our application config from a local .env file.

See: https://www.npmjs.com/package/dotenv

The following changes were made:

- Added the Dotenv framework for managing our application configuration. 
- Created and git-ignored a local .env config file.
- Added a .env.example file.
- Confirmed that the config is working by changing the app to use a port number from the config rather than a hard-coded port number.

See https://eaflood.atlassian.net/browse/WE-588