### PR TITLE
Fixed tests broken by upgrade to Lab 15

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8802,9 +8802,9 @@
       "dev": true
     },
     "nock": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.24.tgz",
-      "integrity": "sha512-Q4u88wVf6MaVRnbsz+BMOWUfOAXFGdeve6hm79nbMG+U/ploywUCn6ISIzUYbiiv+N5EVUZMvIyhwwqLzSzG8Q==",
+      "version": "9.0.25",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.25.tgz",
+      "integrity": "sha512-NG11AOS9UnnTJ0macXJoeUjp4s/DEoPB4724/Cd5ULIu3k/5tRnn+rCX5Z+S10wwWnHQjKBSh94rTdHZxKOTlA==",
       "dev": true,
       "requires": {
         "chai": "3.5.0",

--- a/test/controllers/base.controller.test.js
+++ b/test/controllers/base.controller.test.js
@@ -7,11 +7,11 @@ const Code = require('code')
 const BaseController = require('../../src/controllers/base.controller')
 
 lab.beforeEach((done) => {
-  done()
+
 })
 
 lab.afterEach((done) => {
-  done()
+
 })
 
 lab.experiment('Base Controller tests:', () => {
@@ -27,6 +27,5 @@ lab.experiment('Base Controller tests:', () => {
     Code.expect(pageContext.pageHeading).to.equal(route.pageHeading)
     Code.expect(pageContext.pageTitle).to.equal(route.pageTitle)
     Code.expect(pageContext.formAction).to.equal(route.path)
-    done()
   })
 })

--- a/test/models/application.model.test.js
+++ b/test/models/application.model.test.js
@@ -19,15 +19,11 @@ lab.beforeEach((done) => {
   DynamicsDalService.prototype.create = (dataObject, query) => {
     return '7a8e4354-4f24-e711-80fd-5065f38a1b01'
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   DynamicsDalService.prototype.create = dynamicsCreateStub
-
-  done()
 })
 
 lab.experiment('Application Model tests:', () => {
@@ -36,8 +32,6 @@ lab.experiment('Application Model tests:', () => {
     testApplication.save().then(() => {
       Code.expect(spy.callCount).to.equal(1)
       Code.expect(testApplication.id).to.equal('7a8e4354-4f24-e711-80fd-5065f38a1b01')
-
-      done()
     })
   })
 })

--- a/test/models/base.model.test.js
+++ b/test/models/base.model.test.js
@@ -7,11 +7,11 @@ const Code = require('code')
 const BaseModel = require('../../src/models/base.model')
 
 lab.beforeEach((done) => {
-  done()
+
 })
 
 lab.afterEach((done) => {
-  done()
+
 })
 
 lab.experiment('Base Model tests:', () => {
@@ -20,7 +20,6 @@ lab.experiment('Base Model tests:', () => {
     modelObject.additionalProperty = 'foo'
 
     Code.expect(modelObject.toString()).to.equal('BaseModel: {\n  additionalProperty: foo\n}')
-    done()
   })
 
   lab.test('isNew() correctly identifies if the instance has a Dynamics ID', (done) => {
@@ -31,7 +30,5 @@ lab.experiment('Base Model tests:', () => {
 
     modelObject.id = '7a8e4354-4f24-e711-80fd-5065f38a1b01'
     Code.expect(modelObject.isNew()).to.be.false()
-
-    done()
   })
 })

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -60,8 +60,6 @@ lab.beforeEach((done) => {
   DynamicsDalService.prototype.update = (dataObject, query) => {
     return dataObject.id
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -69,8 +67,6 @@ lab.afterEach((done) => {
   DynamicsDalService.prototype.create = dynamicsCreateStub
   DynamicsDalService.prototype.search = dynamicsSearchStub
   DynamicsDalService.prototype.update = dynamicsUpdateStub
-
-  done()
 })
 
 lab.experiment('Contact Model tests:', () => {
@@ -91,8 +87,6 @@ lab.experiment('Contact Model tests:', () => {
     Contact.getById().then((contact) => {
       Code.expect(spy.callCount).to.equal(1)
     })
-
-    done()
   })
 
   lab.test('list() method returns a list of Contact objects', (done) => {
@@ -102,8 +96,6 @@ lab.experiment('Contact Model tests:', () => {
       Code.expect(contactList.results.length).to.equal(3)
       Code.expect(contactList.count).to.equal(3)
       Code.expect(spy.callCount).to.equal(1)
-
-      done()
     })
   })
 
@@ -112,8 +104,6 @@ lab.experiment('Contact Model tests:', () => {
     testContact.save().then(() => {
       Code.expect(spy.callCount).to.equal(1)
       Code.expect(testContact.id).to.equal('7a8e4354-4f24-e711-80fd-5065f38a1b01')
-
-      done()
     })
   })
 
@@ -123,8 +113,6 @@ lab.experiment('Contact Model tests:', () => {
     testContact.save().then(() => {
       Code.expect(spy.callCount).to.equal(1)
       Code.expect(testContact.id).to.equal('123')
-
-      done()
     })
   })
 })

--- a/test/models/dynamicsSolution.model.test.js
+++ b/test/models/dynamicsSolution.model.test.js
@@ -37,15 +37,11 @@ lab.beforeEach((done) => {
       ]
     }
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   DynamicsDalService.prototype.search = dynamicsSearchStub
-
-  done()
 })
 
 lab.experiment('DynamicsSolution Model tests:', () => {
@@ -62,8 +58,6 @@ lab.experiment('DynamicsSolution Model tests:', () => {
       Code.expect(dynamicsVersionInfo[1].version).to.equal('1.1.10.0')
       Code.expect(dynamicsVersionInfo[2].componentName).to.equal('Licensing and Permitting')
       Code.expect(dynamicsVersionInfo[2].version).to.equal('1.1.11.0')
-
-      done()
     })
   })
 })

--- a/test/models/site.model.test.js
+++ b/test/models/site.model.test.js
@@ -42,8 +42,6 @@ lab.beforeEach((done) => {
   DynamicsDalService.prototype.update = (dataObject, query) => {
     return dataObject.id
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -51,8 +49,6 @@ lab.afterEach((done) => {
   DynamicsDalService.prototype.create = dynamicsCreateStub
   DynamicsDalService.prototype.search = dynamicsSearchStub
   DynamicsDalService.prototype.update = dynamicsUpdateStub
-
-  done()
 })
 
 lab.experiment('Site Model tests:', () => {
@@ -62,8 +58,6 @@ lab.experiment('Site Model tests:', () => {
 
     Code.expect(testSite.name).to.equal(fakeSiteData.name)
     Code.expect(testSite.applicationId).to.equal(fakeSiteData.applicationId)
-
-    done()
   })
 
   lab.test('getByApplicationId() method returns a single Site object', (done) => {
@@ -72,8 +66,6 @@ lab.experiment('Site Model tests:', () => {
       Code.expect(spy.callCount).to.equal(1)
 
       Code.expect(site.name).to.equal(fakeSiteData.name)
-
-      done()
     })
   })
 
@@ -82,8 +74,6 @@ lab.experiment('Site Model tests:', () => {
     testSite.save().then(() => {
       Code.expect(spy.callCount).to.equal(1)
       Code.expect(testSite.id).to.equal('7a8e4354-4f24-e711-80fd-5065f38a1b01')
-
-      done()
     })
   })
 
@@ -93,8 +83,6 @@ lab.experiment('Site Model tests:', () => {
     testSite.save().then(() => {
       Code.expect(spy.callCount).to.equal(2)
       Code.expect(testSite.id).to.equal('123')
-
-      done()
     })
   })
 
@@ -108,7 +96,5 @@ lab.experiment('Site Model tests:', () => {
 
     testSite = new Site(fakeSiteData)
     Code.expect(testSite.isComplete()).to.be.true()
-
-    done()
   })
 })

--- a/test/models/standardRule.model.test.js
+++ b/test/models/standardRule.model.test.js
@@ -21,15 +21,11 @@ const fakeStandardRule = {
 lab.beforeEach((done) => {
   // Stub methods
   dynamicsSearchStub = DynamicsDalService.prototype.search
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   DynamicsDalService.prototype.search = dynamicsSearchStub
-
-  done()
 })
 
 lab.experiment('StandardRule Model tests:', () => {
@@ -68,8 +64,6 @@ lab.experiment('StandardRule Model tests:', () => {
       Code.expect(standardRuleList.results.length).to.equal(3)
       Code.expect(standardRuleList.count).to.equal(3)
       Code.expect(spy.callCount).to.equal(1)
-
-      done()
     })
   })
 
@@ -96,15 +90,11 @@ lab.experiment('StandardRule Model tests:', () => {
       Code.expect(standardRule.codeForId).to.equal(fakeStandardRule.codeForId)
 
       Code.expect(spy.callCount).to.equal(1)
-
-      done()
     })
   })
 
   lab.test('transformPermitCode() method formats string for an ID correctly', (done) => {
     const string = 'SR2015 No 10'
     Code.expect(StandardRule.transformPermitCode(string)).to.equal('sr2015-no-10')
-
-    done()
   })
 })

--- a/test/models/taskList.model.test.js
+++ b/test/models/taskList.model.test.js
@@ -114,15 +114,11 @@ lab.beforeEach((done) => {
       }
     }
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   DynamicsDalService.prototype.search = dynamicsSearchStub
-
-  done()
 })
 
 lab.experiment('Task List Model tests:', () => {
@@ -131,8 +127,6 @@ lab.experiment('Task List Model tests:', () => {
     TaskList.getByApplicationLineId().then((taskList) => {
       Code.expect(taskList).to.not.be.null()
       Code.expect(spy.callCount).to.equal(1)
-
-      done()
     })
   })
 
@@ -163,8 +157,6 @@ lab.experiment('Task List Model tests:', () => {
       Code.expect(Array.isArray(taskList.sections[2].sectionItems)).to.be.true()
       Code.expect(taskList.sections[2].sectionItems.length).to.equal(1)
       Code.expect(taskList.sections[2].sectionItems[0].id).to.equal('submit-pay')
-
-      done()
     })
   })
 })

