### PR TITLE
Add current path to the health page

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ const loadHealthTemplate = () => {
     .replace('##APP_VERSION##', Constants.getVersion())
     .replace('##GITHUB_HREF##', `${Constants.GITHUB_LOCATION}/commit/${config.gitSha}`)
     .replace('##GITHB_COMMIT_REF##', config.gitSha)
+    .replace('##APP_PATH##', fs.realpathSync(__dirname))
   return template
 }
 

--- a/src/views/health.html
+++ b/src/views/health.html
@@ -8,5 +8,6 @@
     <h1 id="health-heading">##SERVICE_NAME##</h1>
     <p>Application version: <span id="health-application-version">##APP_VERSION##</span></p>
     <p>Latest commit: <a target="_blank" href="##GITHUB_HREF##"><span id="health-application-commit-ref">##GITHB_COMMIT_REF##</span></a></p>
+    <p>Current path: <span id="app-path">##APP_PATH##</span></p>
   </body>
 </html>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-416

In our main environments whenever the app is deployed a new folder is created, named using the timestamp of the current date and time. The curent health page will display a commit hash of the version of the project we are running but the same version of the app could be deployed multiple times.

So for debugging purposes it would be useful to see specifically which copy of the project is running, and we can determine that by knowing which release folder it is currently running out off. This change adds the current path to the health page to allow us to see this.