### PR TITLE
Downgrade of JQuery version for IE8

### DIFF
--- a/src/views/partials/common/head.html
+++ b/src/views/partials/common/head.html
@@ -1,5 +1,15 @@
-<!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css?##APP_VERSION##" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css?##APP_VERSION##" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if lte IE 8]>
+  <link href="/public/stylesheets/application-ie8.css?##APP_VERSION##" rel="stylesheet" type="text/css" />
+<![endif]-->
+<!--[if gt IE 8]><!-->
+  <link href="/public/stylesheets/application.css?##APP_VERSION##" media="screen" rel="stylesheet" type="text/css" />
+<!-- <![endif]-->
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<!--[if lte IE 8]>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js">
+<![endif]-->
+<!--[if gt IE 8]><!-->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<!-- <![endif]-->
+
 <script src="/public/javascripts/application.min.js?##APP_VERSION##"></script>


### PR DESCRIPTION
There was a problem with the show/hide functionality on the 'Is this the right company?' page when using IE8.

The problem was caused by IE8 not being able to handle the latest version of JQuery that we were using.

This change downgrades the JQuery version to 1.11.3 (the same as the prototype) for IE8 users.