--- a/test/routes/checkBeforeSending.route.test.js
+++ b/test/routes/checkBeforeSending.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Check your answers before sending your application page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Check your answers before sending your application page tests:',
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Check your answers before sending your application page tests:',
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Check your answers before sending your application page tests:',
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/checkYourEmail.route.test.js
+++ b/test/routes/checkYourEmail.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment(`Search for 'standard rules permit application' in your email page tests:`, () => {
@@ -46,8 +42,6 @@ lab.experiment(`Search for 'standard rules permit application' in your email pag
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment(`Search for 'standard rules permit application' in your email pag
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 })

--- a/test/routes/confidentiality.route.test.js
+++ b/test/routes/confidentiality.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Is part of your application commercially confidential? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Is part of your application commercially confidential? page test
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Is part of your application commercially confidential? page test
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Is part of your application commercially confidential? page test
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/confirmRules.route.test.js
+++ b/test/routes/confirmRules.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Confirm that your operation meets the rules page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Confirm that your operation meets the rules page tests:', () => 
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -70,8 +64,6 @@ lab.experiment('Confirm that your operation meets the rules page tests:', () => 
       // After post:
       // confirm-result-message
       // return-to-task-list-button
-
-      done()
     })
   })
 
@@ -90,7 +82,6 @@ lab.experiment('Confirm that your operation meets the rules page tests:', () => 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/contactDetails.route.test.js
+++ b/test/routes/contactDetails.route.test.js
@@ -37,8 +37,6 @@ lab.beforeEach((done) => {
   contactSaveStub = Contact.prototype.save
   Contact.prototype.save = (authToken) => {
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -46,8 +44,6 @@ lab.afterEach((done) => {
   CookieService.validateCookie = validateCookieStub
   Contact.prototype.getById = contactGetByIdStub
   Contact.prototype.save = contactSaveStub
-
-  done()
 })
 
 lab.experiment('Contact details page tests:', () => {
@@ -67,8 +63,6 @@ lab.experiment('Contact details page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -90,8 +84,6 @@ lab.experiment('Contact details page tests:', () => {
 
       element = doc.getElementById('contact-details-continue').firstChild
       Code.expect(element.nodeValue).to.equal('Continue')
-
-      done()
     })
   })
 
@@ -112,8 +104,6 @@ lab.experiment('Contact details page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/task-list')
-
-      done()
     })
   })
 
