### PR TITLE
Correct the text on the confirm rules submit button

### DIFF
--- a/src/views/confirmRules.html
+++ b/src/views/confirmRules.html
@@ -22,7 +22,7 @@
           {{#if complete}}
             <button id="return-to-task-list-button" type="submit" class="button" name="Return to task list">Return to task list</button>
           {{else}}
-            <button id="operation-meets-rules-button" type="submit" class="button" name="The operation meets these rules">The operation meets these rules</button>
+            <button id="operation-meets-rules-button" type="submit" class="button" name="Our operation meets these rules">Our operation meets these rules</button>
           {{/if}}
         </div>
       </form>


### PR DESCRIPTION
QA states the submit button in the confirm rules page should say 'Our operation meets these rules' not 'The operation...'.