### PR TITLE
Remove unnecessary unit test stub params

### DIFF
--- a/test/models/account.model.test.js
+++ b/test/models/account.model.test.js
@@ -31,7 +31,7 @@ const applicationId = fakeAccountData.companyNumber
 lab.beforeEach(() => {
   testAccount = new Account(fakeAccountData)
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics Account object
     return {
       '@odata.etag': 'W/"1039178"',
@@ -41,13 +41,13 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => fakeApplicationData.accountId
+  DynamicsDalService.prototype.create = () => fakeApplicationData.accountId
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => fakeApplicationData.accountId
+  DynamicsDalService.prototype.update = () => fakeApplicationData.accountId
 
   applicationGetByIdStub = Application.getById
-  Application.getById = (authToken, applicationId) => fakeApplicationData
+  Application.getById = () => fakeApplicationData
 })
 
 lab.afterEach(() => {

--- a/test/models/address.model.test.js
+++ b/test/models/address.model.test.js
@@ -25,7 +25,7 @@ lab.beforeEach(() => {
   testAddress = new Address(fakeAddressData)
 
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics Address object
     return {
       '@odata.context': 'https://ea-lp-crm-devmaster.crm4.dynamics.com/api/data/v8.2/$metadata#defra_addresses/$entity',
@@ -75,10 +75,10 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => testAddressId
+  DynamicsDalService.prototype.create = () => testAddressId
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => dataObject.id
+  DynamicsDalService.prototype.update = (dataObject) => dataObject.id
 })
 
 lab.afterEach(() => {

--- a/test/models/applicationLine.model.test.js
+++ b/test/models/applicationLine.model.test.js
@@ -25,7 +25,7 @@ lab.beforeEach(() => {
   // Stub methods
 
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics Contact objects
     return {
       '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
@@ -73,7 +73,7 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => applicationLineId
+  DynamicsDalService.prototype.create = () => applicationLineId
 })
 
 lab.afterEach(() => {

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -23,7 +23,7 @@ lab.beforeEach(() => {
 
   // Stub methods
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics Contact objects
     return {
       '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
@@ -52,12 +52,12 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => {
+  DynamicsDalService.prototype.create = () => {
     return '7a8e4354-4f24-e711-80fd-5065f38a1b01'
   }
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => {
+  DynamicsDalService.prototype.update = (dataObject) => {
     return dataObject.id
   }
 })
@@ -71,7 +71,7 @@ lab.afterEach(() => {
 
 lab.experiment('Contact Model tests:', () => {
   lab.test('getById() method returns a single Contact object', async () => {
-    DynamicsDalService.prototype.search = (query) => {
+    DynamicsDalService.prototype.search = () => {
       // Dynamics Contact objects
       return {
         '@odata.etag': 'W/"1155486"',

--- a/test/models/dynamicsSolution.model.test.js
+++ b/test/models/dynamicsSolution.model.test.js
@@ -12,7 +12,7 @@ let dynamicsSearchStub
 
 lab.beforeEach(() => {
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics DynamicsSolution objects
     return {
       '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',

--- a/test/models/location.model.test.js
+++ b/test/models/location.model.test.js
@@ -26,7 +26,7 @@ const applicationLineId = 'APPLICATION_LINE_ID'
 lab.beforeEach(() => {
   testLocation = new Location(fakeLocationData)
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics Location object
     return {
       '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
@@ -39,10 +39,10 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => testLocationId
+  DynamicsDalService.prototype.create = () => testLocationId
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => testLocationId
+  DynamicsDalService.prototype.update = () => testLocationId
 })
 
 lab.afterEach(() => {

--- a/test/models/locationDetail.model.test.js
+++ b/test/models/locationDetail.model.test.js
@@ -25,7 +25,7 @@ lab.beforeEach(() => {
   testLocationDetail = new LocationDetail(fakeLocationDetailData)
 
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     // Dynamics LocationDetail object
     return {
       '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
@@ -38,10 +38,10 @@ lab.beforeEach(() => {
   }
 
   dynamicsCreateStub = DynamicsDalService.prototype.create
-  DynamicsDalService.prototype.create = (dataObject, query) => testLocationDetailId
+  DynamicsDalService.prototype.create = () => testLocationDetailId
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => dataObject.id
+  DynamicsDalService.prototype.update = (dataObject) => dataObject.id
 })
 
 lab.afterEach(() => {

--- a/test/models/standardRule.model.test.js
+++ b/test/models/standardRule.model.test.js
@@ -30,7 +30,7 @@ lab.afterEach(() => {
 
 lab.experiment('StandardRule Model tests:', () => {
   lab.test('list() method returns a list of StandardRule objects', async () => {
-    DynamicsDalService.prototype.search = (query) => {
+    DynamicsDalService.prototype.search = () => {
       return {
         '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
         value: [{
@@ -67,7 +67,7 @@ lab.experiment('StandardRule Model tests:', () => {
   })
 
   lab.test('getByCode() method returns a StandardRule object', async () => {
-    DynamicsDalService.prototype.search = (query) => {
+    DynamicsDalService.prototype.search = () => {
       return {
         '@odata.context': 'THE_ODATA_ENDPOINT_AND_QUERY',
         value: [{

--- a/test/models/taskList/companyDetails.model.test.js
+++ b/test/models/taskList/companyDetails.model.test.js
@@ -33,10 +33,10 @@ lab.beforeEach(() => {
   // Stub methods
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => dataObject.id
+  DynamicsDalService.prototype.update = (dataObject) => dataObject.id
 
   applicationLineGetByIdStub = ApplicationLine.getById
-  ApplicationLine.getById = (authToken, applicationLineId) => fakeApplicationLine
+  ApplicationLine.getById = () => fakeApplicationLine
 
   accountGetByApplicationIdStub = Account.getByApplicationId
   Account.getByApplicationId = () => {
@@ -44,7 +44,7 @@ lab.beforeEach(() => {
   }
 
   accountSaveStub = Account.prototype.save
-  Account.prototype.save = (authToken) => {}
+  Account.prototype.save = () => {}
 })
 
 lab.afterEach(() => {

--- a/test/models/taskList/siteNameAndLocation.model.test.js
+++ b/test/models/taskList/siteNameAndLocation.model.test.js
@@ -55,13 +55,13 @@ lab.beforeEach(() => {
   // Stub methods
 
   dynamicsUpdateStub = DynamicsDalService.prototype.update
-  DynamicsDalService.prototype.update = (dataObject, query) => dataObject.id
+  DynamicsDalService.prototype.update = (dataObject) => dataObject.id
 
   applicationLineGetByIdStub = ApplicationLine.getById
-  ApplicationLine.getById = (authToken, applicationLineId) => fakeApplicationLine
+  ApplicationLine.getById = () => fakeApplicationLine
 
   locationGetByApplicationIdStub = Location.getByApplicationId
-  Location.getByApplicationId = (authToken, applicationId, applicationLineId) => {
+  Location.getByApplicationId = () => {
     return new Location(fakeLocation)
   }
 
@@ -71,10 +71,10 @@ lab.beforeEach(() => {
   }
 
   locationSaveStub = Location.prototype.save
-  Location.prototype.save = (authToken) => {}
+  Location.prototype.save = () => {}
 
   locationDetailSaveStub = LocationDetail.prototype.save
-  LocationDetail.prototype.save = (authToken) => {}
+  LocationDetail.prototype.save = () => {}
 
   addressGetByIdStub = Address.getById
   Address.getById = (authToken, id) => {
@@ -103,7 +103,7 @@ const testCompleteness = async (obj, expectedResult) => {
 
 lab.experiment('Task List: Site Name and Location Model tests:', () => {
   lab.test('getSiteName() method correctly retrieves undefined site name when there is no saved Location', async () => {
-    Location.getByApplicationId = (authToken, applicationId, applicationLineId) => {
+    Location.getByApplicationId = () => {
       return undefined
     }
 
@@ -123,7 +123,7 @@ lab.experiment('Task List: Site Name and Location Model tests:', () => {
   })
 
   lab.test('getGridReference() method correctly retrieves undefined grid reference when there is no saved Location or LocationDetail', async () => {
-    Location.getByApplicationId = (authToken, applicationId, applicationLineId) => {
+    Location.getByApplicationId = () => {
       return undefined
     }
     LocationDetail.getByLocationId = (authToken, locationId) => {

--- a/test/models/taskList/taskList.model.test.js
+++ b/test/models/taskList/taskList.model.test.js
@@ -13,7 +13,7 @@ let dynamicsSearchStub
 lab.beforeEach(() => {
   // Stub methods
   dynamicsSearchStub = DynamicsDalService.prototype.search
-  DynamicsDalService.prototype.search = (query) => {
+  DynamicsDalService.prototype.search = () => {
     return {
       '@odata.context': 'https://ea-lp-crm-devmaster.crm4.dynamics.com/api/data/v8.2/$metadata#defra_applicationlines(defra_parametersId(defra_showcostandtime,defra_showcostandtime_completed,defra_confirmreadrules,defra_confirmreadrules_completed,defra_wasterecoveryplanreq,defra_wasterecoveryplanreq_completed,defra_preapprequired,defra_preapprequired_completed,defra_contactdetailsrequired,defra_contactdetailsrequired_completed,defra_pholderdetailsrequired,defra_pholderdetailsrequired_completed,defra_locationrequired,defra_locationrequired_completed,defra_siteplanrequired,defra_siteplanrequired_completed,defra_techcompetenceevreq,defra_techcompetenceevreq_completed,defra_mansystemrequired,defra_mansystemrequired_completed,defra_fireplanrequired,defra_fireplanrequired_completed,defra_surfacedrainagereq,defra_surfacedrainagereq_completed,defra_cnfconfidentialityreq,defra_cnfconfidentialityreq_completed))/$entity',
       '@odata.etag': 'W/"725645"',

--- a/test/routes/addressSelect.route.test.js
+++ b/test/routes/addressSelect.route.test.js
@@ -28,7 +28,7 @@ lab.beforeEach(() => {
 
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/checkBeforeSending.route.test.js
+++ b/test/routes/checkBeforeSending.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/check-before-sending'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/checkYourEmail.route.test.js
+++ b/test/routes/checkYourEmail.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/save-and-return/check-your-email'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/companyCheckName.route.test.js
+++ b/test/routes/companyCheckName.route.test.js
@@ -44,13 +44,13 @@ lab.beforeEach(() => {
 
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   companyLookupGetCompanyNameStub = CompanyLookupService.getCompanyName
   CompanyLookupService.getCompanyName = (companyNumber) => fakeAccountData.companyName
 
   applicationGetByIdStub = Application.getById
-  Application.getById = (authToken, applicationId) => fakeApplicationData
+  Application.getById = () => fakeApplicationData
 
   applicationGetByIdStub = Account.getByApplicationId
   Account.getByApplicationId = (authToken, applicationId) => fakeAccountData

--- a/test/routes/companyNumber.route.test.js
+++ b/test/routes/companyNumber.route.test.js
@@ -78,7 +78,7 @@ lab.experiment('Get company number page tests:', () => {
       }
 
       accountSaveStub = Account.prototype.save
-      Account.prototype.save = (authToken) => new Account(fakeAccount)
+      Account.prototype.save = () => new Account(fakeAccount)
     })
 
     lab.test('should have a back link', async () => {
@@ -128,7 +128,7 @@ lab.experiment('Get company number page tests:', () => {
       }
 
       accountSaveStub = Account.prototype.save
-      Account.prototype.save = (authToken) => {
+      Account.prototype.save = () => {
         return fakeAccount.id
       }
     })

--- a/test/routes/confidentiality.route.test.js
+++ b/test/routes/confidentiality.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/confidentiality'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/confirmRules.route.test.js
+++ b/test/routes/confirmRules.route.test.js
@@ -33,7 +33,7 @@ lab.beforeEach(() => {
   LoggingService.logError = () => {}
 
   getByApplicationIdStub = ConfirmRules.getByApplicationId
-  ConfirmRules.getByApplicationId = (authToken, applicationId, applicationLineId) => fakeConfirmRules
+  ConfirmRules.getByApplicationId = () => fakeConfirmRules
 })
 
 lab.afterEach(() => {
@@ -67,7 +67,7 @@ lab.experiment('Confirm that your operation meets the rules page tests:', () => 
       }
 
       confirmRulesSaveStub = ConfirmRules.prototype.save
-      ConfirmRules.prototype.save = (authToken) => {}
+      ConfirmRules.prototype.save = () => {}
     })
 
     lab.test('should have a back link', async () => {
@@ -128,7 +128,7 @@ lab.experiment('Confirm that your operation meets the rules page tests:', () => 
       }
 
       confirmRulesSaveStub = ConfirmRules.prototype.save
-      ConfirmRules.prototype.save = (authToken) => {}
+      ConfirmRules.prototype.save = () => {}
     })
 
     lab.afterEach(() => {

--- a/test/routes/contactDetails.route.test.js
+++ b/test/routes/contactDetails.route.test.js
@@ -19,7 +19,7 @@ const routePath = '/contact-details'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   contactGetByIdStub = Contact.getById
   Contact.getById = (authToken, id) => {
@@ -33,7 +33,7 @@ lab.beforeEach(() => {
   }
 
   contactSaveStub = Contact.prototype.save
-  Contact.prototype.save = (authToken) => {}
+  Contact.prototype.save = () => {}
 })
 
 lab.afterEach(() => {

--- a/test/routes/contactSearch.route.test.js
+++ b/test/routes/contactSearch.route.test.js
@@ -19,7 +19,7 @@ const routePath = '/contact-search'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   contactListStub = Contact.list
   Contact.list = (authToken) => {

--- a/test/routes/costTime.route.test.js
+++ b/test/routes/costTime.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/cost-time'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/drainageTypeDrain.route.test.js
+++ b/test/routes/drainageTypeDrain.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/drainage-type/drain'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/firePreventionPlan.route.test.js
+++ b/test/routes/firePreventionPlan.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/fire-prevention-plan'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/managementSystem.route.test.js
+++ b/test/routes/managementSystem.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/management-system'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/pageNotFound.route.test.js
+++ b/test/routes/pageNotFound.route.test.js
@@ -14,7 +14,7 @@ lab.beforeEach(() => {
   // Stub methods
 
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/permit/category'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/permitHolderType.route.test.js
+++ b/test/routes/permitHolderType.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/permit-holder/type'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -29,9 +29,9 @@ const fakeStandardRule = {
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
   standardRuleListStub = StandardRule.list
-  StandardRule.list = (authToken) => {
+  StandardRule.list = () => {
     return {
       count: 1,
       results: [fakeStandardRule]
@@ -42,7 +42,7 @@ lab.beforeEach(() => {
   StandardRule.getByCode = (authToken, code) => fakeStandardRule
 
   applicationLineSaveStub = ApplicationLine.save
-  ApplicationLine.prototype.save = (authToken) => {}
+  ApplicationLine.prototype.save = () => {}
 })
 
 lab.afterEach(() => {

--- a/test/routes/postcode.route.test.js
+++ b/test/routes/postcode.route.test.js
@@ -36,10 +36,10 @@ lab.beforeEach(() => {
 
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   siteNameAndLocationGetAddressStub = SiteNameAndLocation.getAddress
-  SiteNameAndLocation.getAddress = (request, authToken, applicationId, applicationLineId) => {
+  SiteNameAndLocation.getAddress = () => {
     return new Address({
       id: 'ADDRESS_ID',
       postcode: fakeAddress.postcode

--- a/test/routes/preApplication.route.test.js
+++ b/test/routes/preApplication.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/pre-application'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/siteGridReference.route.test.js
+++ b/test/routes/siteGridReference.route.test.js
@@ -52,22 +52,22 @@ lab.beforeEach(() => {
 
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   locationSaveStub = Location.prototype.save
-  Location.prototype.save = (authToken) => {}
+  Location.prototype.save = () => {}
 
   locationDetailSaveStub = LocationDetail.prototype.save
-  LocationDetail.prototype.save = (authToken) => {}
+  LocationDetail.prototype.save = () => {}
 
   locationGetByApplicationIdStub = Location.getByApplicationId
-  Location.getByApplicationId = (authToken, applicationId, applicationLineId) => fakeLocation
+  Location.getByApplicationId = () => fakeLocation
 
   getByLocationIdStub = LocationDetail.getByLocationId
-  LocationDetail.getByLocationId = (authToken, locationId) => fakeLocationDetail
+  LocationDetail.getByLocationId = () => fakeLocationDetail
 
   siteNameAndLocationUpdateCompletenessStub = SiteNameAndLocation.updateCompleteness
-  SiteNameAndLocation.updateCompleteness = (authToken, applicationId, applicationLineId) => {}
+  SiteNameAndLocation.updateCompleteness = () => {}
 })
 
 lab.afterEach(() => {
@@ -160,7 +160,7 @@ lab.experiment('Site Grid Reference page tests:', () => {
       }
 
       // Empty location details response
-      Location.getByApplicationId = (authToken, applicationId, applicationLineId) => {
+      Location.getByApplicationId = () => {
         return {}
       }
 

--- a/test/routes/sitePlan.route.test.js
+++ b/test/routes/sitePlan.route.test.js
@@ -15,7 +15,7 @@ const routePath = '/site-plan'
 lab.beforeEach(() => {
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 })
 
 lab.afterEach(() => {

--- a/test/routes/siteSiteName.route.test.js
+++ b/test/routes/siteSiteName.route.test.js
@@ -33,13 +33,13 @@ lab.beforeEach(() => {
 
   // Stub methods
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   getSiteNameStub = SiteNameAndLocation.getSiteName
-  SiteNameAndLocation.getSiteName = (request, authToken, applicationId, applicationLineId) => siteName
+  SiteNameAndLocation.getSiteName = () => siteName
 
   saveSiteNameStub = SiteNameAndLocation.saveSiteName
-  SiteNameAndLocation.saveSiteName = (request, siteName, authToken, applicationId, applicationLineId) => {}
+  SiteNameAndLocation.saveSiteName = () => {}
 })
 
 lab.afterEach(() => {

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -23,13 +23,13 @@ const fakeCookie = {
 lab.beforeEach(() => {
   // Stub methods
   generateCookieStub = CookieService.generateCookie
-  CookieService.generateCookie = (reply) => fakeCookie
+  CookieService.generateCookie = () => fakeCookie
 
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   applicationSaveStub = Application.prototype.save
-  Application.prototype.save = (authToken) => {}
+  Application.prototype.save = () => {}
 })
 
 lab.afterEach(() => {

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -180,16 +180,16 @@ const fakeTaskList = {
 lab.beforeEach(() => {
   // Stub methods
   generateCookieStub = CookieService.generateCookie
-  CookieService.generateCookie = (reply) => fakeCookie
+  CookieService.generateCookie = () => fakeCookie
 
   validateCookieStub = CookieService.validateCookie
-  CookieService.validateCookie = (request) => true
+  CookieService.validateCookie = () => true
 
   standardRuleGetByCodeStub = StandardRule.getByCode
-  StandardRule.getByCode = async (authToken, code) => fakeStandardRule
+  StandardRule.getByCode = async () => fakeStandardRule
 
   taskListGetByApplicationLineIdStub = TaskList.getByApplicationLineId
-  TaskList.getByApplicationLineId = (authToken, applicationLineId) => fakeTaskList
+  TaskList.getByApplicationLineId = () => fakeTaskList
 })
 
 lab.afterEach(() => {

--- a/test/routes/version.route.test.js
+++ b/test/routes/version.route.test.js
@@ -34,10 +34,10 @@ const fakeCookie = {
 lab.beforeEach(() => {
   // Stub methods
   generateCookieStub = CookieService.generateCookie
-  CookieService.generateCookie = (reply) => fakeCookie
+  CookieService.generateCookie = () => fakeCookie
 
   dynamicSolutionGetStub = DynamicsSolution.get
-  DynamicsSolution.get = (authToken) => dynamicsVersionInfo
+  DynamicsSolution.get = () => dynamicsVersionInfo
 })
 
 lab.afterEach(() => {


### PR DESCRIPTION
The purpose of this change is to remove unnecessary parameters from stubbed methods in order to aid readability, ensure consistency and avoid unnecessary typing during unit test development.