@@ -139,8 +129,6 @@ lab.experiment('Contact details page tests:', () => {
 
       let element = doc.getElementById('contact-details-heading').firstChild
       Code.expect(element.nodeValue).to.equal('Who should we contact about this application?')
-
-      done()
     })
   })
 
@@ -161,8 +149,6 @@ lab.experiment('Contact details page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-
-      done()
     })
   })
 })

--- a/test/routes/contactSearch.route.test.js
+++ b/test/routes/contactSearch.route.test.js
@@ -58,8 +58,6 @@ lab.beforeEach((done) => {
       emailaddress1: 'marlon.herzog@example.com'
     })
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -67,8 +65,6 @@ lab.afterEach((done) => {
   CookieService.validateCookie = validateCookieStub
   Contact.prototype.list = contactListStub
   Contact.prototype.getById = contactGetByIdStub
-
-  done()
 })
 
 lab.experiment('Contact search page tests:', () => {
@@ -88,8 +84,6 @@ lab.experiment('Contact search page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -108,8 +102,6 @@ lab.experiment('Contact search page tests:', () => {
 
       let element = doc.getElementById('contacts-heading').firstChild
       Code.expect(element.nodeValue).to.equal('Contact search')
-
-      done()
     })
   })
 
@@ -126,8 +118,6 @@ lab.experiment('Contact search page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal(routePath)
-
-      done()
     })
   })
 
