### PR TITLE
Fix not setting config values breaks tests in CI

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,26 +4,26 @@ require('dotenv').config()
 
 module.exports = {
 
-  port: process.env.WASTE_PERMITS_APP_PORT,
+  port: process.env.WASTE_PERMITS_APP_PORT || 8000,
 
-  nodeEnvironment: process.env.NODE_ENV,
+  nodeEnvironment: process.env.NODE_ENV || 'PRODUCTION',
 
   // Domain name or IP address of the server to issue the azure AD auth request
   // to. Passed in as value for `host:` option when we make the https.request()
   // call
-  azureAuthHost: process.env.AZURE_ACTIVE_DIRECTORY_HOST,
+  azureAuthHost: process.env.AZURE_ACTIVE_DIRECTORY_HOST || 'login.microsoftonline.com',
 
   // OAuth token endpoint for App registered with Azure AD.
   // This appended to AZURE_ACTIVE_DIRECTORY_HOST gives the full url.
   // Passed in as value for `path:` option when we make the https.request() call
-  azureAuthPath: process.env.AZURE_ACTIVE_DIRECTORY_PATH,
+  azureAuthPath: process.env.AZURE_ACTIVE_DIRECTORY_PATH || '/12345678-oi98-4321-8y8o-8y9456987123/oauth2/token',
 
   // Client ID for this app registered with Azure AD
   clientId: process.env.DYNAMICS_CLIENT_ID,
 
   // Your Dynamics root service address, which Azure AD uses to identify which
   // resource you are trying to authenticate with
-  resourceAddr: process.env.DYNAMICS_RESOURCE_ADDR,
+  resourceAddr: process.env.DYNAMICS_RESOURCE_ADDR || 'https://mycrminstance.crm4.dynamics.com',
 
   // The app's Dynamics Username. When we authenticate with Azure AD rather than
   // taking a user to a web page where they can enter credentials and then
@@ -35,9 +35,9 @@ module.exports = {
   dynamicsPassword: process.env.DYNAMICS_PASSWORD,
 
   // Dynamics host address for queries via its web API
-  dynamicsWebApiHost: process.env.DYNAMICS_WEB_API_HOST,
+  dynamicsWebApiHost: process.env.DYNAMICS_WEB_API_HOST || 'mycrminstance.api.crm4.dynamics.com',
 
   // Dynamics path for queries via its web API.
   // This appended to CRM_WEB_API_HOST gives the full url for the web API
-  dynamicsWebApiPath: process.env.DYNAMICS_WEB_API_PATH
+  dynamicsWebApiPath: process.env.DYNAMICS_WEB_API_PATH || '/api/data/v8.2/'
 }

--- a/src/controllers/root.controller.js
+++ b/src/controllers/root.controller.js
@@ -21,11 +21,9 @@ module.exports = class RootController extends BaseController {
   static async doPost (request, reply) {
     // Generate a session token
     const token = uuid4()
-    console.log('Generated session token: ' + token)
 
     // Generate a CRM token
     const authToken = await authService.getToken()
-    console.log('Generated CRM token:' + authToken)
 
     // TODO: Confirm how session handling will work and where the most
     // appropriate point is to create and destroy session cookies

--- a/test/services/activeDirectoryAuth.service.test.js
+++ b/test/services/activeDirectoryAuth.service.test.js
@@ -38,8 +38,8 @@ lab.afterEach((done) => {
   done()
 })
 
-lab.experiment('CRM Token Service tests:', () => {
-  lab.test('Get token method should return the correct CRM token', (done) => {
+lab.experiment('Active Directory Auth Service tests:', () => {
+  lab.test('Get token method should return the correct authentication token', (done) => {
     authService.getToken().then((authToken) => {
       Code.expect(authToken).to.equal(authTokenResponse.access_token)
 


### PR DESCRIPTION
We recently spotted that our tests were actually failing on our CI server, yet the build was still being reported as good. PR #12 fixed the problem of the build not failing, this change resolves the problem causing the tests to fail.

Basically because of changes made to how we do config, and ensuring we always use config rather than having hard coded values if the relevant env vars don't exist, the tests will fail.

This change resolves the problem by ensuring we have safe i.e. ok to commit default values for when an env var is missing. In environments like our CI server, it means we don't have to set env vars but the tests will still be able to run as expected.