### PR TITLE
Fixed site name text field length in the UII

### DIFF
--- a/src/assets/sass/application.scss
+++ b/src/assets/sass/application.scss
@@ -27,3 +27,91 @@ $path: "/public/images/";
 .ea-footer .inline {
     display: inline;
 }
+
+// Form control widths
+// ==========================================================================
+// Setting the widths of forms based on the minimum number of visible characters to display in the input
+// chars  width in ems
+// 60     28.5
+// 50     26
+// 40     20
+// 35     18.5
+// 25     13.5
+// 20     10.5
+// 15     8.5
+// 10     6
+// 5      3.5
+// 3      2.5
+.form-control-char-auto { // intended for select options that have pre-populated text
+  width: 100%;
+  @include media(tablet) {
+    width: auto;
+  }
+}
+.form-control-char-60 {
+  width: 100%;
+  @include media(tablet) {
+    width: 28.5em;
+  }
+}
+.form-control-char-50 {
+  width: 100%;
+  @include media(tablet) {
+    width: 26em;
+  }
+}
+.form-control-char-40 {
+  width: 100%;
+  @include media(tablet) {
+    width: 20em;
+  }
+}
+.form-control-char-35 {
+  width: 100%;
+  @include media(tablet) {
+    width: 18.5em;
+  }
+}
+.form-control-char-25 {
+  width: 100%;
+  @include media(tablet) {
+    width: 13.5em;
+  }
+}
+.form-control-char-20 {
+  width: 100%;
+  @include media(tablet) {
+    width: 10.5em;
+  }
+}
+.form-control-char-15 {
+  width: 100%;
+  @include media(tablet) {
+    width: 8.5em;
+  }
+}
+.form-control-char-10 {
+  width: 100%;
+  @include media(tablet) {
+    width: 6em;
+  }
+}
+.form-control-char-5 {
+  width: 100%;
+  @include media(tablet) {
+    width: 3.5em;
+  }
+}
+.form-control-char-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 2.5em;
+  }
+}
+// For textarea 100% width, even on tablet
+.form-control-full {
+  @include media(tablet) {
+    width: 100%;
+  }
+}
+// end Form control widths


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-470

This change fixes a bug that was identified regarding the length of the Site Name text field on the page, which was shorter than expected.

The fix was to include some additional SCSS into our application.SCSS file. This is SCSS that was added to the Waste Permits prototype but that hadn't been added to the Waste Permits application.