### PR TITLE
Add debug logging to AD Auth service.

### DIFF
--- a/src/services/activeDirectoryAuth.service.js
+++ b/src/services/activeDirectoryAuth.service.js
@@ -27,6 +27,8 @@ module.exports = class ActiveDirectoryAuthService {
 
         response.setEncoding('utf8')
         response.on('data', (chunk) => {
+          LoggingService.logDebug(undefined, chunk)
+          
           // Add each response chunk to the responseParts array
           responseParts.push(chunk)
         })


### PR DESCRIPTION
This change adds some DEBUG level logging to the Active Directory Auth service. This will allow us to investigate any issues experienced when getting an AD token that we want to use with Dynamics.