@@ -148,8 +138,6 @@ lab.experiment('Contact search page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-
-      done()
     })
   })
 })

--- a/test/routes/costTime.route.test.js
+++ b/test/routes/costTime.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Cost and time for this permit page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Cost and time for this permit page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Cost and time for this permit page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Cost and time for this permit page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/drainageTypeDrain.route.test.js
+++ b/test/routes/drainageTypeDrain.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Where does the vehicle storage area drain to? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/error.route.test.js
+++ b/test/routes/error.route.test.js
@@ -9,11 +9,11 @@ const server = require('../../server')
 const routePath = '/error'
 
 lab.beforeEach((done) => {
-  done()
+
 })
 
 lab.afterEach((done) => {
-  done()
+
 })
 
 lab.experiment('Error page tests:', () => {
@@ -33,8 +33,6 @@ lab.experiment('Error page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -53,8 +51,6 @@ lab.experiment('Error page tests:', () => {
 
       let element = doc.getElementById('error-heading').firstChild
       Code.expect(element.nodeValue).to.equal('Something went wrong')
-
-      done()
     })
   })
 })

--- a/test/routes/firePreventionPlan.route.test.js
+++ b/test/routes/firePreventionPlan.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Upload the fire prevention plan page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Upload the fire prevention plan page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Upload the fire prevention plan page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Upload the fire prevention plan page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/health.route.test.js
+++ b/test/routes/health.route.test.js
@@ -10,11 +10,11 @@ const server = require('../../server')
 const routePath = '/health'
 
 lab.beforeEach((done) => {
-  done()
+
 })
 
 lab.afterEach((done) => {
-  done()
+
 })
 
 lab.experiment('Health page tests:', () => {
@@ -34,8 +34,6 @@ lab.experiment('Health page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -60,8 +58,6 @@ lab.experiment('Health page tests:', () => {
 
       element = doc.getElementById('health-application-commit-ref').firstChild
       Code.expect(element.nodeValue).to.exist()
-
-      done()
     })
   })
 })

--- a/test/routes/managementSystem.route.test.js
+++ b/test/routes/managementSystem.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Which management system will you use? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Which management system will you use? page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Which management system will you use? page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Which management system will you use? page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/pageNotFound.route.test.js
+++ b/test/routes/pageNotFound.route.test.js
@@ -17,13 +17,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-  done()
 })
 
 lab.experiment('Page Not Found (404) page tests:', () => {
@@ -43,8 +41,6 @@ lab.experiment('Page Not Found (404) page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -72,8 +68,6 @@ lab.experiment('Page Not Found (404) page tests:', () => {
 
       element = doc.getElementById('page-not-found-apply-link').firstChild
       Code.expect(element.nodeValue).to.exist()
-
-      done()
     })
   })
 
@@ -91,7 +85,6 @@ lab.experiment('Page Not Found (404) page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/start/start-or-open-saved')
-      done()
     })
   })
 
@@ -105,7 +98,6 @@ lab.experiment('Page Not Found (404) page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal(routePath)
-      done()
     })
   })
 })

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('What do you want the permit for? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('What do you want the permit for? page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('What do you want the permit for? page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -76,8 +69,6 @@ lab.experiment('What do you want the permit for? page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/permit/select')
-
-      done()
     })
   })
 
@@ -96,7 +87,6 @@ lab.experiment('What do you want the permit for? page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/permitHolderType.route.test.js
+++ b/test/routes/permitHolderType.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Who will be the permit holder? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Who will be the permit holder? page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Who will be the permit holder? page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Who will be the permit holder? page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -48,8 +48,6 @@ lab.beforeEach((done) => {
 
   applicationLineSaveStub = ApplicationLine.save
   ApplicationLine.prototype.save = (authToken) => {}
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -58,8 +56,6 @@ lab.afterEach((done) => {
   StandardRule.prototype.list = standardRuleListStub
   StandardRule.getByCode = standardRuleGetByCodeStub
   ApplicationLine.prototype.save = applicationLineSaveStub
-
-  done()
 })
 
 lab.experiment('Select a permit page tests:', () => {
@@ -79,8 +75,6 @@ lab.experiment('Select a permit page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -112,8 +106,6 @@ lab.experiment('Select a permit page tests:', () => {
 
       element = doc.getElementById('permit-select-submit').firstChild
       Code.expect(element.nodeValue).to.equal('Continue')
-
-      done()
     })
   })
 
@@ -130,8 +122,6 @@ lab.experiment('Select a permit page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/task-list')
-
-      done()
     })
   })
 
