### PR TITLE
Amend to support deploy and run app in Heroku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@
 NODE_ENV=DEVELOPMENT
 
 # The port that the Waste Permits Hapi web server runs on
-WASTE_PERMITS_APP_PORT=8000
+PORT=8000
 
 # Domain name or IP address of the server to issue the azure AD auth request to
 AZURE_ACTIVE_DIRECTORY_HOST="login.microsoftonline.com"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,7 @@
-web: node index.js
+# As per heroku best practices https://devcenter.heroku.com/articles/node-best-practices
+# we optimize to avoid garbage. Node (V8) uses a lazy and greedy garbage
+# collector and has default limit of about 1.5 GB. We can control the garbage
+# collector using flags.
+# On the Heroku free tier we are limted to only 512mb per dyno, so the
+# following tailors node to run in a container of this size.
+web: node --optimize_for_size --max_old_space_size=460 --gc_interval=100 index.js

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const loadHealthTemplate = () => {
 }
 
 server.connection({
-  port: process.env.WASTE_PERMITS_APP_PORT,
+  port: config.port,
   routes: {
     validate: {
       options: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "postinstall": "gulp build",
     "test": "lab -t 90",
     "test-cov-html": "lab -r html -o coverage.html"
   },

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,7 +4,7 @@ require('dotenv').config()
 
 module.exports = {
 
-  port: process.env.WASTE_PERMITS_APP_PORT || 8000,
+  port: process.env.PORT || 8000,
 
   nodeEnvironment: process.env.NODE_ENV || 'PRODUCTION',
 


### PR DESCRIPTION
As a means of checking that the app can deploy and run in a production like environment whilst we await our actual environments, we would like to deploy the app to [Heroku](https://www.heroku.com/).

However to support this we need to make a number of minor changes to the project

- Change the name of the env var we use to get the port number from. On Heroku you cannot set the port; it is dynamically applied. So your app must read it from an env var named PORT. Rather than tweak the code to do 2 checks (check for our env var, then check for Heroku's) this change amends the code to always just look for an env var name PORT
- Update the Procfile to follow Heroku best practise for a node app running on a free dyno
- Add the `postinstall` directive to `package.json` so that we run our gulp build tasks after an npm install. This is something Heroku expects

Additionally in Heroku we have added all the env vars we need (excluding PORT as Heroku sets that), along with setting `NPM_CONFIG_PRODUCTION` to false. This is because our gulp file contains tasks that are only run in development, but needs has to require dev only dependencies to make that happen. By default Heroku will install the dependencies using `npm install --production` which would ignore anything under `devDependencies`. Setting this env var ensures everything gets installed.