### PR TITLE
The Dynamics Dal Service was not waiting for an asynchronous update

### DIFF
--- a/src/models/application.model.js
+++ b/src/models/application.model.js
@@ -16,9 +16,6 @@ module.exports = class Application extends BaseModel {
       this.relevantOffencesDetails = application.relevantOffencesDetails
       this.bankruptcy = application.bankruptcy
       this.bankruptcyDetails = application.bankruptcyDetails
-
-      // The following delay is required by the untilComplete method
-      this.delay = 250
     }
     Utilities.convertFromDynamics(this)
   }
@@ -52,18 +49,6 @@ module.exports = class Application extends BaseModel {
     }
   }
 
-  // A bug currently exists where the account id isn't updated straight away in dynamics even when the save is successful.
-  // This function is a temporary fix to wait until we are sure we can get the account id.
-  // This and the code overriding the delay property in the test, can be removed when the update is successful only when the update in dynamics has fully completed.
-  async untilComplete (authToken) {
-    for (let retries = 10; retries && !(await Application.getById(authToken, this.id)).accountId; retries--) {
-      if (!retries) {
-        throw new Error('Failed to complete')
-      }
-      await new Promise(resolve => setTimeout(resolve, this.delay))
-    }
-  }
-
   async save (authToken) {
     const dynamicsDal = new DynamicsDalService(authToken)
 
@@ -91,9 +76,6 @@ module.exports = class Application extends BaseModel {
           dataObject['defra_customerid_account@odata.bind'] = `accounts(${this.accountId})`
         }
         await dynamicsDal.update(query, dataObject)
-
-        // The following "untilComplete" can be removed when the update is successful only when the update in dynamics has fully completed.
-        await this.untilComplete(authToken)
       }
     } catch (error) {
       LoggingService.logError(`Unable to save Application: ${error}`)

--- a/src/models/confirmRules.model.js
+++ b/src/models/confirmRules.model.js
@@ -13,8 +13,6 @@ module.exports = class ConfirmRules extends BaseModel {
     this.applicationId = confirmRules.applicationId
     this.applicationLineId = confirmRules.applicationLineId
     this.complete = confirmRules.complete
-    // The following delay is required by the untilComplete method
-    this.delay = 250
     Utilities.convertFromDynamics(this)
   }
 
@@ -39,18 +37,6 @@ module.exports = class ConfirmRules extends BaseModel {
     }
   }
 
-  // A bug currently exists where the completeness isn't updated straight away in dynamics even when the save is successful.
-  // This function is a temporary fix to wait until we are sure we can get the completeness value.
-  // This and the code overriding the delay property in the test, can be removed when the update is successful only when the update in dynamics has fully completed.
-  async untilComplete (authToken) {
-    for (let retries = 10; retries && !(await ConfirmRules.getByApplicationId(authToken, this.applicationId, this.applicationLineId)).complete; retries--) {
-      if (!retries) {
-        throw new Error('Failed to complete')
-      }
-      await new Promise(resolve => setTimeout(resolve, this.delay))
-    }
-  }
-
   async save (authToken) {
     const dynamicsDal = new DynamicsDalService(authToken)
 
@@ -63,8 +49,6 @@ module.exports = class ConfirmRules extends BaseModel {
 
         const query = `defra_wasteparamses(${applicationLine.parametersId})`
         await dynamicsDal.update(query, entity)
-        // The following "untilComplete" can be removed when the update is successful only when the update in dynamics has fully completed.
-        await this.untilComplete(authToken)
       }
     } catch (error) {
       LoggingService.logError(`Unable to update Confirm Rules completeness: ${error}`)

--- a/src/services/dynamicsDal.service.js
+++ b/src/services/dynamicsDal.service.js
@@ -25,7 +25,7 @@ module.exports = class DynamicsDalService {
     Utilities.convertToDynamics(dataObject)
     const options = this._requestOptions(this.authToken, query, 'PATCH', dataObject)
     LoggingService.logDebug('Dynamics PATCH options', options)
-    this._call(options, dataObject)
+    await this._call(options, dataObject)
   }
 
   async search (query) {


### PR DESCRIPTION
The Dynamics DAL Service was not waiting for an asynchronous update to complete.

https://eaflood.atlassian.net/browse/WE-801

This was not an issue in dynamics, but instead an issue in the front-end dynamics data access layer service (dynamicsDAL.service).
The update method was not waiting for the asynchronous call to complete when applying a patch to dynamics.