### PR TITLE
Refactor of save method in models to prevent duplication

### DIFF
--- a/src/models/account.model.js
+++ b/src/models/account.model.js
@@ -9,6 +9,7 @@ const Utilities = require('../utilities/utilities')
 module.exports = class Account extends BaseModel {
   constructor (account) {
     super()
+    this.entity = 'accounts'
     if (account) {
       this.id = account.id
       this.companyNumber = account.companyNumber
@@ -44,31 +45,12 @@ module.exports = class Account extends BaseModel {
   }
 
   async save (authToken, isDraft) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-
-    // Update the Account
-    try {
-      // Map the Account to the corresponding Dynamics schema Account object
-      const dataObject = {
-        defra_companyhouseid: Utilities.stripWhitespace(this.companyNumber).toUpperCase(),
-        name: this.name,
-        defra_draft: isDraft,
-        defra_validatedwithcompanyhouse: this.isValidatedWithCompaniesHouse
-      }
-
-      let query
-      if (this.isNew()) {
-        // New Account
-        query = 'accounts'
-        this.id = await dynamicsDal.create(query, dataObject)
-      } else {
-        // Update Account
-        query = `accounts(${this.id})`
-        await dynamicsDal.update(query, dataObject)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save Account: ${error}`)
-      throw error
+    const dataObject = {
+      defra_companyhouseid: Utilities.stripWhitespace(this.companyNumber).toUpperCase(),
+      name: this.name,
+      defra_draft: isDraft,
+      defra_validatedwithcompanyhouse: this.isValidatedWithCompaniesHouse
     }
+    await super.save(authToken, dataObject)
   }
 }

--- a/src/models/address.model.js
+++ b/src/models/address.model.js
@@ -8,6 +8,7 @@ const Utilities = require('../utilities/utilities')
 module.exports = class Address extends BaseModel {
   constructor (address) {
     super()
+    this.entity = 'defra_addresses'
     this.id = address.id
     this.postcode = address.postcode
     Utilities.convertFromDynamics(this)
@@ -35,26 +36,10 @@ module.exports = class Address extends BaseModel {
   }
 
   async save (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    try {
-      // Map the Address to the corresponding Dynamics schema Address object
-      const dataObject = {
-        defra_postcode: this.postcode
-      }
-
-      let query
-      if (this.isNew()) {
-        // New Address
-        query = 'defra_addresses'
-        this.id = await dynamicsDal.create(query, dataObject)
-      } else {
-        // Update Address
-        query = `defra_addresses(${this.id})`
-        await dynamicsDal.update(query, dataObject)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save Address: ${error}`)
-      throw error
+    // Map the Address to the corresponding Dynamics schema Address object
+    const dataObject = {
+      defra_postcode: this.postcode
     }
+    await super.save(authToken, dataObject)
   }
 }

--- a/src/models/application.model.js
+++ b/src/models/application.model.js
@@ -80,6 +80,9 @@ module.exports = class Application extends BaseModel {
       dataObject['defra_customerid_account@odata.bind'] = `accounts(${this.accountId})`
     }
     await super.save(authToken, dataObject)
+
+    // The following "untilComplete" can be removed when the update is successful only when the update in dynamics has fully completed.
+    await this.untilComplete(authToken)
     if (isNew) {
       LoggingService.logInfo(`Created application with ID: ${this.id}`)
     }

--- a/src/models/applicationLine.model.js
+++ b/src/models/applicationLine.model.js
@@ -9,6 +9,7 @@ const Utilities = require('../utilities/utilities')
 module.exports = class ApplicationLine extends BaseModel {
   constructor (applicationLine) {
     super()
+    this.entity = 'defra_applicationlines'
     this.applicationId = applicationLine.applicationId
     this.standardRuleId = applicationLine.standardRuleId
     this.parametersId = applicationLine.parametersId
@@ -34,25 +35,11 @@ module.exports = class ApplicationLine extends BaseModel {
   }
 
   async save (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-
     const dataObject = {
       'defra_applicationId@odata.bind': `defra_applications(${this.applicationId})`,
       'defra_standardruleId@odata.bind': `defra_standardrules(${this.standardRuleId})`,
       defra_permittype: Constants.Dynamics.PermitTypes.STANDARD
     }
-
-    try {
-      let query
-      if (this.isNew()) {
-        // New application line
-        query = 'defra_applicationlines'
-        this.id = await dynamicsDal.create(query, dataObject)
-        LoggingService.logInfo(`Created Application Line with ID: ${this.id}`)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save Application Line: ${error}`)
-      throw error
-    }
+    await super.save(authToken, dataObject)
   }
 }

--- a/src/models/base.model.js
+++ b/src/models/base.model.js
@@ -37,11 +37,6 @@ module.exports = class BaseModel {
         // Update Entity
         query = `${this.entity}(${this.id})`
         await dynamicsDal.update(query, dataObject)
-
-        // The following "untilComplete" can be removed when the update is successful only when the update in dynamics has fully completed.
-        if (this.untilComplete) {
-          await this.untilComplete(authToken)
-        }
       }
     } catch (error) {
       LoggingService.logError(`Unable to save ${this.entity}: ${error}`)

--- a/src/models/contact.model.js
+++ b/src/models/contact.model.js
@@ -8,6 +8,7 @@ module.exports = class Contact extends BaseModel {
   constructor (dataObject = undefined) {
     super()
     if (dataObject) {
+      this.entity = 'contacts'
       this.id = dataObject.id
       this.firstName = dataObject.firstName
       this.lastName = dataObject.lastName
@@ -19,7 +20,7 @@ module.exports = class Contact extends BaseModel {
   static async getById (authToken, id) {
     const dynamicsDal = new DynamicsDalService(authToken)
     const query = `contacts(${id})?$select=contactid,firstname,lastname,telephone1,emailaddress1`
-    var contact
+    let contact
 
     try {
       const response = await dynamicsDal.search(query)
@@ -73,8 +74,6 @@ module.exports = class Contact extends BaseModel {
   }
 
   async save (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-
     // Map the Contact to the corresponding Dynamics schema Contact object
     const dataObject = {
       firstname: this.firstName,
@@ -82,21 +81,6 @@ module.exports = class Contact extends BaseModel {
       telephone1: this.telephone,
       emailaddress1: this.email
     }
-
-    try {
-      let query
-      if (this.isNew()) {
-        // New contact
-        query = 'contacts'
-        this.id = await dynamicsDal.create(query, dataObject)
-      } else {
-        // Update contact
-        query = `contacts(${this.id})`
-        await dynamicsDal.update(query, dataObject)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save Contact: ${error}`)
-      throw error
-    }
+    await super.save(authToken, dataObject)
   }
 }

--- a/src/models/location.model.js
+++ b/src/models/location.model.js
@@ -8,6 +8,7 @@ const Utilities = require('../utilities/utilities')
 module.exports = class Location extends BaseModel {
   constructor (location) {
     super()
+    this.entity = 'defra_locations'
     this.id = location.id
     this.name = location.name
     this.applicationId = location.applicationId
@@ -41,28 +42,11 @@ module.exports = class Location extends BaseModel {
   }
 
   async save (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-
-    // Update the Location
-    try {
-      // Map the Location to the corresponding Dynamics schema Location object
-      const dataObject = {
-        defra_name: this.name,
-        'defra_applicationId@odata.bind': `defra_applications(${this.applicationId})`
-      }
-      let query
-      if (this.isNew()) {
-        // New Location
-        query = 'defra_locations'
-        this.id = await dynamicsDal.create(query, dataObject)
-      } else {
-        // Update Location
-        query = `defra_locations(${this.id})`
-        await dynamicsDal.update(query, dataObject)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save Location: ${error}`)
-      throw error
+    // Map the Location to the corresponding Dynamics schema Location object
+    const dataObject = {
+      defra_name: this.name,
+      'defra_applicationId@odata.bind': `defra_applications(${this.applicationId})`
     }
+    await super.save(authToken, dataObject)
   }
 }

--- a/src/models/locationDetail.model.js
+++ b/src/models/locationDetail.model.js
@@ -8,6 +8,7 @@ const Utilities = require('../utilities/utilities')
 module.exports = class LocationDetail extends BaseModel {
   constructor (locationDetail) {
     super()
+    this.entity = 'defra_locationdetailses'
     this.id = locationDetail.id
     this.gridReference = locationDetail.gridReference
     this.locationId = locationDetail.locationId
@@ -46,32 +47,14 @@ module.exports = class LocationDetail extends BaseModel {
   }
 
   async save (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-
-    // Update the LocationDetail
-    try {
-      // Map the Location to the corresponding Dynamics schema LocationDetail object
-      const dataObject = {
-        defra_gridreferenceid: this.gridReference,
-        'defra_locationId@odata.bind': `defra_locations(${this.locationId})`
-      }
-      if (this.addressId) {
-        dataObject['defra_addressId@odata.bind'] = `defra_addresses(${this.addressId})`
-      }
-
-      let query
-      if (this.isNew()) {
-        // New LocationDetail
-        query = 'defra_locationdetailses'
-        this.id = await dynamicsDal.create(query, dataObject)
-      } else {
-        // Update LocationDetail
-        query = `defra_locationdetailses(${this.id})`
-        await dynamicsDal.update(query, dataObject)
-      }
-    } catch (error) {
-      LoggingService.logError(`Unable to save LocationDetail: ${error}`)
-      throw error
+    // Map the Location to the corresponding Dynamics schema LocationDetail object
+    const dataObject = {
+      defra_gridreferenceid: this.gridReference,
+      'defra_locationId@odata.bind': `defra_locations(${this.locationId})`
     }
+    if (this.addressId) {
+      dataObject['defra_addressId@odata.bind'] = `defra_addresses(${this.addressId})`
+    }
+    await super.save(authToken, dataObject)
   }
 }

--- a/test/models/account.model.test.js
+++ b/test/models/account.model.test.js
@@ -62,7 +62,7 @@ lab.afterEach(() => {
 lab.experiment('Account Model tests:', () => {
   lab.test('Constructor creates a Account object correctly', () => {
     const emptyAccount = new Account()
-    Code.expect(emptyAccount).to.be.empty()
+    Code.expect(emptyAccount.id).to.be.equal(undefined)
 
     Code.expect(testAccount.companyNumber).to.equal(fakeAccountData.companyNumber)
     Code.expect(testAccount.name).to.equal(fakeAccountData.name)


### PR DESCRIPTION
Refactor of save method in models to allow most of the common work to be done in the base model thus preventing code climate from triggering duplicate code alerts.