### PR TITLE
Improve form validator defensive coding

### DIFF
--- a/src/controllers/contactSearch.controller.js
+++ b/src/controllers/contactSearch.controller.js
@@ -22,7 +22,7 @@ module.exports = class ContactSearchController extends BaseController {
         .state(Constants.COOKIE_KEY, request.state[Constants.COOKIE_KEY])
     } catch (error) {
       console.error(error)
-      return reply.redirect('/error')
+      return reply.redirect(Constants.Routes.ERROR.path)
     }
   }
 

--- a/src/controllers/error.controller.js
+++ b/src/controllers/error.controller.js
@@ -6,7 +6,6 @@ const BaseController = require('./base.controller')
 module.exports = class ErrorController extends BaseController {
   static async doGet (request, reply, errors) {
     const pageContext = BaseController.createPageContext(Constants.Routes.ERROR.pageHeading, errors)
-
     return reply.view('error', pageContext)
   }
 

--- a/src/validators/base.validator.js
+++ b/src/validators/base.validator.js
@@ -10,17 +10,30 @@ module.exports = class BaseValidator {
     pageContext.errorList = []
 
     validationErrors.data.details.forEach((error) => {
+      console.log(error)
+
       const fieldName = error.path
-      pageContext.errors[fieldName] = this.errorMessages[fieldName][error.type]
 
-      if (!pageContext.errors[fieldName]) {
-        pageContext.errors[fieldName] = `Validation message not found... Field: [${fieldName}] Error Type: [${error.type}]`
+      if (!this.errorMessages[fieldName]) {
+        // Handle validation messages missing in the validator
+        pageContext.errors[fieldName] = `Unable to find error messages for field: ${fieldName}`
+        pageContext.errorList.push({
+          fieldName: fieldName,
+          message: pageContext.errors[fieldName]
+        })
+      } else {
+        // Look up the corresponding error message for the field that is in error and add to the page context
+        pageContext.errors[fieldName] = this.errorMessages[fieldName][error.type]
+
+        if (!pageContext.errors[fieldName]) {
+          pageContext.errors[fieldName] = `Validation message not found... Field: [${fieldName}] Error Type: [${error.type}]`
+        }
+
+        pageContext.errorList.push({
+          fieldName: fieldName,
+          message: pageContext.errors[fieldName]
+        })
       }
-
-      pageContext.errorList.push({
-        fieldName: error.path,
-        message: pageContext.errors[error.path]
-      })
     })
   }
 }

--- a/src/validators/base.validator.js
+++ b/src/validators/base.validator.js
@@ -10,8 +10,6 @@ module.exports = class BaseValidator {
     pageContext.errorList = []
 
     validationErrors.data.details.forEach((error) => {
-      console.log(error)
-
       const fieldName = error.path
 
       if (!this.errorMessages[fieldName]) {

--- a/src/views/partials/common/head.html
+++ b/src/views/partials/common/head.html
@@ -1,1 +1,1 @@
-<link href="public/stylesheets/application.css?##APP_VERSION##" media="screen" rel="stylesheet" />
+<link href="/public/stylesheets/application.css?##APP_VERSION##" media="screen" rel="stylesheet" />


### PR DESCRIPTION
The purpose of this PR is to improve the handling by the validator of the situation where we are developing a page but we have forgotten to add one or more of the validation messages that are required by the Joi validators we have specified that we want to use.

To demonstrate the issue, comment out the error messages contained in _this.errorMessages_ in site.validator.js

i.e.
    this.errorMessages = {
      // 'site-name': {
      //   'any.empty': `Enter the site name`,
      //   'string.max': `Enter a shorter site name with no more than 170 characters`,
      //   'string.regex.invert.base': `The site name cannot contain any of these characters: ${DISALLOWED_CHARACTERS}`
      // },
      // 'another-name': {
      //   'any.empty': `Enter the other name`,
      //   'string.max': `Enter a shorter other name with no more than 170 characters`,
      //   'string.regex.invert.base': `The other name cannot contain any of these characters: ${DISALLOWED_CHARACTERS}`
      // }
    }

If you now submit the Site page with no data, you see Error screen and the following error output on the console:

TypeError: Cannot read property 'any.empty' of undefined

= Not very developer-friendly...

With the changes in this PR, instead of seeing the error screen as above you will remain on the Site page and you will see the following on-screen validation messages:

Unable to find error messages for field: site-name
Unable to find error messages for field: another-name
