### PR TITLE
Removed HTML 5 form validation from all forms

### DIFF
--- a/src/views/companyNumber.html
+++ b/src/views/companyNumber.html
@@ -9,7 +9,7 @@
 
       {{> common/errorSummary }}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <h1 class="heading-large"><label id="page-heading" for="company-number">{{ pageHeading }}</label></h1>

--- a/src/views/confirmRules.html
+++ b/src/views/confirmRules.html
@@ -27,7 +27,7 @@
         <p id="confirm-rules-paragraph-1">If your operation doesn't meet these rules, you may need a different standard rules permit or a bespoke permit instead.</p>
       {{/unless}}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
         <div class="form-group">
           {{#if complete}}

--- a/src/views/contactSearch.html
+++ b/src/views/contactSearch.html
@@ -11,7 +11,7 @@
         A temporary page for visualising querying functionality.
       </p>
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <div class="form-group">

--- a/src/views/directorDateOfBirth.html
+++ b/src/views/directorDateOfBirth.html
@@ -11,7 +11,7 @@
 
       {{> common/pageHeading pageHeading }}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <p id="dob-explanation">

--- a/src/views/permitCategory.html
+++ b/src/views/permitCategory.html
@@ -9,7 +9,7 @@
 
       {{> common/pageHeading pageHeading }}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         {{> common/submitButton }}

--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -9,7 +9,7 @@
 
       {{> common/pageHeading pageHeading }}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <fieldset aria-labelledby="permit-select-heading">

--- a/src/views/siteGridReference.html
+++ b/src/views/siteGridReference.html
@@ -11,7 +11,7 @@
 
       {{> common/pageHeading pageHeading }}
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <div class="form-group {{#getFormErrorGroupClass errors.site-grid-reference}}{{/getFormErrorGroupClass}}">

--- a/src/views/siteSiteName.html
+++ b/src/views/siteSiteName.html
@@ -13,7 +13,7 @@
 
       <p id="site-site-name-subheading">The site is the area you want the permit to cover.</p>
 
-      <form method="POST" action="{{ formAction }}">
+      <form method="post" action="{{ formAction }}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
         <div class="form-group {{#getFormErrorGroupClass errors.site-name}}{{/getFormErrorGroupClass}}">


### PR DESCRIPTION
The purpose of this change is to remove the HTML5 client side form validation on all our forms in order to ensure that all validation is carried out in the GDS required way.