### PR TITLE
Return a 404 http status code on the 'page not found' screen

### DIFF
--- a/src/controllers/pageNotFound.controller.js
+++ b/src/controllers/pageNotFound.controller.js
@@ -11,7 +11,7 @@ module.exports = class PageNotFoundController extends BaseController {
     pageContext.taskList = Constants.Routes.TASK_LIST
     pageContext.startOpenOrSaved = Constants.Routes.START_OR_OPEN_SAVED
 
-    return reply.view('pageNotFound', pageContext)
+    return reply.view('pageNotFound', pageContext).code(404)
   }
 
   handler (request, reply, source, errors) {


### PR DESCRIPTION
The purpose of this change is to ensure that a 404 http error is returned to the client when they try and view a page that is not available.

We handle 404 errors and display a user-friendly page but we also want to return the correct 404 error code to the browser.