@@ -150,7 +140,6 @@ lab.experiment('Select a permit page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 
@@ -173,8 +162,6 @@ lab.experiment('Select a permit page tests:', () => {
       const element = doc.getElementById('error-summary')
 
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -202,8 +189,6 @@ lab.experiment('Select a permit page tests:', () => {
       // Chosen permit ID error
       element = doc.getElementById('chosen-permit-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 
@@ -233,8 +218,6 @@ lab.experiment('Select a permit page tests:', () => {
       // Chosen permit ID error
       element = doc.getElementById('chosen-permit-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 })

--- a/test/routes/preApplication.route.test.js
+++ b/test/routes/preApplication.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Have you discussed this application with us? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Have you discussed this application with us? page tests:', () =>
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Have you discussed this application with us? page tests:', () =>
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Have you discussed this application with us? page tests:', () =>
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/root.route.test.js
+++ b/test/routes/root.route.test.js
@@ -16,15 +16,11 @@ lab.beforeEach((done) => {
   ActiveDirectoryAuthService.prototype.getToken = () => {
     return '__GENERATED_CRM_TOKEN__'
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   ActiveDirectoryAuthService.prototype.getToken = getAuthTokenStub
-
-  done()
 })
 
 lab.experiment('Default page tests:', () => {
@@ -38,8 +34,6 @@ lab.experiment('Default page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/start/start-or-open-saved')
-
-      done()
     })
   })
 })

--- a/test/routes/sitePlan.route.test.js
+++ b/test/routes/sitePlan.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Upload the site plan page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Upload the site plan page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Upload the site plan page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Upload the site plan page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/siteSiteName.route.test.js
+++ b/test/routes/siteSiteName.route.test.js
@@ -37,8 +37,6 @@ lab.beforeEach((done) => {
   Site.getByApplicationId = (authToken, applicationId, applicationLineId) => {
     return fakeSite
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -47,8 +45,6 @@ lab.afterEach((done) => {
 
   Site.prototype.save = siteSaveStub
   Site.getByApplicationId = getByApplicationIdStub
-
-  done()
 })
 
 lab.experiment('Site page tests:', () => {
@@ -72,8 +68,6 @@ lab.experiment('Site page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -112,8 +106,6 @@ lab.experiment('Site page tests:', () => {
 
       element = doc.getElementById('site-site-name-submit').firstChild
       Code.expect(element.nodeValue).to.equal('Continue')
-
-      done()
     })
   })
 
@@ -147,8 +139,6 @@ lab.experiment('Site page tests:', () => {
 
       element = doc.getElementById('site-site-name-submit').firstChild
       Code.expect(element.nodeValue).to.equal('Continue')
-
-      done()
     })
   })
 
@@ -170,8 +160,6 @@ lab.experiment('Site page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/task-list')
-
-      done()
     })
   })
 
@@ -188,8 +176,6 @@ lab.experiment('Site page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/task-list')
-
-      done()
     })
   })
 
