### PR TITLE
Restrict the combined length of the address fields to 450 characters in total

### DIFF
--- a/src/models/address.model.js
+++ b/src/models/address.model.js
@@ -12,14 +12,14 @@ class Address extends BaseModel {
   static get mapping () {
     return [
       {field: 'id', dynamics: 'defra_addressid'},
-      {field: 'buildingNameOrNumber', dynamics: 'defra_premises', length: {max: 170}},
-      {field: 'addressLine1', dynamics: 'defra_street', length: {max: 170}},
-      {field: 'addressLine2', dynamics: 'defra_locality', length: {max: 170}},
+      {field: 'buildingNameOrNumber', dynamics: 'defra_premises', length: {max: 50}},
+      {field: 'addressLine1', dynamics: 'defra_street', length: {max: 100}},
+      {field: 'addressLine2', dynamics: 'defra_locality', length: {max: 100}},
       {field: 'townOrCity', dynamics: 'defra_towntext', length: {max: 70}},
       {field: 'postcode', dynamics: 'defra_postcode', length: {max: 8}},
       {field: 'uprn', dynamics: 'defra_uprn', length: {max: 20}},
       {field: 'fromAddressLookup', dynamics: 'defra_fromaddresslookup'},
-      {field: 'fullAddress', dynamics: 'defra_name', length: {max: 600}}
+      {field: 'fullAddress', dynamics: 'defra_name', length: {max: 450}}
     ]
   }
 

--- a/test/routes/address/invoice/manualEntryInvoice.route.test.js
+++ b/test/routes/address/invoice/manualEntryInvoice.route.test.js
@@ -311,9 +311,9 @@ lab.experiment('Invoice address select page tests:', () => {
           [FORM_FIELD_ID.townOrCity]: longTownOrCity,
           [FORM_FIELD_ID.postcode]: longPostcode
         }
-        await checkValidationError(FORM_FIELD_ID.buildingNameOrNumber, `Enter a shorter building name or number with no more than 170 characters`, 0)
-        await checkValidationError(FORM_FIELD_ID.addressLine1, `Enter a shorter address line 1 with no more than 170 characters`, 1)
-        await checkValidationError(FORM_FIELD_ID.addressLine2, `Enter a shorter address line 2 with no more than 170 characters`, 2)
+        await checkValidationError(FORM_FIELD_ID.buildingNameOrNumber, `Enter a shorter building name or number with no more than 50 characters`, 0)
+        await checkValidationError(FORM_FIELD_ID.addressLine1, `Enter a shorter address line 1 with no more than 100 characters`, 1)
+        await checkValidationError(FORM_FIELD_ID.addressLine2, `Enter a shorter address line 2 with no more than 100 characters`, 2)
         await checkValidationError(FORM_FIELD_ID.townOrCity, `Enter a shorter town or city with no more than 70 characters`, 3)
         await checkValidationError(FORM_FIELD_ID.postcode, `Enter a shorter postcode with no more than 8 characters`, 4)
       })

--- a/test/routes/address/site/manualEntrySite.route.test.js
+++ b/test/routes/address/site/manualEntrySite.route.test.js
@@ -304,9 +304,9 @@ lab.experiment('Address select page tests:', () => {
           [FORM_FIELD_ID.townOrCity]: longTownOrCity,
           [FORM_FIELD_ID.postcode]: longPostcode
         }
-        await checkValidationError(FORM_FIELD_ID.buildingNameOrNumber, `Enter a shorter building name or number with no more than 170 characters`, 0)
-        await checkValidationError(FORM_FIELD_ID.addressLine1, `Enter a shorter address line 1 with no more than 170 characters`, 1)
-        await checkValidationError(FORM_FIELD_ID.addressLine2, `Enter a shorter address line 2 with no more than 170 characters`, 2)
+        await checkValidationError(FORM_FIELD_ID.buildingNameOrNumber, `Enter a shorter building name or number with no more than 50 characters`, 0)
+        await checkValidationError(FORM_FIELD_ID.addressLine1, `Enter a shorter address line 1 with no more than 100 characters`, 1)
+        await checkValidationError(FORM_FIELD_ID.addressLine2, `Enter a shorter address line 2 with no more than 100 characters`, 2)
         await checkValidationError(FORM_FIELD_ID.townOrCity, `Enter a shorter town or city with no more than 70 characters`, 3)
         await checkValidationError(FORM_FIELD_ID.postcode, `Enter a shorter postcode with no more than 8 characters`, 4)
       })


### PR DESCRIPTION
This is to make sure the maximum field length of 450 characters for the CRM is not exceeded.