### PR TITLE
Add a label for snyk.io to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/DEFRA/waste-permits.svg?branch=master)](https://travis-ci.org/DEFRA/waste-permits)
 [![NSP Status](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc/badge)](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc)
+[![Known Vulnerabilities](https://snyk.io/test/github/defra/waste-permits/badge.svg)](https://snyk.io/test/github/defra/waste-permits)
 [![dependencies Status](https://david-dm.org/defra/waste-permits/status.svg)](https://david-dm.org/defra/waste-permits)
 [![Code Climate](https://codeclimate.com/github/DEFRA/waste-permits/badges/gpa.svg)](https://codeclimate.com/github/DEFRA/waste-permits)
 [![Test Coverage](https://codeclimate.com/github/DEFRA/waste-permits/badges/coverage.svg)](https://codeclimate.com/github/DEFRA/waste-permits/coverage)


### PR DESCRIPTION
[Snyk](https://snyk.io/) continuously monitors your application's dependencies to identify security vulnerabilities.

Currently we use [Node security platform](https://nodesecurity.io) for Node.js projects, and [Hakiri](https://hakiri.io/) for Ruby based projects. **Snyk** has the ability to support both, which will allow us to standardise on a single tool across our projects.

Integration for **Snyk** is done via their web UI, so all this change does is add a badge to the README for **Snyk**.