### PR TITLE
Add support for greenkeeper.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,21 @@ cache:
   directories:
     - node_modules
 
-before_script:
+before_install:
+  - npm install -g greenkeeper-lockfile@1
   - npm install -g gulp-cli
+
+before_script:
+  - greenkeeper-lockfile-update
 
 script:
   - gulp test-ci
   - gulp html-hint
   - gulp standard
   - gulp check-handlebars
+
+after_script:
+  - greenkeeper-lockfile-upload
 
 after_success:
   - npm install -g codeclimate-test-reporter

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Waste Permits Service
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/DEFRA/waste-permits.svg)](https://greenkeeper.io/)
-
 [![Build Status](https://travis-ci.org/DEFRA/waste-permits.svg?branch=master)](https://travis-ci.org/DEFRA/waste-permits)
 [![NSP Status](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc/badge)](https://nodesecurity.io/orgs/cruikshanks/projects/fb915ae3-9c10-485d-bfc8-38c5c53316cc)
 [![Known Vulnerabilities](https://snyk.io/test/github/defra/waste-permits/badge.svg)](https://snyk.io/test/github/defra/waste-permits)
@@ -9,6 +7,7 @@
 [![Code Climate](https://codeclimate.com/github/DEFRA/waste-permits/badges/gpa.svg)](https://codeclimate.com/github/DEFRA/waste-permits)
 [![Test Coverage](https://codeclimate.com/github/DEFRA/waste-permits/badges/coverage.svg)](https://codeclimate.com/github/DEFRA/waste-permits/coverage)
 [![Dependency Status](https://dependencyci.com/github/DEFRA/waste-permits/badge)](https://dependencyci.com/github/DEFRA/waste-permits)
+[![Greenkeeper badge](https://badges.greenkeeper.io/DEFRA/waste-permits.svg)](https://greenkeeper.io/)
 
 You may need to apply to the [Environment Agency](https://www.gov.uk/government/organisations/environment-agency) for an environmental permit if your business uses, recycles, treats, stores or disposes of waste or mining waste. This permit can be for activities at one site or for mobile plant that can be used at many sites.
 


### PR DESCRIPTION
[Greenkeeper.io](https://greenkeeper.io/) monitors your projects's dependencies and when it finds an update, will generate a PR on a new branch in order to trigger your CI to run.

Using this service means we can automate the process of checking for updates and testing whether they break the app. Its important to keep your app up to date for both reasons of security and maintainability.