### PR TITLE
Change name of GIT_SHA file

### DIFF
--- a/src/services/commitHash.service.js
+++ b/src/services/commitHash.service.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 module.exports = class CommitHashService {
   // commitHash() will first look for an env var called `GIT_SHA` for the
   // reference. If that doesn't exist it will next look for a file called
-  // `GIT_SHA`. Finally if that fails it will attempt to make a call to git
+  // `REVISION`. Finally if that fails it will attempt to make a call to git
   // directly.
   //
   // Whatever the result, the end result is an env var called `GIT_SHA` will be
@@ -22,8 +22,8 @@ module.exports = class CommitHashService {
   // When we run the app using either gulp or directly via `node server.js` we
   // rely on the logic to make a call to git, and then set an env var.
   //
-  // When we deploy the app, our scripts will create a file containing the sha
-  // called GIT_SHA. This is because the we won't have the env var GIT_SHA
+  // When we deploy the app, the tool will create a file containing the sha
+  // called REVISION. This is because the we won't have the env var GIT_SHA
   // available, nor will we even have the .git folder in order to query it using
   // the git cli.
   static commitHash () {
@@ -34,7 +34,7 @@ module.exports = class CommitHashService {
     }
 
     // If the env var was not set then we next prioritise reading from a file
-    // called GIT_SHA. This is to fit in with our deployment process
+    // called REVISION. This is to fit in with our deployment process
     // (non-heroku) which will create this file and add the current commit hash
     // to it
     commitReference = this._queryFile()
@@ -53,7 +53,7 @@ module.exports = class CommitHashService {
 
     // Whatever the result by now, we set the env var to the value we have. This
     // means after the first call to commitHash() subsequent calls should return
-    // immediately after reading GIT_SHAs
+    // immediately after reading GIT_SHA
     process.env.GIT_SHA = commitReference
 
     return commitReference
@@ -63,7 +63,7 @@ module.exports = class CommitHashService {
     let result
     try {
       // Read the latest Git commit reference from a file
-      result = fs.readFileSync('GIT_SHA', 'utf8')
+      result = fs.readFileSync('REVISION', 'utf8')
     } catch (err) {
       result = undefined
     }

--- a/test/services/commitHash.service.test.js
+++ b/test/services/commitHash.service.test.js
@@ -43,7 +43,7 @@ lab.experiment('Commit hash service tests:', () => {
     done()
   })
 
-  lab.test('commitHash() returns contents of GIT_SHA file when env var not set', (done) => {
+  lab.test('commitHash() returns contents of REVISION file when env var not set', (done) => {
     fs.readFileSync = (file, encoding) => {
       return 'fromfile-fromfile-fromfile'
     }
@@ -59,7 +59,7 @@ lab.experiment('Commit hash service tests:', () => {
     done()
   })
 
-  lab.test('commitHash() sets the env var GIT_SHA after having read the reference from the GIT_SHA file', (done) => {
+  lab.test('commitHash() sets the env var GIT_SHA after having read the reference from the REVISION file', (done) => {
     fs.readFileSync = (file, encoding) => {
       return 'setfileenv-setfileenv-setfileenv'
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-416

When the app is deployed there will be no `.git` folder so we can't query git for the latest commit sha, nor will there be the env var GIT_SHA.

We are intending to use [Shipit](https://github.com/shipitjs/shipit) for our deployment, and initially we thought the only way to obtain the commit sha was to add a custom action that created a file called GIT_SHA containing with the sha.

However after more use of the tool, we spotted it already does this automatically, but calls the file `REVISION`. So we've been able to strip out the custom deployment action, however it does mean a change in the name of the file we expect when the env var and querying git is not available.