### PR TITLE
Changed task list item route for MVP

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,11 @@ Constants.Routes = {
     pageHeading: `Search for 'standard rules permit application' in your email`,
     taskListHeading: `Search for 'standard rules permit application' in your email`
   },
+  COMPANY_NUMBER: {
+    path: '/permit-holder/company/number',
+    pageHeading: `What's the UK company registration number?`,
+    taskListHeading: `What's the company name or registration number?`
+  },
   CONFIDENTIALITY: {
     path: '/confidentiality',
     pageHeading: 'Is part of your application commercially confidential?',

--- a/src/models/taskList/taskList.model.js
+++ b/src/models/taskList/taskList.model.js
@@ -80,7 +80,10 @@ module.exports = class TaskList extends BaseModel {
       }, {
         id: 'give-permit-holder-details',
         label: Constants.Routes.PERMIT_HOLDER_TYPE.taskListHeading,
-        href: Constants.Routes.PERMIT_HOLDER_TYPE.path,
+        // For MVP the route for this task list item is different,
+        // we will go straight to the Company Details pathway instead.
+        href: Constants.Routes.COMPANY_NUMBER.path,
+        // href: Constants.Routes.PERMIT_HOLDER_TYPE.path,
         completedLabelId: 'site-operator-completed',
         rulesetId: Constants.Dynamics.RulesetIds.PERMIT_HOLDER_DETAILS,
         available: false


### PR DESCRIPTION
The purpose of this change is to modify the task list route so that the 'Give permit holder details' link goes directly to the 'Enter company number' page, bypassing another page that will one day ask the user what type of permit holder they are.

Since this only temporary for MVP I have left the intended route in place and commented out with a suitable comment so that it can be put back in again easily when required.