### PR TITLE
Correct CSS for mobile display and adjust spacing to match prototype

### DIFF
--- a/src/assets/sass/patterns/_permit-select.scss
+++ b/src/assets/sass/patterns/_permit-select.scss
@@ -1,14 +1,12 @@
 // Choose permit radio button list
 .permit-selector {
-  min-height: 2em;
   float: none;
-  padding: 8px 10px 9px 50px;
+  padding: 0px 10px 0px 40px;
 }
 
-.permit-item {
+label.permit-item {
   display: inline-block;
   width: 100%;
-  margin-top: -5px;
 
   .permit-name {
     float: left;


### PR DESCRIPTION
Update SASS only:
* make permit-item more specific so it overrides in correct order
* adjust padding on permit-selector