### PR TITLE
Add missing IDs to form fields

### DIFF
--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -22,7 +22,7 @@
             </p>
           </div>
 
-          <div class="form-group {{#getFormErrorGroupClass errors.started-application}}{{/getFormErrorGroupClass}}">
+          <div id="chosen-permit" class="form-group {{#getFormErrorGroupClass errors.started-application}}{{/getFormErrorGroupClass}}">
             {{> common/fieldError fieldId='chosen-permit-error' message=errors.chosen-permit }}
 
             {{#each standardRules.results}}

--- a/src/views/startOrOpenSaved.html
+++ b/src/views/startOrOpenSaved.html
@@ -18,7 +18,7 @@
             <p>You'll need a debit or credit card to pay the application cost. This is between £{{ cost.lower }} and £{{ cost.upper }}, depending on the permit.</p>
           </div>
 
-          <div class="form-group {{#getFormErrorGroupClass errors.started-application}}{{/getFormErrorGroupClass}}">
+          <div id="started-application" class="form-group {{#getFormErrorGroupClass errors.started-application}}{{/getFormErrorGroupClass}}">
             {{> common/fieldError fieldId='started-application-error' message=errors.started-application }}
 
             <div class="multiple-choice">


### PR DESCRIPTION
If a validation error message is displayed, users should be able to click on the error message and be redirected to the form field where the problem is. However, if the form fields (or surrounding elements) don't have the correct ID, this doesn't work. This change adds the correct IDs to all form fields so the error message validation links work properly.

This was reported as part of QA on https://eaflood.atlassian.net/browse/WE-553