### PR TITLE
Fix the select permit layout

### DIFF
--- a/src/assets/sass/patterns/_permit-select.scss
+++ b/src/assets/sass/patterns/_permit-select.scss
@@ -1,5 +1,6 @@
 // Choose permit radio button list
 .permit-selector {
+  min-height: 2em;
   float: none;
   padding: 8px 10px 9px 50px;
 }


### PR DESCRIPTION
Fix the select permit layout to prevent the radio buttons being too close together when there is only one line of text in the label.