### PR TITLE
Mobile permit selection bug fix

### DIFF
--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -16,9 +16,9 @@
           <legend class="visuallyhidden">{{ pageHeading }}</legend>
 
           <div class="panel panel-border-wide">
-            <p>Showing permits for mobile plant.
+            <p id="select-permit-hint-text">Showing permits for <span id="permit-type-description">mobile plant</span>.
               <!-- Not in use for MVP -->
-              <!-- <a href="/{{ permitCategoryRoute }}">
+              <!-- <a id="back-to-all-permit-groups-link" href="/{{ permitCategoryRoute }}">
                 Back to all permit groups
               </a> -->
             </p>

--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -15,14 +15,14 @@
         <fieldset aria-labelledby="permit-select-heading">
           <legend class="visuallyhidden">{{ pageHeading }}</legend>
 
-          <!-- Not in use for MVP -->
-          <!-- <div class="panel panel-border-wide">
-            <p>Showing permits for car and vehicle dismantling.<br>
-              <a href="/{{ permitCategoryRoute }}">
+          <div class="panel panel-border-wide">
+            <p>Showing permits for mobile plant.
+              <!-- Not in use for MVP -->
+              <!-- <a href="/{{ permitCategoryRoute }}">
                 Back to all permit groups
-              </a>
+              </a> -->
             </p>
-          </div> -->
+          </div>
 
           <div id="chosen-permit" class="form-group {{#getFormErrorGroupClass errors.started-application}}{{/getFormErrorGroupClass}}">
             {{> common/fieldError fieldId='chosen-permit-error' message=errors.chosen-permit }}

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -85,6 +85,16 @@ lab.experiment('Select a permit page tests:', () => {
     let element = doc.getElementById('page-heading').firstChild
     Code.expect(element.nodeValue).to.equal('Select a permit')
 
+    element = doc.getElementById('select-permit-hint-text')
+    Code.expect(element).to.exist()
+
+    element = doc.getElementById('permit-type-description')
+    Code.expect(element).to.exist()
+
+    // Not visible for MVP
+    element = doc.getElementById('back-to-all-permit-groups-link')
+    Code.expect(element).to.not.exist()
+
     element = doc.getElementById('chosen-permit-sr2015-no-18-name').firstChild
     Code.expect(element.nodeValue).to.include('Metal recycling, vehicle storage, depollution and dismantling facility')
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-842

This fixes a missing piece of copy that was incorrectly commented out and changes the hard coded hint text to match the 'mobile plant' permit types that are now in the list. 