### PR TITLE
Prevent 403 error in technical qualification upload

### DIFF
--- a/src/assets/sass/patterns/_upload-evidence.scss
+++ b/src/assets/sass/patterns/_upload-evidence.scss
@@ -2,7 +2,14 @@
 #uploadForm {
   input[type="file"] {
     max-width: 100%;
-  };
+    &::-webkit-file-upload-button {
+      font-size: 2rem;
+      padding: 0.5rem 1rem;
+      margin-right: 50px;
+      background:#f5f6ff;
+      color: #000;
+    }
+  }
 }
 
 .form-uploader{

--- a/src/assets/sass/patterns/_upload-evidence.scss
+++ b/src/assets/sass/patterns/_upload-evidence.scss
@@ -10,6 +10,10 @@
       color: #000;
     }
   }
+  input[type=file]:hover,
+  input[type=file]::-webkit-file-upload-button:hover {
+    cursor: pointer;
+  }
 }
 
 .form-uploader{

--- a/src/controllers/technicalQualification.controller.js
+++ b/src/controllers/technicalQualification.controller.js
@@ -19,14 +19,16 @@ module.exports = class TechnicalQualificationController extends BaseController {
       const application = await Application.getById(authToken, applicationId)
       if (application) {
         pageContext.formValues = {
-          'technical-qualification': application.technicalQualification,
-          'wamitab': WAMITAB_QUALIFICATION,
-          'getting-qualification': REGISTERED_ON_A_COURSE,
-          'deemed': DEEMED_COMPETENCE,
-          'esa-eu': ESA_EU_SKILLS
+          'technical-qualification': application.technicalQualification
         }
       }
     }
+    Object.assign(pageContext.formValues, {
+      'wamitab': WAMITAB_QUALIFICATION,
+      'getting-qualification': REGISTERED_ON_A_COURSE,
+      'deemed': DEEMED_COMPETENCE,
+      'esa-eu': ESA_EU_SKILLS
+    })
     switch (pageContext.formValues['technical-qualification']) {
       case WAMITAB_QUALIFICATION:
         pageContext.wamitabChecked = true

--- a/src/controllers/uploads/baseUploadEvidence.controller.js
+++ b/src/controllers/uploads/baseUploadEvidence.controller.js
@@ -19,14 +19,12 @@ module.exports = class BaseUploadEvidenceController extends BaseController {
 
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors, this.validator)
-    pageContext.uploadFormAction = `${this.path}/upload`
     const authToken = CookieService.getAuthToken(request)
     const applicationId = CookieService.getApplicationId(request)
     const list = await Annotation.listByApplicationId(authToken, applicationId)
+
+    pageContext.uploadFormAction = `${this.path}/upload`
     pageContext.annotations = list.map(({filename, id}) => ({filename, removeAction: `${this.path}/remove/${id}`}))
-
-    pageContext.canContinue = pageContext.annotations && pageContext.annotations.length
-
     pageContext.fileTypes = this.validator.formatValidTypes()
     pageContext.maxSize = this.validator.getMaxSize()
     Object.assign(pageContext, this.getSpecificPageContext())
@@ -41,6 +39,10 @@ module.exports = class BaseUploadEvidenceController extends BaseController {
       const authToken = CookieService.getAuthToken(request)
       const applicationId = CookieService.getApplicationId(request)
       const applicationLineId = CookieService.getApplicationLineId(request)
+      const list = await Annotation.listByApplicationId(authToken, applicationId)
+      if (!list.length) {
+        return this.handler(request, reply, undefined, BaseUploadEvidenceController._customError('noFilesUploaded'))
+      }
       if (this.updateCompleteness) {
         await this.updateCompleteness(authToken, applicationId, applicationLineId)
       }
@@ -63,15 +65,7 @@ module.exports = class BaseUploadEvidenceController extends BaseController {
 
       // Make sure no duplicate files are uploaded
       if (this._haveDuplicateFiles(fileData, annotationsList)) {
-        const errors = {
-          data: {
-            details: [{
-              path: ['file'],
-              type: 'duplicateFile'
-            }]
-          }
-        }
-        return this.handler(request, reply, undefined, errors)
+        return this.handler(request, reply, undefined, BaseUploadEvidenceController._customError('duplicateFile'))
       }
 
       // Save each file as an attachment to an annotation
@@ -109,14 +103,7 @@ module.exports = class BaseUploadEvidenceController extends BaseController {
 
   async uploadFailAction (request, reply, errors) {
     if (errors && errors.output && errors.output.statusCode === Constants.Errors.REQUEST_ENTITY_TOO_LARGE) {
-      errors = {
-        data: {
-          details: [{
-            path: ['file'],
-            type: 'fileTooBig'
-          }]
-        }
-      }
+      errors = BaseUploadEvidenceController._customError('fileTooBig')
     }
     return this.handler(request, reply, undefined, errors)
   }
@@ -129,6 +116,17 @@ module.exports = class BaseUploadEvidenceController extends BaseController {
   _haveDuplicateFiles (listA, listB) {
     const haveDuplicateFiles = listA.filter(({filename}) => this._containsFilename(filename, listB))
     return !!haveDuplicateFiles.length
+  }
+
+  static _customError (type) {
+    return {
+      data: {
+        details: [{
+          type,
+          path: ['file']
+        }]
+      }
+    }
   }
 
   _getFileData (file) {

--- a/src/routes/uploads/baseUploadRoute.js
+++ b/src/routes/uploads/baseUploadRoute.js
@@ -2,6 +2,14 @@ const BaseRoute = require('../baseRoute')
 const Constants = require('../../constants')
 
 class UploadRoute extends BaseRoute {
+  static POST (controller) {
+    const route = super.POST(controller)
+    route.config.plugins = {
+      crumb: false // Disabled to prevent 403 when testing for missing file upload
+    }
+    return route
+  }
+
   static REMOVE (controller) {
     return {
       method: 'GET',

--- a/src/validators/uploadEntity.validator.js
+++ b/src/validators/uploadEntity.validator.js
@@ -18,6 +18,7 @@ module.exports = class UploadEntityValidator extends BaseValidator {
       'file': {
         'fileTooBig': `That file’s too big. Upload a file that’s no more than ${this.getMaxSize()}.`,
         'duplicateFile': `That file has the same name as one you’ve already uploaded. Choose another file or rename the file before uploading it again.`,
+        'noFilesUploaded': `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`,
         'array.base': ' ',
         'object.base': ' '
       },

--- a/src/views/uploadEvidence.html
+++ b/src/views/uploadEvidence.html
@@ -75,13 +75,7 @@
 
       <form method="POST" action="{{formAction}}">
         {{> common/csrfToken token=DefraCsrfToken}}
-        <div class="form-group">
-          {{#if canContinue}}
-          {{> common/submitButton }}
-          {{else}}
-          <button id="submit-button" type="submit" class="button" name="Continue" aria-disabled="true" disabled="disabled">Continue</button>
-          {{/if}}
-        </div>
+        {{> common/submitButton }}
       </form>
 
     </div>

--- a/test/routes/pageNotFound.route.test.js
+++ b/test/routes/pageNotFound.route.test.js
@@ -32,7 +32,7 @@ lab.experiment('Page Not Found (404) page tests:', () => {
     }
 
     const res = await server.inject(request)
-    Code.expect(res.statusCode).to.equal(200)
+    Code.expect(res.statusCode).to.equal(404)
 
     const parser = new DOMParser()
     const doc = parser.parseFromString(res.payload, 'text/html')
@@ -49,7 +49,7 @@ lab.experiment('Page Not Found (404) page tests:', () => {
     }
 
     const res = await server.inject(request)
-    Code.expect(res.statusCode).to.equal(200)
+    Code.expect(res.statusCode).to.equal(404)
 
     const parser = new DOMParser()
     const doc = parser.parseFromString(res.payload, 'text/html')

--- a/test/routes/upload/uploadCourseRegistration.route.test.js
+++ b/test/routes/upload/uploadCourseRegistration.route.test.js
@@ -89,7 +89,6 @@ lab.experiment('Company Declare Upload Course registration tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.not.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.exist()
         Code.expect(doc.getElementById('course-registration-description')).to.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('disabled')
       })
 
       lab.test('when there are annotations', async () => {
@@ -98,7 +97,6 @@ lab.experiment('Company Declare Upload Course registration tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.not.exist()
         Code.expect(doc.getElementById('course-registration-description')).to.not.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('')
       })
     })
 
@@ -280,8 +278,26 @@ lab.experiment('Company Declare Upload Course registration tests:', () => {
       TechnicalQualification.updateCompleteness = updateCompletenessStub
     })
 
+    lab.experiment('invalid', () => {
+      lab.test(`when continue button pressed and there are no files uploaded`, async () => {
+        const expectedErrorMessage = `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`
+        const res = await server.inject(postRequest)
+        Code.expect(res.statusCode).to.equal(200)
+
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(res.payload, 'text/html')
+
+        // Panel summary error item
+        Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
+
+        // Company number field error
+        Code.expect(doc.getElementById('file-error').firstChild.nodeValue).to.equal(expectedErrorMessage)
+      })
+    })
+
     lab.experiment('success', () => {
-      lab.test(`when posted`, async () => {
+      lab.test(`when continue button pressed and there are files uploaded`, async () => {
+        Annotation.listByApplicationId = () => Promise.resolve([new Annotation(fakeAnnotation)])
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)
         Code.expect(res.headers['location']).to.equal(nextRoutePath)

--- a/test/routes/upload/uploadDeemedEvidence.route.test.js
+++ b/test/routes/upload/uploadDeemedEvidence.route.test.js
@@ -89,7 +89,6 @@ lab.experiment('Company Declare Upload Deemed evidence tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.not.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.exist()
         Code.expect(doc.getElementById('deemed-evidence-description')).to.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('disabled')
       })
 
       lab.test('when there are annotations', async () => {
@@ -98,7 +97,6 @@ lab.experiment('Company Declare Upload Deemed evidence tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.not.exist()
         Code.expect(doc.getElementById('deemed-evidence-description')).to.not.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('')
       })
     })
 
@@ -280,8 +278,26 @@ lab.experiment('Company Declare Upload Deemed evidence tests:', () => {
       TechnicalQualification.updateCompleteness = updateCompletenessStub
     })
 
+    lab.experiment('invalid', () => {
+      lab.test(`when continue button pressed and there are no files uploaded`, async () => {
+        const expectedErrorMessage = `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`
+        const res = await server.inject(postRequest)
+        Code.expect(res.statusCode).to.equal(200)
+
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(res.payload, 'text/html')
+
+        // Panel summary error item
+        Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
+
+        // Company number field error
+        Code.expect(doc.getElementById('file-error').firstChild.nodeValue).to.equal(expectedErrorMessage)
+      })
+    })
+
     lab.experiment('success', () => {
-      lab.test(`when posted`, async () => {
+      lab.test(`when continue button pressed and there are files uploaded`, async () => {
+        Annotation.listByApplicationId = () => Promise.resolve([new Annotation(fakeAnnotation)])
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)
         Code.expect(res.headers['location']).to.equal(nextRoutePath)

--- a/test/routes/upload/uploadEsaEuSkills.route.test.js
+++ b/test/routes/upload/uploadEsaEuSkills.route.test.js
@@ -89,7 +89,6 @@ lab.experiment('Company Declare Upload ESA EU skills tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.not.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.exist()
         Code.expect(doc.getElementById('esa-eu-skills-description')).to.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('disabled')
       })
 
       lab.test('when there are annotations', async () => {
@@ -98,7 +97,6 @@ lab.experiment('Company Declare Upload ESA EU skills tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.not.exist()
         Code.expect(doc.getElementById('esa-eu-skills-description')).to.not.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('')
       })
     })
 
@@ -280,8 +278,26 @@ lab.experiment('Company Declare Upload ESA EU skills tests:', () => {
       TechnicalQualification.updateCompleteness = updateCompletenessStub
     })
 
+    lab.experiment('invalid', () => {
+      lab.test(`when continue button pressed and there are no files uploaded`, async () => {
+        const expectedErrorMessage = `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`
+        const res = await server.inject(postRequest)
+        Code.expect(res.statusCode).to.equal(200)
+
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(res.payload, 'text/html')
+
+        // Panel summary error item
+        Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
+
+        // Company number field error
+        Code.expect(doc.getElementById('file-error').firstChild.nodeValue).to.equal(expectedErrorMessage)
+      })
+    })
+
     lab.experiment('success', () => {
-      lab.test(`when posted`, async () => {
+      lab.test(`when continue button pressed and there are files uploaded`, async () => {
+        Annotation.listByApplicationId = () => Promise.resolve([new Annotation(fakeAnnotation)])
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)
         Code.expect(res.headers['location']).to.equal(nextRoutePath)

--- a/test/routes/upload/uploadWamitabQualification.route.test.js
+++ b/test/routes/upload/uploadWamitabQualification.route.test.js
@@ -89,7 +89,6 @@ lab.experiment('Company Declare Upload Wamitab tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.not.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.exist()
         Code.expect(doc.getElementById('wamitab-qualification-description')).to.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('disabled')
       })
 
       lab.test('when there are annotations', async () => {
@@ -98,7 +97,6 @@ lab.experiment('Company Declare Upload Wamitab tests:', () => {
         Code.expect(doc.getElementById('has-annotations')).to.exist()
         Code.expect(doc.getElementById('has-no-annotations')).to.not.exist()
         Code.expect(doc.getElementById('wamitab-qualification-description')).to.not.exist()
-        Code.expect(doc.getElementById('submit-button').getAttribute('disabled')).to.equal('')
       })
     })
 
@@ -280,8 +278,26 @@ lab.experiment('Company Declare Upload Wamitab tests:', () => {
       TechnicalQualification.updateCompleteness = updateCompletenessStub
     })
 
+    lab.experiment('invalid', () => {
+      lab.test(`when continue button pressed and there are no files uploaded`, async () => {
+        const expectedErrorMessage = `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`
+        const res = await server.inject(postRequest)
+        Code.expect(res.statusCode).to.equal(200)
+
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(res.payload, 'text/html')
+
+        // Panel summary error item
+        Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
+
+        // Company number field error
+        Code.expect(doc.getElementById('file-error').firstChild.nodeValue).to.equal(expectedErrorMessage)
+      })
+    })
+
     lab.experiment('success', () => {
-      lab.test(`when posted`, async () => {
+      lab.test(`when continue button pressed and there are files uploaded`, async () => {
+        Annotation.listByApplicationId = () => Promise.resolve([new Annotation(fakeAnnotation)])
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)
         Code.expect(res.headers['location']).to.equal(nextRoutePath)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-832

- Prevent 403 error in technical qualification upload
- Style Choose file button
- Show error when continuing without uploads in upload page
- Fix technical qualification
- Page not found test should check for a 404 error code
  
  