### PR TITLE
Active Directory token error handling

### DIFF
--- a/src/controllers/root.controller.js
+++ b/src/controllers/root.controller.js
@@ -23,7 +23,14 @@ module.exports = class RootController extends BaseController {
     const token = uuid4()
 
     // Generate a CRM token
-    const authToken = await authService.getToken()
+
+    let authToken
+    try {
+      authToken = await authService.getToken()
+    } catch (err) {
+      console.error(err)
+      return reply.redirect('/error')
+    }
 
     // TODO: Confirm how session handling will work and where the most
     // appropriate point is to create and destroy session cookies

--- a/src/services/activeDirectoryAuth.service.js
+++ b/src/services/activeDirectoryAuth.service.js
@@ -45,9 +45,13 @@ module.exports = class ActiveDirectoryAuthService {
 
           // Parse the response JSON and extract the CRM access token
           const tokenResponse = JSON.parse(completeResponse)
-          const token = tokenResponse.access_token
 
-          resolve(token)
+          const token = tokenResponse.access_token
+          if (token) {
+            resolve(token)
+          } else {
+            reject(new Error('Error obtaining Active Directory auth token: ' + completeResponse))
+          }
         })
       })
 


### PR DESCRIPTION
This PR adds error handling to when we attempt to get an Active Directory token for connecting to Dynamics. We will now redirect off to the error screen if the token unexpectedly isn’t obtained for some reason (e.g. invalid username / password) and we will display error information on the console.