### PR TITLE
Correct confidentiality link and remove redundant template

### DIFF
--- a/src/views/confidentiality.html
+++ b/src/views/confidentiality.html
@@ -1,9 +1,0 @@
-<main id="content" role="main">
-
-  {{> common/betaBanner }}
-
-  {{> common/backLink }}
-
-  <h1 id="page-heading" class="heading-large">{{ pageHeading }}</h1>
-
-</main>

--- a/src/views/partials/confidentialityDescription.html
+++ b/src/views/partials/confidentialityDescription.html
@@ -4,7 +4,7 @@
 
   <div id="confidentiality-hint" class="form-group">
     <p>Guidance about confidentiality is in the
-      <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/government/publications/environmental-permitting-guidance-core-guidance-2">
+      <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/government/publications/environmental-permitting-guidance-core-guidance--2">
         <span>environmental permitting guidance core guidance on GOV.UK (opens new tab).</span>
       </a>
     </p>


### PR DESCRIPTION
- Amended link to include extra hyphen as discovered in QA review.
- Removed redundant confidentiality template 