### PR TITLE
Remove red border around file upload control

### DIFF
--- a/src/views/uploadEvidence.html
+++ b/src/views/uploadEvidence.html
@@ -63,7 +63,7 @@
         <div id="uploader" class="form-group form-uploader">
           <div class="form-group {{#getFormErrorGroupClass errors.file}}{{/getFormErrorGroupClass}} {{#getFormErrorGroupClass errors.content-type}}{{/getFormErrorGroupClass}}">
             {{> common/fieldError fieldId='file-error' message=errors.file }}
-            <input id="file" class="{{#if errors.file}}form-control-error{{/if}}" name="file" type="file">
+            <input id="file" name="file" type="file">
             <input id="filename" name="technicalCertificateFile" type="hidden">
             <input name="technicalCertificateFileUploaded" value="{{technicalCertificateFileUploaded}}" type="hidden">
           </div>

--- a/test/routes/upload/uploadCourseRegistration.route.test.js
+++ b/test/routes/upload/uploadCourseRegistration.route.test.js
@@ -34,7 +34,6 @@ const checkExpectedErrors = (res, expectedErrorMessage) => {
   Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
 
   // Company number field error
-  Code.expect(doc.getElementById('file').getAttribute('class')).contains('form-control-error')
   Code.expect(doc.getElementById('file-error').firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
 }
 

--- a/test/routes/upload/uploadDeemedEvidence.route.test.js
+++ b/test/routes/upload/uploadDeemedEvidence.route.test.js
@@ -34,7 +34,6 @@ const checkExpectedErrors = (res, expectedErrorMessage) => {
   Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
 
   // Company number field error
-  Code.expect(doc.getElementById('file').getAttribute('class')).contains('form-control-error')
   Code.expect(doc.getElementById('file-error').firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
 }
 

--- a/test/routes/upload/uploadEsaEuSkills.route.test.js
+++ b/test/routes/upload/uploadEsaEuSkills.route.test.js
@@ -34,7 +34,6 @@ const checkExpectedErrors = (res, expectedErrorMessage) => {
   Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
 
   // Company number field error
-  Code.expect(doc.getElementById('file').getAttribute('class')).contains('form-control-error')
   Code.expect(doc.getElementById('file-error').firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
 }
 

--- a/test/routes/upload/uploadWamitabQualification.route.test.js
+++ b/test/routes/upload/uploadWamitabQualification.route.test.js
@@ -34,7 +34,6 @@ const checkExpectedErrors = (res, expectedErrorMessage) => {
   Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
 
   // Company number field error
-  Code.expect(doc.getElementById('file').getAttribute('class')).contains('form-control-error')
   Code.expect(doc.getElementById('file-error').firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
 }
 


### PR DESCRIPTION
This change improves the appearance of the file upload controls if a validation error occurs, e.g. a user hasn't selected a file before trying to submit the page.

It was agreed with the designers that a red border shouldn't be added to the control because it didn't have a border beforehand. This is in keeping with other controls in the application such as radio buttons.