### PR TITLE
Fix the Confirm Rules Model tests

### DIFF
--- a/src/models/confirmRules.model.js
+++ b/src/models/confirmRules.model.js
@@ -12,6 +12,8 @@ module.exports = class ConfirmRules extends BaseModel {
     this.applicationId = confirmRules.applicationId
     this.applicationLineId = confirmRules.applicationLineId
     this.complete = confirmRules.complete
+    // The following delay is required by the untilComplete method
+    this.delay = 250
   }
 
   static async getByApplicationId (authToken, applicationId, applicationLineId) {
@@ -37,13 +39,13 @@ module.exports = class ConfirmRules extends BaseModel {
 
   // A bug currently exists where the completeness isn't updated straight away in dynamics even when the save is successful.
   // This function is a temporary fix to wait until we are sure we can get the completeness value.
-  // This can be removed when the update is successful only when the update in dynamics has fully completed.
+  // This and the code overriding the delay property in the test, can be removed when the update is successful only when the update in dynamics has fully completed.
   async untilComplete (authToken) {
     for (let retries = 10; retries && !(await ConfirmRules.getByApplicationId(authToken, this.applicationId, this.applicationLineId)).complete; retries--) {
       if (!retries) {
         throw new Error('Failed to complete')
       }
-      await new Promise(resolve => setTimeout(resolve, 250))
+      await new Promise(resolve => setTimeout(resolve, this.delay))
     }
   }
 

--- a/test/models/confirmRules.model.test.js
+++ b/test/models/confirmRules.model.test.js
@@ -28,6 +28,7 @@ let savedConfirmRulesData = {}
 
 lab.beforeEach(() => {
   testConfirmRules = new ConfirmRules(fakeConfirmRulesData)
+  testConfirmRules.delay = 0
 
   dynamicsSearchStub = DynamicsDalService.prototype.search
   DynamicsDalService.prototype.search = () => {
@@ -37,8 +38,9 @@ lab.beforeEach(() => {
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
   DynamicsDalService.prototype.update = (query, entity) => {
-    const defra_parametersId = Object.assign({}, fakeConfirmRulesDynamicsData.defra_parametersId, entity)
-    savedConfirmRulesData = {defra_parametersId}
+    savedConfirmRulesData = {
+      defra_parametersId: Object.assign({}, fakeConfirmRulesDynamicsData.defra_parametersId, entity)
+    }
   }
 })
 


### PR DESCRIPTION
The tests were timing out when calling the save() method due to the timeout/retry work-around when saving completeness.

A fix to allow the tests to override the delay to 0 prevents the tests timing out.