### PR TITLE
Add missing skipLinkMessage to context

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ Constants.COOKIE_PATH = { path: '/' }
 Constants.GITHUB_LOCATION = 'https://github.com/DEFRA/waste-permits'
 Constants.TIMESTAMP_FORMAT = 'DD/MM/YYYY HH:mm:ss'
 Constants.PAGE_TITLE_ERROR_PREFIX = 'Problem: '
+Constants.SKIP_LINK_MESSAGE = `Skip to main content`
 
 Constants.LogLevel = {
   ERROR: 'ERROR',

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -6,6 +6,7 @@ const CookieService = require('../services/cookie.service')
 module.exports = class BaseController {
   static createPageContext (route, errors, ValidatorSubClass) {
     const pageContext = {
+      skipLinkMessage: Constants.SKIP_LINK_MESSAGE,
       pageTitle: Constants.buildPageTitle(route.pageHeading),
       pageHeading: route.pageHeading,
       formAction: route.path


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-636

It was spotted when testing the accessibility of the 'APply for a standard rules permit' (the first page in the service to be properly implemented) that the option to skip to the main content was not working properly.

Upon investigation we believe its simply because we are not providing the text for the link, hence nothing is displayed. And to do that we need to add `skipLinkMessage` to the context object.

This change fixes the issue.