### PR TITLE
Fix site page validators after recent id changes

### DIFF
--- a/src/models/dynamicsSolution.model.js
+++ b/src/models/dynamicsSolution.model.js
@@ -21,7 +21,7 @@ module.exports = class DynamicsSolution extends BaseModel {
       const response = await dynamicsDal.search(query)
 
       const dynamicsVersionInfo = []
-      for (let solution of response) {
+      for (let solution of response.value) {
         dynamicsVersionInfo.push({
           componentName: solution.friendlyname,
           version: solution.version

--- a/src/validators/site.validator.js
+++ b/src/validators/site.validator.js
@@ -12,12 +12,12 @@ module.exports = class SiteValidator extends BaseValidator {
     super()
 
     this.errorMessages = {
-      siteName: {
+      'site-name': {
         'any.empty': `Enter the site name`,
         'string.max': `Enter a shorter site name with no more than 170 characters`,
         'string.regex.invert.base': `The site name cannot contain any of these characters: ${DISALLOWED_CHARACTERS}`
       },
-      anotherName: {
+      'another-name': {
         'any.empty': `Enter the other name`,
         'string.max': `Enter a shorter other name with no more than 170 characters`,
         'string.regex.invert.base': `The other name cannot contain any of these characters: ${DISALLOWED_CHARACTERS}`
@@ -27,14 +27,14 @@ module.exports = class SiteValidator extends BaseValidator {
 
   static getFormValidators () {
     return {
-      siteName: Joi
+      'site-name': Joi
         .string()
         .max(SITE_NAME_MAX_LENGTH)
         .regex(DISALLOWED_CHARACTERS_REGEX, {
           invert: true
         })
         .required(),
-      anotherName: Joi
+      'another-name': Joi
         .string()
         .max(SITE_NAME_MAX_LENGTH)
         .regex(DISALLOWED_CHARACTERS_REGEX, {

--- a/src/views/site.html
+++ b/src/views/site.html
@@ -13,7 +13,7 @@
 
       <form method="POST" action="site">
 
-        <div class="form-group {{#getFormErrorGroupClass errors.siteName}}{{/getFormErrorGroupClass}}">
+        <div class="form-group {{#getFormErrorGroupClass errors.site-name}}{{/getFormErrorGroupClass}}">
           <label class="form-label" for="site-name">
             <span id="site-name-label">Site name</span>
             <span class="form-hint">If it doesn’t already have a name, enter the name you’ll use</span>
@@ -21,10 +21,10 @@
 
           {{> common/fieldError fieldId='site-name-error' message=errors.siteName }}
 
-          <input class="form-control form-control-char-60" id="site-name" name="site-name" type="text" value="{{formValues.siteName}}">
+          <input class="form-control form-control-char-60" id="site-name" name="site-name" type="text" value="{{formValues.site-name}}">
         </div>
 
-        <div class="form-group {{#getFormErrorGroupClass errors.anotherName}}{{/getFormErrorGroupClass}}">
+        <div class="form-group {{#getFormErrorGroupClass errors.another-name}}{{/getFormErrorGroupClass}}">
           <label class="form-label" for="another-name">
             Another name
             <span class="form-hint">If it doesn’t already have a name, enter the name you’ll use</span>
@@ -32,7 +32,7 @@
 
           {{> common/fieldError message=errors.anotherName }}
 
-          <input class="form-control form-control-char-60" id="another-name" name="another-name" type="text" value="{{formValues.anotherName}}">
+          <input class="form-control form-control-char-60" id="another-name" name="another-name" type="text" value="{{formValues.another-name}}">
         </div>
 
         <div class="form-group">

--- a/src/views/site.html
+++ b/src/views/site.html
@@ -19,7 +19,7 @@
             <span class="form-hint">If it doesn’t already have a name, enter the name you’ll use</span>
           </label>
 
-          {{> common/fieldError fieldId='site-name-error' message=errors.siteName }}
+          {{> common/fieldError fieldId='site-name-error' message=errors.site-name }}
 
           <input class="form-control form-control-char-60" id="site-name" name="site-name" type="text" value="{{formValues.site-name}}">
         </div>
@@ -30,7 +30,7 @@
             <span class="form-hint">If it doesn’t already have a name, enter the name you’ll use</span>
           </label>
 
-          {{> common/fieldError message=errors.anotherName }}
+          {{> common/fieldError message=errors.another-name }}
 
           <input class="form-control form-control-char-60" id="another-name" name="another-name" type="text" value="{{formValues.another-name}}">
         </div>

--- a/test/routes/site.route.test.js
+++ b/test/routes/site.route.test.js
@@ -59,8 +59,8 @@ lab.experiment('Site page tests:', () => {
       url: '/site',
       headers: {},
       payload: {
-        siteName: 'My Site',
-        anotherName: 'Other site name'
+        'site-name': 'My Site',
+        'another-name': 'Other site name'
       }
     }
 
@@ -97,8 +97,8 @@ lab.experiment('Site page tests:', () => {
       url: '/site',
       headers: {},
       payload: {
-        siteName: '',
-        anotherName: ''
+        'site-name': '',
+        'another-name': ''
       }
     }
 
@@ -122,8 +122,8 @@ lab.experiment('Site page tests:', () => {
       url: '/site',
       headers: {},
       payload: {
-        siteName: '',
-        anotherName: ''
+        'site-name': '',
+        'another-name': ''
       }
     }
 
@@ -154,8 +154,8 @@ lab.experiment('Site page tests:', () => {
       url: '/site',
       headers: {},
       payload: {
-        siteName: '___INVALID_SITE_NAME___',
-        anotherName: ''
+        'site-name': '___INVALID_SITE_NAME___',
+        'another-name': ''
       }
     }
 
@@ -186,8 +186,8 @@ lab.experiment('Site page tests:', () => {
       url: '/site',
       headers: {},
       payload: {
-        siteName: '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789X',
-        anotherName: ''
+        'site-name': '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789X',
+        'another-name': ''
       }
     }
 


### PR DESCRIPTION
This PR fixes a problem with site page validation introduced in previous commits when HTML element IDs were changed in the HTML template to satisfy the the HTML linter.

The validator now uses the IDs in the new format (using hyphens instead of camel case).


