### PR TITLE
Amend test task for build to fail if tests fail

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -107,7 +107,11 @@ gulp.task('test', ['standard'], () => {
 // Test task
 gulp.task('test-ci', ['standard'], () => {
   return gulp.src('test')
-    .pipe(lab('--coverage --reporter console --output stdout --reporter lcov --output lcov.info --verbose'))
+    .pipe(lab({
+      args: '--coverage --reporter console --output stdout --reporter lcov --output lcov.info --verbose --bail',
+      opts: {
+        emitLabError: true
+      }}))
 })
 
 // Build task


### PR DESCRIPTION
This change adds the `--bail` flag, which stops the tests and returns exit code 1 if the tests fail. It also updates the Gulp task used to run tests on Travis so the build fails if this occurs.