@@ -208,7 +194,6 @@ lab.experiment('Site page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 
@@ -231,8 +216,6 @@ lab.experiment('Site page tests:', () => {
       const element = doc.getElementById('error-summary')
 
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -262,8 +245,6 @@ lab.experiment('Site page tests:', () => {
       // Site name field error
       element = doc.getElementById('site-name-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 
@@ -293,8 +274,6 @@ lab.experiment('Site page tests:', () => {
       // Site name field error
       element = doc.getElementById('site-name-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 
@@ -324,8 +303,6 @@ lab.experiment('Site page tests:', () => {
       // Site name field error
       element = doc.getElementById('site-name-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 })

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -33,7 +33,6 @@ lab.beforeEach((done) => {
 
   applicationSaveStub = Application.prototype.save
   Application.prototype.save = (authToken) => {}
-  done()
 })
 
 lab.afterEach((done) => {
@@ -41,8 +40,6 @@ lab.afterEach((done) => {
   CookieService.generateCookie = generateCookieStub
   CookieService.validateCookie = validateCookieStub
   Application.prototype.save = applicationSaveStub
-
-  done()
 })
 
 lab.experiment('Start or Open Saved page tests:', () => {
@@ -62,8 +59,6 @@ lab.experiment('Start or Open Saved page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -91,8 +86,6 @@ lab.experiment('Start or Open Saved page tests:', () => {
 
       element = doc.getElementById('start-or-open-saved-submit').firstChild
       Code.expect(element.nodeValue).to.equal('Continue')
-
-      done()
     })
   })
 
@@ -109,8 +102,6 @@ lab.experiment('Start or Open Saved page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/permit/category')
-
-      done()
     })
   })
 
@@ -127,8 +118,6 @@ lab.experiment('Start or Open Saved page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/save-and-return/check-your-email')
-
-      done()
     })
   })
 
@@ -156,8 +145,6 @@ lab.experiment('Start or Open Saved page tests:', () => {
       // Site name field error
       element = doc.getElementById('started-application-error').firstChild
       Code.expect(element.nodeValue).to.equal(errorMessage)
-
-      done()
     })
   })
 })

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -198,8 +198,6 @@ lab.beforeEach((done) => {
   TaskList.getByApplicationLineId = (authToken, applicationLineId) => {
     return fakeTaskList
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
@@ -208,7 +206,6 @@ lab.afterEach((done) => {
   CookieService.validateCookie = validateCookieStub
   StandardRule.getByCode = standardRuleGetByCodeStub
   TaskList.getByApplicationLineId = taskListGetByApplicationLineIdStub
-  done()
 })
 
 lab.experiment('Task List page tests:', () => {
@@ -228,8 +225,6 @@ lab.experiment('Task List page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -243,7 +238,6 @@ lab.experiment('Task List page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -275,8 +269,6 @@ lab.experiment('Task List page tests:', () => {
 
       element = doc.getElementById('select-a-different-permit')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -311,8 +303,6 @@ lab.experiment('Task List page tests:', () => {
       Code.expect(element).to.exist()
       element = doc.getElementById('send-and-pay-section-heading')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -379,8 +369,6 @@ lab.experiment('Task List page tests:', () => {
       Code.expect(element).to.not.exist()
       element = doc.getElementById('upload-the-site-plan-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -432,8 +420,6 @@ lab.experiment('Task List page tests:', () => {
         element = doc.getElementById(id)
         Code.expect(element).to.not.exist()
       })
-
-      done()
     })
   })
 
@@ -452,7 +438,6 @@ lab.experiment('Task List page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/technicalQualification.route.test.js
+++ b/test/routes/technicalQualification.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Which qualification does the person providing technical management have? page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Which qualification does the person providing technical manageme
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Which qualification does the person providing technical manageme
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Which qualification does the person providing technical manageme
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/routes/version.route.test.js
+++ b/test/routes/version.route.test.js
@@ -42,16 +42,12 @@ lab.beforeEach((done) => {
   DynamicsSolution.get = (authToken) => {
     return dynamicsVersionInfo
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   this.generateCookie = generateCookieStub
   DynamicsSolution.get = dynamicSolutionGetStub
-
-  done()
 })
 
 lab.experiment('Version page tests:', () => {
@@ -71,8 +67,6 @@ lab.experiment('Version page tests:', () => {
 
       let element = doc.getElementById('back-link')
       Code.expect(element).to.not.exist()
-
-      done()
     })
   })
 
@@ -99,7 +93,6 @@ lab.experiment('Version page tests:', () => {
         element = doc.getElementById(`dynamics-item-${i}-component-version`).firstChild
         Code.expect(element.nodeValue).to.equal(dynamicsVersionInfo[i].version)
       }
-      done()
     })
   })
 })

--- a/test/routes/wasteRecoveryPlan.route.test.js
+++ b/test/routes/wasteRecoveryPlan.route.test.js
@@ -18,15 +18,11 @@ lab.beforeEach((done) => {
   CookieService.validateCookie = () => {
     return true
   }
-
-  done()
 })
 
 lab.afterEach((done) => {
   // Restore stubbed methods
   CookieService.validateCookie = validateCookieStub
-
-  done()
 })
 
 lab.experiment('Waste Recovery Plan page tests:', () => {
@@ -46,8 +42,6 @@ lab.experiment('Waste Recovery Plan page tests:', () => {
 
       const element = doc.getElementById('back-link')
       Code.expect(element).to.exist()
-
-      done()
     })
   })
 
@@ -61,7 +55,6 @@ lab.experiment('Waste Recovery Plan page tests:', () => {
 
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(200)
-      done()
     })
   })
 
@@ -80,7 +73,6 @@ lab.experiment('Waste Recovery Plan page tests:', () => {
     server.inject(request, (res) => {
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal('/error')
-      done()
     })
   })
 })

--- a/test/services/activeDirectoryAuth.service.test.js
+++ b/test/services/activeDirectoryAuth.service.test.js
@@ -24,13 +24,10 @@ let authTokenResponse = {
 
 lab.beforeEach((done) => {
   authService = new ActiveDirectoryAuthService()
-
-  done()
 })
 
 lab.afterEach((done) => {
   nock.cleanAll()
-  done()
 })
 
 lab.experiment('Active Directory Auth Service tests:', () => {
@@ -40,8 +37,6 @@ lab.experiment('Active Directory Auth Service tests:', () => {
 
     authService.getToken().then((authToken) => {
       Code.expect(authToken).to.equal(authTokenResponse.access_token)
-
-      done()
     })
   })
 
@@ -52,7 +47,6 @@ lab.experiment('Active Directory Auth Service tests:', () => {
     authService.getToken()
       .catch((error) => {
         Code.expect(error.message).to.equal('socket hang up')
-        done()
       })
   })
 })

--- a/test/services/commitHash.service.test.js
+++ b/test/services/commitHash.service.test.js
@@ -25,22 +25,18 @@ lab.beforeEach((done) => {
   processEnvStub = Object.assign({}, process.env)
   readFileSyncStub = fs.readFileSync
   execSyncStub = fs.readFileSync
-
-  done()
 })
 
 lab.afterEach((done) => {
   process.env = processEnvStub
   fs.readFileSync = readFileSyncStub
   childProcess.execSync = execSyncStub
-  done()
 })
 
 lab.experiment('Commit hash service tests:', () => {
   lab.test('commitHash() returns the value of GIT_SHA env var when set', (done) => {
     process.env.GIT_SHA = 'foobar-foobar-foobar'
     Code.expect(CommitHashService.commitHash()).to.equal('foobar-foobar-foobar')
-    done()
   })
 
   lab.test('commitHash() returns contents of REVISION file when env var not set', (done) => {
@@ -48,7 +44,6 @@ lab.experiment('Commit hash service tests:', () => {
       return 'fromfile-fromfile-fromfile'
     }
     Code.expect(CommitHashService.commitHash()).to.equal('fromfile-fromfile-fromfile')
-    done()
   })
 
   lab.test('commitHash() returns the result of quering git directly when both the GIT_SHA env var and file are not set', (done) => {
@@ -56,7 +51,6 @@ lab.experiment('Commit hash service tests:', () => {
       return 'fromgit-fromgit-fromgit'
     }
     Code.expect(CommitHashService.commitHash()).to.equal('fromgit-fromgit-fromgit')
-    done()
   })
 
   lab.test('commitHash() sets the env var GIT_SHA after having read the reference from the REVISION file', (done) => {
@@ -65,7 +59,6 @@ lab.experiment('Commit hash service tests:', () => {
     }
     Code.expect(CommitHashService.commitHash()).to.equal('setfileenv-setfileenv-setfileenv')
     Code.expect(process.env.GIT_SHA).to.equal('setfileenv-setfileenv-setfileenv')
-    done()
   })
 
   lab.test('commitHash() sets the env var GIT_SHA after having queried git for the reference', (done) => {
@@ -74,6 +67,5 @@ lab.experiment('Commit hash service tests:', () => {
     }
     Code.expect(CommitHashService.commitHash()).to.equal('setgitenv-setgitenv-setgitenv')
     Code.expect(process.env.GIT_SHA).to.equal('setgitenv-setgitenv-setgitenv')
-    done()
   })
 })

--- a/test/services/cookie.service.test.js
+++ b/test/services/cookie.service.test.js
@@ -20,25 +20,19 @@ lab.beforeEach((done) => {
 
     log: (token, message) => {}
   }
-
-  done()
 })
 
-lab.afterEach((done) => {
-  done()
-})
+lab.afterEach((done) => {})
 
 lab.experiment('Cookie Service tests:', () => {
   lab.test('Validate cookie should successfully validate a valid cookie', (done) => {
     Code.expect(CookieService.validateCookie(fakeRequest)).to.be.true()
-    done()
   })
 
   lab.test('Validate cookie should successfully validate a missing cookie', (done) => {
     fakeRequest.state = {}
     CookieService.validateCookie(fakeRequest)
     Code.expect(CookieService.validateCookie(fakeRequest)).to.be.false()
-    done()
   })
 
   lab.test('Validate cookie should successfully validate an invalid cookie', (done) => {
@@ -47,6 +41,5 @@ lab.experiment('Cookie Service tests:', () => {
 
     fakeRequest.state.DefraSession.applicationId = ''
     Code.expect(CookieService.validateCookie(fakeRequest)).to.be.false()
-    done()
   })
 })

--- a/test/services/dynamicsDal.service.test.js
+++ b/test/services/dynamicsDal.service.test.js
@@ -75,13 +75,10 @@ lab.beforeEach((done) => {
     .get(`${config.dynamicsWebApiPath}__DYNAMICS_TIMEOUT_QUERY__`)
     .socketDelay(7000)
     .reply(200, {})
-
-  done()
 })
 
 lab.afterEach((done) => {
   nock.cleanAll()
-  done()
 })
 
 lab.experiment('Dynamics Service tests:', () => {
@@ -91,7 +88,6 @@ lab.experiment('Dynamics Service tests:', () => {
       Code.expect(spy.callCount).to.equal(1)
       Code.expect(response).to.equal('7a8e4354-4f24-e711-80fd-5065f38a1b01')
       DynamicsDalService.prototype._call.restore()
-      done()
     })
   })
 
@@ -100,7 +96,6 @@ lab.experiment('Dynamics Service tests:', () => {
     dynamicsDal.update('__DYNAMICS_UPDATE_QUERY__', {}).then((response) => {
       Code.expect(spy.callCount).to.equal(1)
       DynamicsDalService.prototype._call.restore()
-      done()
     })
   })
 
@@ -109,7 +104,6 @@ lab.experiment('Dynamics Service tests:', () => {
     dynamicsDal.search('__DYNAMICS_LIST_QUERY__').then((response) => {
       Code.expect(spy.callCount).to.equal(1)
       DynamicsDalService.prototype._call.restore()
-      done()
     })
   })
 
@@ -119,7 +113,6 @@ lab.experiment('Dynamics Service tests:', () => {
       Code.expect(spy.callCount).to.equal(1)
 
       DynamicsDalService.prototype._call.restore()
-      done()
     })
   })
 
@@ -131,7 +124,6 @@ lab.experiment('Dynamics Service tests:', () => {
         Code.expect(err).to.endWith('Code: 500 Message: null')
 
         DynamicsDalService.prototype._call.restore()
-        done()
       })
   })
 
@@ -143,7 +135,6 @@ lab.experiment('Dynamics Service tests:', () => {
         Code.expect(err.message).to.equal('socket hang up')
 
         DynamicsDalService.prototype._call.restore()
-        done()
       })
   })
 })

