### PR TITLE
Refactor how we obtain current git commit sha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-latestCommit.json
 
 /node_modules/
 /govuk_modules/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -75,11 +75,7 @@ gulp.task('install-govuk-files', [], (done) => {
 // Query Git for the latest commit reference and store it locally in latestCommit.json
 gulp.task('git-commit-reference', [], (done) => {
   git.long((commitReference) => {
-    fs.writeFile('latestCommit.json', commitReference, (err) => {
-      if (err) {
-        throw err
-      }
-    })
+    process.env['GIT_SHA'] = commitReference
   })
 })
 

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const loadHealthTemplate = () => {
     .replace('##PAGE_TITLE##', Constants.buildPageTitle(Constants.Routes.HEALTH.pageHeading))
     .replace('##SERVICE_NAME##', Constants.SERVICE_NAME)
     .replace('##APP_VERSION##', Constants.getVersion())
-    .replace('##GITHUB_HREF##', `${Constants.GITHUB_LOCATION}/commit/${Constants.getLatestCommit()}`)
-    .replace('##GITHB_COMMIT_REF##', Constants.getLatestCommit())
+    .replace('##GITHUB_HREF##', `${Constants.GITHUB_LOCATION}/commit/${config.gitSha}`)
+    .replace('##GITHB_COMMIT_REF##', config.gitSha)
   return template
 }
 
@@ -119,7 +119,7 @@ server.start((err) => {
   console.info('Server running in environment: ' + config.nodeEnvironment)
   console.info('Server running at:', server.info)
   console.info(`Service: ${Constants.SERVICE_NAME}\nVersion: ${Constants.getVersion()}`)
-  console.info(`Latest commit: ${Constants.getLatestCommit()}`)
+  console.info(`Latest commit: ${config.gitSha}`)
 })
 
 // Listen on SIGINT signal and gracefully stop the server

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,6 +8,16 @@ module.exports = {
 
   nodeEnvironment: process.env.NODE_ENV || 'PRODUCTION',
 
+  // When running locally using the default gulp task it will call
+  // `gulp git-commit-reference`. This will set the env var `GIT_SHA` with the
+  // latest git commit sha, which we then read in here.
+  // When deployed to heroku we make use of a custom build pack
+  // https://github.com/dive-networks/heroku-buildpack-git-sha that also sets
+  // an env var called GIT_SHA. This means whether running locally or on heroku
+  // we can read the git commit sha and display it correctly in the /health and
+  // /version views.
+  gitSha: process.env.GIT_SHA,
+
   // Domain name or IP address of the server to issue the azure AD auth request
   // to. Passed in as value for `host:` option when we make the https.request()
   // call

--- a/src/constants.js
+++ b/src/constants.js
@@ -50,17 +50,6 @@ Constants.buildPageTitle = (pageHeading) => {
   return `${pageHeading} - ${Constants.SERVICE_NAME} - ${Constants.GDS_NAME}`
 }
 
-Constants.getLatestCommit = () => {
-  let latestCommit
-  try {
-    // Read the latest Git commit reference
-    latestCommit = fs.readFileSync('latestCommit.json', 'utf8')
-  } catch (err) {
-    latestCommit = 'Unknown'
-  }
-  return latestCommit
-}
-
 Constants.getVersion = () => {
   let version
   try {

--- a/src/controllers/version.controller.js
+++ b/src/controllers/version.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const moment = require('moment')
+const config = require('../config/config')
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
@@ -25,8 +26,8 @@ module.exports = class VersionController extends BaseController {
       pageContext.dynamicsSolution = await DynamicsSolution.get(authToken)
 
       pageContext.applicationVersion = Constants.getVersion()
-      pageContext.githubRef = Constants.getLatestCommit()
-      pageContext.githubUrl = `${Constants.GITHUB_LOCATION}/commit/${Constants.getLatestCommit()}`
+      pageContext.githubRef = config.gitSha
+      pageContext.githubUrl = `${Constants.GITHUB_LOCATION}/commit/${config.gitSha}`
       pageContext.renderTimestamp = moment().format(Constants.TIMESTAMP_FORMAT)
 
       return reply


### PR DESCRIPTION
Previously we had a gulp task that wrote to a file (`latestCommit.json`) what the sha is for the latest git commit present.

However when the app is deployed to Heroku this method no longer works because

- git information is not available to a running app
- an app in Heroku cannot write to file

The good news is Heroku does populate an environment variable with the git sha during the build process (see https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary). The bad news is this env var is also not available to running apps. However a buildpack has been created that can extract the value from `SOURCE_VERSION` and make it available to a running app as `GIT_SHA`.

We can add the buildpack to our app by

- installing the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
- logging into heroku from the CLI with `heroku login`
- adding the build pack to the app with `heroku buildpacks:add https://github.com/dive-networks/heroku-buildpack-git-sha -a waste-permits`

We could have then changed the app to also check for this if looking for the file failed. However instead this change tweaks how we get and set the git sha. Rather than create a file, now the gulp task sets an environment variable instead. As an environment variable we can then read it with `config.js`. When you run the app locally using the default gulp task the env var `GIT_SHA` will be created. When you run the app in Heroku it will already exist, and either way `config.js` will pick it up.