### PR TITLE
Add pages and tests for permit selection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,10 @@ Constants.Routes = {
     path: '/check-before-sending',
     pageHeading: 'Check your answers before sending your application'
   },
+  CHECK_YOUR_EMAIL: {
+    path: '/save-and-return/check-your-email',
+    pageHeading: `Search for 'standard rules permit application' in your email`
+  },
   CONFIDENTIALITY: {
     path: '/confidentiality',
     pageHeading: 'Is part of your application commercially confidential?'
@@ -37,10 +41,6 @@ Constants.Routes = {
   CONTACT_DETAILS: {
     path: '/contact-details',
     pageHeading: 'Who should we contact about this application?'
-  },
-  CHECK_YOUR_EMAIL: {
-    path: '/save-and-return/check-your-email',
-    pageHeading: `Search for 'standard rules permit application' in your email`
   },
   CONTACT_SEARCH: {
     path: '/contact-search',

--- a/src/constants.js
+++ b/src/constants.js
@@ -78,6 +78,10 @@ Constants.Routes = {
     path: '/permit-holder/type',
     pageHeading: 'Who will be the permit holder?'
   },
+  PERMIT_SELECT: {
+    path: '/permit/select',
+    pageHeading: 'Select a permit'
+  },
   PRE_APPLICATION: {
     path: '/pre-application',
     pageHeading: 'Have you discussed this application with us?'

--- a/src/constants.js
+++ b/src/constants.js
@@ -71,7 +71,7 @@ Constants.Routes = {
     pageHeading: 'Which management system will you use?'
   },
   PERMIT_CATEGORY: {
-    path: '/permit-category',
+    path: '/permit/category',
     pageHeading: 'What do you want the permit for?'
   },
   PERMIT_HOLDER_TYPE: {

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -25,7 +25,7 @@ module.exports = class PermitCategoryController extends BaseController {
       // TODO persist the data here if required
       // const applicationId = request.state[Constants.COOKIE_KEY].applicationId
 
-      return reply.redirect(Constants.Routes.CONTACT.path)
+      return reply.redirect(Constants.Routes.PERMIT_SELECT.path)
     }
   }
 

--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -7,6 +7,8 @@ module.exports = class PermitSelectController extends BaseController {
   static async doGet (request, reply, errors) {
     try {
       const pageContext = BaseController.createPageContext(Constants.Routes.PERMIT_SELECT)
+
+      pageContext.formValues = request.payload
       return reply
         .view('permitSelect', pageContext)
     } catch (error) {
@@ -16,7 +18,14 @@ module.exports = class PermitSelectController extends BaseController {
   }
 
   static async doPost (request, reply, errors) {
-    // Not implemented yet
+    if (errors && errors.data.details) {
+      return PermitSelectController.doGet(request, reply, errors)
+    } else {
+      // TODO persist the data here if required
+      // const applicationId = request.state[Constants.COOKIE_KEY].applicationId
+
+      return reply.redirect(Constants.Routes.TASK_LIST.path)
+    }
   }
 
   static handler (request, reply, source, errors) {

--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const Constants = require('../constants')
+const BaseController = require('./base.controller')
+
+module.exports = class PermitSelectController extends BaseController {
+  static async doGet (request, reply, errors) {
+    try {
+      const pageContext = BaseController.createPageContext(Constants.Routes.PERMIT_SELECT)
+      return reply
+        .view('permitSelect', pageContext)
+    } catch (error) {
+      request.log('ERROR', error)
+      return reply.redirect(Constants.Routes.ERROR.path)
+    }
+  }
+
+  static async doPost (request, reply, errors) {
+    // Not implemented yet
+  }
+
+  static handler (request, reply, source, errors) {
+    return BaseController.handler(request, reply, errors, PermitSelectController)
+  }
+}

--- a/src/routes/permitSelect.route.js
+++ b/src/routes/permitSelect.route.js
@@ -2,6 +2,7 @@
 
 const Constants = require('../constants')
 const PermitSelectController = require('../controllers/permitSelect.controller')
+const PermitSelectValidator = require('../validators/permitSelect.validator')
 
 module.exports = [{
   method: ['GET'],
@@ -12,6 +13,20 @@ module.exports = [{
     state: {
       parse: true,
       failAction: 'error'
+    }
+  }
+}, {
+  method: ['POST'],
+  path: Constants.Routes.PERMIT_SELECT.path,
+  config: {
+    description: 'The POST Permit Select page',
+    handler: PermitSelectController.handler,
+    validate: {
+      options: {
+        allowUnknown: true
+      },
+      payload: PermitSelectValidator.getFormValidators(),
+      failAction: PermitSelectController.handler
     }
   }
 }]

--- a/src/routes/permitSelect.route.js
+++ b/src/routes/permitSelect.route.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const Constants = require('../constants')
+const PermitSelectController = require('../controllers/permitSelect.controller')
+
+module.exports = [{
+  method: ['GET'],
+  path: Constants.Routes.PERMIT_SELECT.path,
+  config: {
+    description: 'The Select a permit page',
+    handler: PermitSelectController.handler,
+    state: {
+      parse: true,
+      failAction: 'error'
+    }
+  }
+}]

--- a/src/validators/permitSelect.validator.js
+++ b/src/validators/permitSelect.validator.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// const Joi = require('joi')
+const BaseValidator = require('./base.validator')
+
+module.exports = class PermitSelectValidator extends BaseValidator {
+  constructor () {
+    super()
+
+    this.errorMessages = {}
+  }
+
+  static getFormValidators () {
+    return {}
+  }
+}

--- a/src/views/permitCategory.html
+++ b/src/views/permitCategory.html
@@ -9,9 +9,13 @@
 
       <h1 id="permit-category-heading" class="heading-large">{{ pageHeading }}</h1>
 
-      <div class="form-group">
-        <button id="permit-category-submit" type="submit" class="button">Continue</button>
-      </div>
+      <form method="POST" action="{{ formAction }}">
+
+        <div class="form-group">
+          <button id="permit-category-submit" type="submit" class="button">Continue</button>
+        </div>
+
+      </form>
 
     </div>
   </div>

--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -1,0 +1,18 @@
+<main id="content" role="main">
+
+  {{> common/betaBanner }}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      {{> common/errorSummary }}
+
+      <h1 id="permit-select-heading" class="heading-large">{{ pageHeading }}</h1>
+
+      <div class="form-group">
+        <button id="permit-select-submit" type="submit" class="button">Continue</button>
+      </div>
+
+    </div>
+  </div>
+</main>

--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -9,9 +9,13 @@
 
       <h1 id="permit-select-heading" class="heading-large">{{ pageHeading }}</h1>
 
-      <div class="form-group">
-        <button id="permit-select-submit" type="submit" class="button">Continue</button>
-      </div>
+      <form method="POST" action="{{ formAction }}">
+
+        <div class="form-group">
+          <button id="permit-select-submit" type="submit" class="button">Continue</button>
+        </div>
+
+      </form>
 
     </div>
   </div>

--- a/test/routes/checkYourEmail.route.test.js
+++ b/test/routes/checkYourEmail.route.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const Code = require('code')
+const server = require('../../server')
+const CookieService = require('../../src/services/cookie.service')
+
+let validateCookieStub
+
+lab.beforeEach((done) => {
+  // Stub methods
+  validateCookieStub = CookieService.validateCookie
+  CookieService.validateCookie = () => {
+    return true
+  }
+
+  done()
+})
+
+lab.afterEach((done) => {
+  // Restore stubbed methods
+  CookieService.validateCookie = validateCookieStub
+
+  done()
+})
+
+lab.experiment(`Search for 'standard rules permit application' in your email page tests:`, () => {
+  lab.test('GET /save-and-return/check-your-email success ', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/save-and-return/check-your-email',
+      headers: {},
+      payload: {}
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+  lab.test('GET /save-and-return/check-your-email redirects to error screen when the user token is invalid', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/save-and-return/check-your-email',
+      headers: {},
+      payload: {}
+    }
+
+    CookieService.validateCookie = () => {
+      return undefined
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers['location']).to.equal('/error')
+      done()
+    })
+  })
+})

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const Code = require('code')
+const server = require('../../server')
+const CookieService = require('../../src/services/cookie.service')
+
+let validateCookieStub
+
+lab.beforeEach((done) => {
+  // Stub methods
+  validateCookieStub = CookieService.validateCookie
+  CookieService.validateCookie = () => {
+    return true
+  }
+
+  done()
+})
+
+lab.afterEach((done) => {
+  // Restore stubbed methods
+  CookieService.validateCookie = validateCookieStub
+
+  done()
+})
+
+lab.experiment('What do you want the permit for? page tests:', () => {
+  lab.test('GET /permit-category success ', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/permit-category',
+      headers: {},
+      payload: {}
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+  lab.test('GET /permit-category redirects to error screen when the user token is invalid', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/permit-category',
+      headers: {},
+      payload: {}
+    }
+
+    CookieService.validateCookie = () => {
+      return undefined
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers['location']).to.equal('/error')
+      done()
+    })
+  })
+})

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -40,6 +40,22 @@ lab.experiment('What do you want the permit for? page tests:', () => {
     })
   })
 
+  lab.test('POST /permit/category success redirects to the permit select route', (done) => {
+    const request = {
+      method: 'POST',
+      url: '/permit/category',
+      headers: {},
+      payload: {}
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers['location']).to.equal('/permit/select')
+
+      done()
+    })
+  })
+
   lab.test('GET /permit/category redirects to error screen when the user token is invalid', (done) => {
     const request = {
       method: 'GET',

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -26,10 +26,10 @@ lab.afterEach((done) => {
 })
 
 lab.experiment('What do you want the permit for? page tests:', () => {
-  lab.test('GET /permit-category success ', (done) => {
+  lab.test('GET /permit/category success ', (done) => {
     const request = {
       method: 'GET',
-      url: '/permit-category',
+      url: '/permit/category',
       headers: {},
       payload: {}
     }
@@ -40,10 +40,10 @@ lab.experiment('What do you want the permit for? page tests:', () => {
     })
   })
 
-  lab.test('GET /permit-category redirects to error screen when the user token is invalid', (done) => {
+  lab.test('GET /permit/category redirects to error screen when the user token is invalid', (done) => {
     const request = {
       method: 'GET',
-      url: '/permit-category',
+      url: '/permit/category',
       headers: {},
       payload: {}
     }

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const Code = require('code')
+const server = require('../../server')
+const CookieService = require('../../src/services/cookie.service')
+
+let validateCookieStub
+
+lab.beforeEach((done) => {
+  // Stub methods
+  validateCookieStub = CookieService.validateCookie
+  CookieService.validateCookie = () => {
+    return true
+  }
+
+  done()
+})
+
+lab.afterEach((done) => {
+  // Restore stubbed methods
+  CookieService.validateCookie = validateCookieStub
+
+  done()
+})
+
+lab.experiment('Select a permit page tests:', () => {
+  lab.test('GET /permit/select success ', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/permit/select',
+      headers: {},
+      payload: {}
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+  lab.test('GET /permit/select redirects to error screen when the user token is invalid', (done) => {
+    const request = {
+      method: 'GET',
+      url: '/permit/select',
+      headers: {},
+      payload: {}
+    }
+
+    CookieService.validateCookie = () => {
+      return undefined
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers['location']).to.equal('/error')
+      done()
+    })
+  })
+})

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -40,6 +40,22 @@ lab.experiment('Select a permit page tests:', () => {
     })
   })
 
+  lab.test('POST /permit/select success redirects to the task list route', (done) => {
+    const request = {
+      method: 'POST',
+      url: '/permit/select',
+      headers: {},
+      payload: {}
+    }
+
+    server.inject(request, (res) => {
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers['location']).to.equal('/task-list')
+
+      done()
+    })
+  })
+
   lab.test('GET /permit/select redirects to error screen when the user token is invalid', (done) => {
     const request = {
       method: 'GET',

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -88,7 +88,7 @@ lab.experiment('Start or Open Saved page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
-      Code.expect(res.headers['location']).to.equal('/permit-category')
+      Code.expect(res.headers['location']).to.equal('/permit/category')
 
       done()
     })


### PR DESCRIPTION
Add additional routes, controllers and views for the stages of permit selection. This is so we can have a joined-up user journey from the entry point of the application to the task list.

Also add some tests for new and existing pages.