### PR TITLE
Add the ability to check the text content of an element.

### DIFF
--- a/src/views/upload/technicalQualification/courseRegistration.html
+++ b/src/views/upload/technicalQualification/courseRegistration.html
@@ -22,7 +22,7 @@
           <span class="bold-small">Upload the {{> abbreviations/WAMITAB }} or {{> abbreviations/EPOC }} course registration email or letter.</span>
           {{#if wamitabRiskIsMediumOrHigh}}
           <p id="wamitab-risk-is-medium-or-high">
-            You must complete the EPOC course or 4 units of the {{> abbreviations/WAMITAB }} qualification within 4 weeks of starting operating.
+            You must complete the {{> abbreviations/EPOC }} course or 4 units of the {{> abbreviations/WAMITAB }} qualification within 4 weeks of starting operating.
             You must get a full qualification within 12 months of starting operating.
           </p>
           {{else}}

--- a/test/routes/generalTestHelper.test.js
+++ b/test/routes/generalTestHelper.test.js
@@ -16,6 +16,11 @@ module.exports = class GeneralTestHelper {
     this.routePath = routePath
   }
 
+  static textContent (element) {
+    // Returns the trimmed text content of an element reducing the embedded whitespace to single spaces
+    return element.textContent.trim().replace(/\s+/g, ' ')
+  }
+
   test (excludeCookieGetTests = false, excludeCookiePostTests = false) {
     const {lab, routePath} = this
 

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -205,7 +205,7 @@ const fakeTaskList = {
 const checkElement = (element, text, href) => {
   Code.expect(element).to.exist()
   if (text) {
-    Code.expect(element.lastChild.nodeValue.trim()).to.equal(text)
+    Code.expect(GeneralTestHelper.textContent(element)).to.equal(text)
   }
   if (href) {
     Code.expect(element.getAttribute('href')).to.equal(href)
@@ -291,7 +291,7 @@ lab.experiment('Task List page tests:', () => {
     const doc = parser.parseFromString(res.payload, 'text/html')
 
     // Check the existence of the page title and Standard Rule infos
-    checkElement(doc.getElementById('page-heading'), 'Apply for a standard rules waste permit')
+    checkElement(doc.getElementById('page-heading'), 'Task list: Apply for a standard rules waste permit')
     checkElement(doc.getElementById('task-list-heading-visually-hidden'))
     checkElement(doc.getElementById('standard-rule-name-and-code'), `${fakeStandardRule.permitName} - ${fakeStandardRule.code}`)
     checkElement(doc.getElementById('select-a-different-permit'))

--- a/test/routes/upload/technicalQualification/courseRegistration.route.test.js
+++ b/test/routes/upload/technicalQualification/courseRegistration.route.test.js
@@ -67,6 +67,13 @@ lab.experiment('Company Declare Upload Course registration tests:', () => {
         title: 'displays WAMITAB low risk information',
         stubs: () => (StandardRule.getByApplicationLineId = () => ({wamitabRiskLevel: WamitabRiskLevel.LOW})),
         test: (doc) => Code.expect(doc.getElementById('wamitab-risk-is-low')).to.exist()
+      },
+      {
+        title: 'displays correct course registration details',
+        test: (doc) => {
+          Code.expect(GeneralTestHelper.textContent(doc.getElementById('course-registration-description')))
+            .to.equal('Upload the WAMITAB or EPOC course registration email or letter. You must complete the qualification within 4 weeks of starting operating. Check the WAMITAB risk tables (opens new tab) to find the qualifications needed for this permit.')
+        }
       }
     ])
     helper.getFailure()

--- a/test/routes/upload/technicalQualification/deemedEvidence.route.test.js
+++ b/test/routes/upload/technicalQualification/deemedEvidence.route.test.js
@@ -2,6 +2,7 @@
 
 const Lab = require('lab')
 const lab = exports.lab = Lab.script()
+const Code = require('code')
 const sinon = require('sinon')
 
 const TechnicalQualification = require('../../../../src/models/taskList/technicalQualification.model')
@@ -48,7 +49,16 @@ lab.experiment('Company Declare Upload Deemed evidence tests:', () => {
     }
 
     // Perform general get tests
-    helper.getSuccess(options)
+    helper.getSuccess(options, [
+      // Additional tests
+      {
+        title: 'displays correct course registration details',
+        test: (doc) => {
+          Code.expect(GeneralTestHelper.textContent(doc.getElementById('deemed-evidence-description')))
+            .to.equal('Upload evidence of one of these: deemed competence an Environment Agency assessment that they were a nominated manager under the transitional provisions for previously exempt activities and passed the general knowledge assessment. Also upload up-to-date relevant WAMITAB continuing competence certificates. You must pass a new continuing competence assessment every 2 years.')
+        }
+      }
+    ])
     helper.getFailure()
   })
 

--- a/test/routes/upload/technicalQualification/esaEuSkills.route.test.js
+++ b/test/routes/upload/technicalQualification/esaEuSkills.route.test.js
@@ -2,6 +2,7 @@
 
 const Lab = require('lab')
 const lab = exports.lab = Lab.script()
+const Code = require('code')
 const sinon = require('sinon')
 
 const TechnicalQualification = require('../../../../src/models/taskList/technicalQualification.model')
@@ -48,7 +49,16 @@ lab.experiment('Company Declare Upload ESA EU skills tests:', () => {
     }
 
     // Perform general get tests
-    helper.getSuccess(options)
+    helper.getSuccess(options, [
+      // Additional tests
+      {
+        title: 'displays correct course registration details',
+        test: (doc) => {
+          Code.expect(GeneralTestHelper.textContent(doc.getElementById('esa-eu-skills-description')))
+            .to.equal('Upload a copy of the Competence Management System certificate. Check the certificate hasn\'t expired. They are valid for 3 years. If you’re getting a certificate, upload evidence of a contract with an accredited certification body. After 4 weeks you must have evidence of an agreed schedule for audit and certification and after 6 months evidence of a completed gap analysis audit. You must have a certified system within 12 months of starting operations at the site.')
+        }
+      }
+    ])
     helper.getFailure()
   })
 

--- a/test/routes/upload/technicalQualification/wamitabQualification.route.test.js
+++ b/test/routes/upload/technicalQualification/wamitabQualification.route.test.js
@@ -2,6 +2,7 @@
 
 const Lab = require('lab')
 const lab = exports.lab = Lab.script()
+const Code = require('code')
 const sinon = require('sinon')
 
 const TechnicalQualification = require('../../../../src/models/taskList/technicalQualification.model')
@@ -48,7 +49,16 @@ lab.experiment('Company Declare Upload Wamitab tests:', () => {
     }
 
     // Perform general get tests
-    helper.getSuccess(options)
+    helper.getSuccess(options, [
+      // Additional tests
+      {
+        title: 'displays correct course registration details',
+        test: (doc) => {
+          Code.expect(GeneralTestHelper.textContent(doc.getElementById('wamitab-qualification-description')))
+            .to.equal('Upload copies of the certificates. If the qualification is over 2 years old, upload copies of the relevant continuing competence certificates as well. Check the WAMITAB risk tables (opens new tab) to make sure you have the correct qualification for this permit. We’ll use the WAMITAB database to check that the qualifications are valid.')
+        }
+      }
+    ])
     helper.getFailure()
   })
 

--- a/test/routes/upload/uploadHelper.js
+++ b/test/routes/upload/uploadHelper.js
@@ -113,7 +113,9 @@ module.exports = class UploadTestHelper {
       })
 
       additionalTests.forEach(({title, stubs, test}) => lab.test(title, async () => {
-        stubs()
+        if (stubs) {
+          stubs()
+        }
         const doc = await getDoc(options)
         test(doc)
       }))


### PR DESCRIPTION
Added a new static "textContent" method to the GeneralTestHelper which allows us to stop having to find the text content of an element using element.firstChild.nodeValue as well as the ability to retrieve all the text content of an element no matter the structure.