### PR TITLE
Add SameSite=Strict flag to cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,9 @@ server.state(Constants.COOKIE_KEY, {
   ttl: null,                // Session lifespan (deleted when browser closed)
   isSecure: true,           // Secure
   isHttpOnly: true,         // and non-secure
+  isSameSite: 'Strict',     // Don't attach cookies on cross-site requests, preventing CSRF attacks
   encoding: 'base64json',   // Base 64 JSON encoded
-  clearInvalid: false,      // remove invalid cookies
+  clearInvalid: false,      // Remove invalid cookies
   strictHeader: true        // Don't allow violations of RFC 6265
 })
 


### PR DESCRIPTION
Added the SameSite=Strict flag to the cookie. This is so the cookie won't be sent with any requests that come from off-site – very useful for preventing CSRF attacks.

Note that you have to be using Chrome or Opera to test this as it isn't yet supported by other browsers.

You can see SameSite=Strict in action by linking to the contact page from another domain. If it doesn't have the cookie, it will redirect to the error page.

If you inspect the cookie in Chrome, you can also see if SameSite=Strict is switched on.