### PR TITLE
Fixed validation of grid references.

### DIFF
--- a/src/models/taskList/siteNameAndLocation.model.js
+++ b/src/models/taskList/siteNameAndLocation.model.js
@@ -21,7 +21,6 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
-      // return reply.redirect(Constants.Routes.ERROR.path)
     }
     return siteName
   }
@@ -45,7 +44,6 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
-      // return reply.redirect(Constants.Routes.ERROR.path)
     }
   }
 
@@ -65,12 +63,13 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
-      // return reply.redirect(Constants.Routes.ERROR.path)
     }
     return gridReference
   }
 
   static async saveGridReference (request, gridReference, authToken, applicationId, applicationLineId) {
+      // Strip out whitespace from the grid reference, convert to upper case and save it
+    gridReference = gridReference.replace(/\s/g, '').toUpperCase()
     try {
       // Get the Location for this application
       let location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
@@ -102,7 +101,6 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
-      // return reply.redirect(Constants.Routes.ERROR.path)
     }
   }
 

--- a/src/validators/siteGridReference.validator.js
+++ b/src/validators/siteGridReference.validator.js
@@ -3,7 +3,10 @@
 const Joi = require('joi')
 const BaseValidator = require('./base.validator')
 
-const GRID_REFERENCE_REGEX = /[a-zA-Z]{2}[\d+]{10}/g
+// Must be 2 letters (case insensitive) and 10 digits, e.g. AB1234567890 or ab1234567890
+// The requirement is to ignore whitespace contained within the grid reference,
+// therefore 'AB   12345 6 7 8 9 0' is deemed to be valid input
+const GRID_REFERENCE_REGEX = /^(([a-zA-Z]{1}[\s]*){2}([\d+]{1}[\s]*){10})$/g
 
 module.exports = class SiteGridReferenceValidator extends BaseValidator {
   constructor () {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-472

This fix ensures that the grid reference can be entered with any number of whitespace characters contained anywhere within it.

We also now automatically convert the first two letters in the grid reference to upper case before it is persisted in Dynamics.