### PR TITLE
Site postcode screen - fixed the address lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ DYNAMIC_WEB_API_HOST="mycrminstance.api.crm4.dynamics.com"
 DYNAMICS_WEB_API_PATH="/api/data/v8.2/"
 
 # The service used to return addresses based on a postcode lookup
-ADDRESS_LOOKUP_SERVICE="http://ea-addressfacadeXXXX.XXXXXXX.net/address-service/v1"
+ADDRESS_LOOKUP_SERVICE="http://addressfacade.cloudapp.net/address-service/v1"
 ADDRESS_LOOKUP_SERVICE_KEY="CLIENT_KEY_HERE"
 
 # The service used to retrieve details of companies from Companies House

--- a/src/services/addressLookup.service.js
+++ b/src/services/addressLookup.service.js
@@ -7,11 +7,7 @@ const config = require('../config/config')
 module.exports = class AddressLookupService {
   static async getAddressesFromPostcode (postcode) {
     const options = {
-      uri: config.ADDRESS_LOOKUP_SERVICE + '/addresses/postcode',
-      qs: {
-        'query-string': postcode,
-        key: config.ADDRESS_LOOKUP_SERVICE_KEY
-      },
+      uri: `${config.ADDRESS_LOOKUP_SERVICE}/addresses/postcode?key=${config.ADDRESS_LOOKUP_SERVICE_KEY}&postcode=${postcode}`,
       json: true
     }
 


### PR DESCRIPTION
This is just a small change to fix the address lookup on the site postcode screen. We parked this previously but but the postcode screen fails when the page is submitted without this fix.

Also it will be useful to be able to retrieve addresses from the addressbase facade using the postcode screen.