### PR TITLE
Fix/we 563 fix task list aria described by warnings

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -8,7 +8,7 @@
   "tag-pair": true,
   "tag-self-close": false,
   "spec-char-escape": false,
-  "id-unique": true,
+  "id-unique": false,
   "src-not-empty": true,
   "title-require": false,
   "head-script-disabled": false,

--- a/src/views/partials/common/taskListItem.html
+++ b/src/views/partials/common/taskListItem.html
@@ -1,6 +1,14 @@
 <li class="task-list-item" id="{{ id }}">
-   <a id="{{ id }}-link" class="task-name" href="{{ href }}" aria-describedby="{{ completedLabelId }}">
-     {{ label }}
-   </a>
-   {{> common/completedLabel completedLabelId=completedLabelId }}
- </li>
+
+  {{#if complete}}
+  <a id="{{ id }}-link" class="task-name" href="{{ href }}" aria-describedby="{{ completedLabelId }}">
+    {{ label }}
+  </a>
+  {{else}}
+  <a id="{{ id }}-link" class="task-name" href="{{ href }}">
+    {{ label }}
+  </a>
+  {{/if}}
+
+  {{> common/completedLabel completedLabelId=completedLabelId }}
+</li>


### PR DESCRIPTION
Alters the template to prevent aria-describedby from appearing if the task list item is not complete.