--- a/test/services/logging.service.test.js
+++ b/test/services/logging.service.test.js
@@ -8,13 +8,9 @@ const sinon = require('sinon')
 const LoggingService = require('../../src/services/logging.service')
 const server = require('../../server')
 
-lab.beforeEach((done) => {
-  done()
-})
+lab.beforeEach((done) => {})
 
-lab.afterEach((done) => {
-  done()
-})
+lab.afterEach((done) => {})
 
 lab.experiment('LoggingService tests: Server logging:', () => {
   lab.test('Error messages are logged', (done) => {
@@ -26,7 +22,6 @@ lab.experiment('LoggingService tests: Server logging:', () => {
     Code.expect(spy.threw()).to.equal(false)
 
     server.log.restore()
-    done()
   })
 
   lab.test('Info messages are logged', (done) => {
@@ -38,7 +33,6 @@ lab.experiment('LoggingService tests: Server logging:', () => {
     Code.expect(spy.threw()).to.equal(false)
 
     server.log.restore()
-    done()
   })
 })
 
@@ -53,8 +47,6 @@ lab.experiment('LoggingService tests: Request logging:', () => {
     Code.expect(spy.calledOnce).to.equal(true)
     Code.expect(spy.calledWith('ERROR', 'An error has occurred')).to.equal(true)
     Code.expect(spy.threw()).to.equal(false)
-
-    done()
   })
 
   lab.test('Info messages are logged', (done) => {
@@ -67,7 +59,5 @@ lab.experiment('LoggingService tests: Request logging:', () => {
     Code.expect(spy.calledOnce).to.equal(true)
     Code.expect(spy.calledWith('INFO', 'Something has happened')).to.equal(true)
     Code.expect(spy.threw()).to.equal(false)
-
-    done()
   })
 })


### PR DESCRIPTION
Lab version 15 drops support for ending tests by executing the done callback and running tests in parallel. All tests now are executed using async/await and should be much simpler to construct as a result. As a result, it was necessary to remove all the calls to done() from our tests.