### PR TITLE
Convert Dynamics null values

### DIFF
--- a/src/models/account.model.js
+++ b/src/models/account.model.js
@@ -16,6 +16,7 @@ module.exports = class Account extends BaseModel {
       this.tradingName = account.tradingName
       this.IsValidatedWithCompaniesHouse = account.IsValidatedWithCompaniesHouse
     }
+    Utilities.convertFromDynamics(this)
   }
 
   static async getByApplicationId (authToken, applicationId) {
@@ -29,9 +30,9 @@ module.exports = class Account extends BaseModel {
         if (result) {
           account = new Account({
             id: application.accountId,
-            companyNumber: Utilities.replaceNull(result.defra_companyhouseid),
-            companyName: Utilities.replaceNull(result.name),
-            tradingName: Utilities.replaceNull(result.defra_tradingname)
+            companyNumber: result.defra_companyhouseid,
+            companyName: result.name,
+            tradingName: result.defra_tradingname
           })
         }
       } catch (error) {
@@ -51,7 +52,7 @@ module.exports = class Account extends BaseModel {
       const dataObject = {
         defra_companyhouseid: this.companyNumber.toUpperCase(),
         name: this.companyName,
-        defra_tradingname: Utilities.UndefinedToNull(this.tradingName),
+        defra_tradingname: this.tradingName,
         defra_draft: isDraft,
         defra_validatedwithcompanyhouse: this.IsValidatedWithCompaniesHouse
       }

--- a/src/models/address.model.js
+++ b/src/models/address.model.js
@@ -10,6 +10,7 @@ module.exports = class Address extends BaseModel {
     super()
     this.id = address.id
     this.postcode = address.postcode
+    Utilities.convertFromDynamics(this)
   }
 
   static async getById (authToken, id) {
@@ -21,8 +22,8 @@ module.exports = class Address extends BaseModel {
         const result = await dynamicsDal.search(query)
         if (result) {
           address = new Address({
-            id: Utilities.replaceNull(result.defra_addressid),
-            postcode: Utilities.replaceNull(result.defra_postcode)
+            id: result.defra_addressid,
+            postcode: result.defra_postcode
           })
         }
       } catch (error) {

--- a/src/models/application.model.js
+++ b/src/models/application.model.js
@@ -14,6 +14,7 @@ module.exports = class Application extends BaseModel {
       // The following delay is required by the untilComplete method
       this.delay = 250
     }
+    Utilities.convertFromDynamics(this)
   }
 
   static async getById (authToken, applicationId) {
@@ -22,7 +23,7 @@ module.exports = class Application extends BaseModel {
     try {
       const result = await dynamicsDal.search(query)
       const application = new Application({
-        accountId: Utilities.replaceNull(result._defra_customerid_value)
+        accountId: result._defra_customerid_value
       })
       application.id = applicationId
       return application

--- a/src/models/applicationLine.model.js
+++ b/src/models/applicationLine.model.js
@@ -4,6 +4,7 @@ const Constants = require('../constants')
 const LoggingService = require('../services/logging.service')
 const DynamicsDalService = require('../services/dynamicsDal.service')
 const BaseModel = require('./base.model')
+const Utilities = require('../utilities/utilities')
 
 module.exports = class ApplicationLine extends BaseModel {
   constructor (applicationLine) {
@@ -11,6 +12,7 @@ module.exports = class ApplicationLine extends BaseModel {
     this.applicationId = applicationLine.applicationId
     this.standardRuleId = applicationLine.standardRuleId
     this.parametersId = applicationLine.parametersId
+    Utilities.convertFromDynamics(this)
   }
 
   static async getById (authToken, applicationLineId) {

--- a/src/models/confirmRules.model.js
+++ b/src/models/confirmRules.model.js
@@ -5,6 +5,7 @@ const DynamicsDalService = require('../services/dynamicsDal.service')
 const BaseModel = require('./base.model')
 const LoggingService = require('../services/logging.service')
 const ApplicationLine = require('./applicationLine.model')
+const Utilities = require('../utilities/utilities')
 
 module.exports = class ConfirmRules extends BaseModel {
   constructor (confirmRules) {
@@ -14,6 +15,7 @@ module.exports = class ConfirmRules extends BaseModel {
     this.complete = confirmRules.complete
     // The following delay is required by the untilComplete method
     this.delay = 250
+    Utilities.convertFromDynamics(this)
   }
 
   static async getByApplicationId (authToken, applicationId, applicationLineId) {

--- a/src/models/location.model.js
+++ b/src/models/location.model.js
@@ -12,6 +12,7 @@ module.exports = class Location extends BaseModel {
     this.name = location.name
     this.applicationId = location.applicationId
     this.applicationLineId = location.applicationLineId
+    Utilities.convertFromDynamics(this)
   }
 
   static async getByApplicationId (authToken, applicationId, applicationLineId) {
@@ -25,10 +26,10 @@ module.exports = class Location extends BaseModel {
         const result = response.value[0]
         if (result) {
           location = new Location({
-            id: Utilities.replaceNull(result.defra_locationid),
+            id: result.defra_locationid,
             applicationId: applicationId,
             applicationLineId: applicationLineId,
-            name: Utilities.replaceNull(result.defra_name)
+            name: result.defra_name
           })
         }
       } catch (error) {

--- a/src/models/locationDetail.model.js
+++ b/src/models/locationDetail.model.js
@@ -12,6 +12,7 @@ module.exports = class LocationDetail extends BaseModel {
     this.gridReference = locationDetail.gridReference
     this.locationId = locationDetail.locationId
     this.addressId = locationDetail.addressId
+    Utilities.convertFromDynamics(this)
   }
 
   static async getByLocationId (authToken, locationId) {
@@ -26,10 +27,10 @@ module.exports = class LocationDetail extends BaseModel {
 
         if (result) {
           locationDetail = new LocationDetail({
-            id: Utilities.replaceNull(result.defra_locationdetailsid),
+            id: result.defra_locationdetailsid,
             locationId: locationId,
-            gridReference: Utilities.replaceNull(result.defra_gridreferenceid),
-            addressId: Utilities.replaceNull(result._defra_addressid_value)
+            gridReference: result.defra_gridreferenceid,
+            addressId: result._defra_addressid_value
           })
         }
       } catch (error) {

--- a/src/services/dynamicsDal.service.js
+++ b/src/services/dynamicsDal.service.js
@@ -5,6 +5,7 @@ const https = require('https')
 const HttpsProxyAgent = require('https-proxy-agent')
 const config = require('../config/config')
 const LoggingService = require('../services/logging.service')
+const Utilities = require('../utilities/utilities')
 
 module.exports = class DynamicsDalService {
   constructor (authToken) {
@@ -12,6 +13,7 @@ module.exports = class DynamicsDalService {
   }
 
   async create (query, dataObject) {
+    Utilities.convertToDynamics(dataObject)
     const options = this._requestOptions(this.authToken, query, 'POST', dataObject)
     LoggingService.logDebug('Dynamics POST options', options)
     const result = await this._call(options, dataObject)
@@ -20,6 +22,7 @@ module.exports = class DynamicsDalService {
   }
 
   async update (query, dataObject) {
+    Utilities.convertToDynamics(dataObject)
     const options = this._requestOptions(this.authToken, query, 'PATCH', dataObject)
     LoggingService.logDebug('Dynamics PATCH options', options)
     this._call(options, dataObject)

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -1,23 +1,39 @@
 'use strict'
 
 module.exports = class Utilities {
-  static replaceNull (value) {
+  // This method iterates though the data object properties and converts any null values to undefined
+  static convertFromDynamics (dataObject) {
+    for (let [key, value] of Object.entries(dataObject)) {
+      dataObject[key] = Utilities._replaceNull(value)
+    }
+    return dataObject
+  }
+
+  // This method iterates though the data object properties and converts any undefined values to null
+  static convertToDynamics (dataObject) {
+    for (let [key, value] of Object.entries(dataObject)) {
+      dataObject[key] = Utilities._replaceUndefined(value)
+    }
+    return dataObject
+  }
+
+  static stripWhitespace (value) {
+    if (value) {
+      value = value.replace(/\s/g, '')
+    }
+    return value
+  }
+
+  static _replaceNull (value) {
     if (value === null) {
       value = undefined
     }
     return value
   }
 
-  static UndefinedToNull (value) {
+  static _replaceUndefined (value) {
     if (value === undefined) {
       value = null
-    }
-    return value
-  }
-
-  static stripWhitespace (value) {
-    if (value) {
-      value = value.replace(/\s/g, '')
     }
     return value
   }

--- a/test/models/account.model.test.js
+++ b/test/models/account.model.test.js
@@ -19,7 +19,7 @@ const fakeAccountData = {
   id: undefined,
   companyNumber: 'COMPANY_NUMBER',
   companyName: undefined,
-  tradingName: undefined
+  tradingName: null
 }
 const fakeApplicationData = {
   id: 'APPLICATION_ID',
@@ -65,6 +65,10 @@ lab.experiment('Account Model tests:', () => {
     Code.expect(emptyAccount).to.be.empty()
 
     Code.expect(testAccount.companyNumber).to.equal(fakeAccountData.companyNumber)
+    Code.expect(testAccount.companyName).to.equal(fakeAccountData.companyName)
+
+    // Should have been converted from null to undefined
+    Code.expect(testAccount.tradingName).to.equal(undefined)
   })
 
   lab.test('getByApplicationId() method returns a single Account object', async () => {

--- a/test/utilities/utilities.test.js
+++ b/test/utilities/utilities.test.js
@@ -28,24 +28,87 @@ lab.experiment('Utilities tests:', () => {
     Code.expect(result).to.equal(expectedResult)
   })
 
-  lab.test('replaceNull() correctly returns the input string having replaced null with undefined', () => {
+  lab.test('convertFromDynamics() should correctly convert all object property values from null to undefined', () => {
+    let inputValue = {}
+    let expectedResult = {}
+    let result
+
+    result = Utilities.convertFromDynamics(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+
+    inputValue = {
+      someProp: null,
+      anotherProp: 'SOME VALUE'
+    }
+    expectedResult = {
+      someProp: undefined,
+      anotherProp: 'SOME VALUE'
+    }
+    result = Utilities.convertFromDynamics(inputValue)
+    Code.expect(result.someProp).to.equal(expectedResult.someProp)
+    Code.expect(result.anotherProp).to.equal(expectedResult.anotherProp)
+  })
+
+  lab.test('convertToDynamics() should correctly convert all object property values from undefined to null', () => {
+    let inputValue = {}
+    let expectedResult = {}
+    let result
+
+    result = Utilities.convertToDynamics(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+
+    inputValue = {
+      someProp: undefined,
+      anotherProp: 'SOME VALUE'
+    }
+    expectedResult = {
+      someProp: null,
+      anotherProp: 'SOME VALUE'
+    }
+    result = Utilities.convertToDynamics(inputValue)
+    Code.expect(result.someProp).to.equal(expectedResult.someProp)
+    Code.expect(result.anotherProp).to.equal(expectedResult.anotherProp)
+  })
+
+  lab.test('_replaceNull() correctly returns the input string having replaced null with undefined', () => {
     let inputValue, expectedResult, result
 
     inputValue = expectedResult = undefined
-    result = Utilities.replaceNull(inputValue)
+    result = Utilities._replaceNull(inputValue)
     Code.expect(result).to.equal(expectedResult)
 
     inputValue = expectedResult = ''
-    result = Utilities.replaceNull(inputValue)
+    result = Utilities._replaceNull(inputValue)
     Code.expect(result).to.equal(expectedResult)
 
     inputValue = expectedResult = '  THE INPUT STRING  '
-    result = Utilities.replaceNull(inputValue)
+    result = Utilities._replaceNull(inputValue)
     Code.expect(result).to.equal(expectedResult)
 
     inputValue = null
     expectedResult = undefined
-    result = Utilities.replaceNull(inputValue)
+    result = Utilities._replaceNull(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+  })
+
+  lab.test('_replaceUndefined() correctly returns the input string having replaced undefined with null', () => {
+    let inputValue, expectedResult, result
+
+    inputValue = expectedResult = null
+    result = Utilities._replaceUndefined(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+
+    inputValue = expectedResult = ''
+    result = Utilities._replaceUndefined(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+
+    inputValue = expectedResult = '  THE INPUT STRING  '
+    result = Utilities._replaceUndefined(inputValue)
+    Code.expect(result).to.equal(expectedResult)
+
+    inputValue = undefined
+    expectedResult = null
+    result = Utilities._replaceUndefined(inputValue)
     Code.expect(result).to.equal(expectedResult)
   })
 })


### PR DESCRIPTION
A better way to handle null and undefined values when data goes to / from Dynamics.

The object property values are now iterated and any properties that are found to be null when they should be undefined are modified (and vice versa).

The call to convertFromDynamics(...) has been placed in the model constructor, the call to convertToDynamics(...) has been placed in the Dynamics data access layer.