### PR TITLE
Refactor/create app context

### DIFF
--- a/src/controllers/address/base/addressManual.controller.js
+++ b/src/controllers/address/base/addressManual.controller.js
@@ -3,15 +3,11 @@
 const Constants = require('../../../constants')
 const BaseController = require('../../base.controller')
 const CookieService = require('../../../services/cookie.service')
-const Application = require('../../../models/application.model')
 
 module.exports = class AddressManualController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -49,9 +45,7 @@ module.exports = class AddressManualController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+      const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
       const addressDto = {
         buildingNameOrNumber: request.payload['building-name-or-number'],

--- a/src/controllers/address/base/addressSelect.controller.js
+++ b/src/controllers/address/base/addressSelect.controller.js
@@ -4,15 +4,11 @@ const Constants = require('../../../constants')
 const BaseController = require('../../base.controller')
 const CookieService = require('../../../services/cookie.service')
 const Address = require('../../../models/address.model')
-const Application = require('../../../models/application.model')
 
 module.exports = class AddressSelectController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -59,9 +55,7 @@ module.exports = class AddressSelectController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+      const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
       const addressDto = {
         uprn: request.payload['select-address'],

--- a/src/controllers/address/base/postcode.controller.js
+++ b/src/controllers/address/base/postcode.controller.js
@@ -4,15 +4,11 @@ const Constants = require('../../../constants')
 const BaseController = require('../../base.controller')
 const CookieService = require('../../../services/cookie.service')
 const Address = require('../../../models/address.model')
-const Application = require('../../../models/application.model')
 
 module.exports = class PostcodeController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -50,7 +46,7 @@ module.exports = class PostcodeController extends BaseController {
   }
 
   async doPost (request, reply, errors) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
+    const {authToken} = await this.createApplicationContext(request)
     const postcode = request.payload['postcode']
     const errorPath = 'postcode'
 

--- a/src/controllers/applicationReceived.controller.js
+++ b/src/controllers/applicationReceived.controller.js
@@ -2,19 +2,14 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
-const Contact = require('../models/contact.model')
 const Payment = require('../models/payment.model')
 
 module.exports = class ApplicationReceivedController extends BaseController {
   async doGet (request, reply) {
     const pageContext = this.createPageContext()
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
-    const contact = await Contact.getByApplicationId(authToken, applicationId)
+
+    const {authToken, applicationLineId, application, contact} = await this.createApplicationContext(request, {application: true, contact: true})
+
     const bacsPayment = await Payment.getByApplicationLineIdAndType(authToken, applicationLineId, Constants.Dynamics.PaymentTypes.BACS_PAYMENT)
 
     pageContext.applicationName = application.applicationName

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -5,6 +5,10 @@ const CookieService = require('../services/cookie.service')
 const LoggingService = require('../services/logging.service')
 const {COOKIE_RESULT} = require('../constants')
 const Application = require('../models/application.model')
+const ApplicationLine = require('../models/applicationLine.model')
+const Account = require('../models/account.model')
+const Contact = require('../models/contact.model')
+const StandardRule = require('../models/standardRule.model')
 
 module.exports = class BaseController {
   constructor (route, validator, cookieValidationRequired = true) {
@@ -42,16 +46,44 @@ module.exports = class BaseController {
     return pageContext
   }
 
-  async createApplicationContext (request, options = {application: false}) {
-    const appContext = {
-      authToken: CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN),
-      applicationId: CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID),
-      applicationLineId: CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    }
+  async createApplicationContext (request,
+    options = {
+      application: false,
+      applicationLine: false,
+      account: false,
+      contact: false,
+      standardRule: false}) {
+    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
+    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
+    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+    let application, applicationLine, account, contact, standardRule
+
     if (options.application) {
-      appContext.application = await Application.getById(appContext.authToken, appContext.applicationId)
+      application = await Application.getById(authToken, applicationId)
     }
-    return appContext
+    if (options.applicationLine) {
+      applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
+    }
+    if (options.account) {
+      account = await Account.getByApplicationId(authToken, applicationId)
+    }
+    if (options.contact) {
+      contact = await Contact.getByApplicationId(authToken, applicationId)
+    }
+    if (options.standardRule) {
+      standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
+    }
+
+    return {
+      authToken: authToken,
+      applicationId: applicationId,
+      applicationLineId: applicationLineId,
+      application: application,
+      applicationLine: applicationLine,
+      account: account,
+      contact: contact,
+      standardRule: standardRule
+    }
   }
 
   redirect (request, reply, viewPath, cookie) {

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -67,14 +67,14 @@ module.exports = class BaseController {
     ])
 
     return {
-      authToken: authToken,
-      applicationId: applicationId,
-      applicationLineId: applicationLineId,
-      application: application,
-      applicationLine: applicationLine,
-      account: account,
-      contact: contact,
-      standardRule: standardRule
+      authToken,
+      applicationId,
+      applicationLineId,
+      application,
+      applicationLine,
+      account,
+      contact,
+      standardRule
     }
   }
 

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -56,23 +56,15 @@ module.exports = class BaseController {
     const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
     const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
     const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    let application, applicationLine, account, contact, standardRule
 
-    if (options.application) {
-      application = await Application.getById(authToken, applicationId)
-    }
-    if (options.applicationLine) {
-      applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-    }
-    if (options.account) {
-      account = await Account.getByApplicationId(authToken, applicationId)
-    }
-    if (options.contact) {
-      contact = await Contact.getByApplicationId(authToken, applicationId)
-    }
-    if (options.standardRule) {
-      standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
-    }
+    // Query in parallel for optional entities
+    const [application, applicationLine, account, contact, standardRule] = await Promise.all([
+      options.application ? Application.getById(authToken, applicationId) : Promise.resolve(undefined),
+      options.applicationLine ? ApplicationLine.getById(authToken, applicationLineId) : Promise.resolve(undefined),
+      options.account ? Account.getByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
+      options.contact ? Contact.getByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
+      options.standardRule ? StandardRule.getByApplicationLineId(authToken, applicationLineId) : Promise.resolve(undefined)
+    ])
 
     return {
       authToken: authToken,

--- a/src/controllers/checkBeforeSending.controller.js
+++ b/src/controllers/checkBeforeSending.controller.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Constants = require('../constants')
-const Application = require('../models/application.model')
 const ApplicationLine = require('../models/applicationLine.model')
 const BaseController = require('./base.controller')
 const TaskList = require('../models/taskList/taskList.model')
@@ -14,7 +13,6 @@ const ContactCheck = require('../models/checkYourAnswers/contact.check')
 const PermitHolderCheck = require('../models/checkYourAnswers/permitHolder.check')
 const ConfidentialityCheck = require('../models/checkYourAnswers/confidentiality.check')
 const InvoiceCheck = require('../models/checkYourAnswers/invoice.check')
-const CookieService = require('../services/cookie.service')
 
 module.exports = class CheckBeforeSendingController extends BaseController {
   constructor (...args) {
@@ -58,10 +56,7 @@ module.exports = class CheckBeforeSendingController extends BaseController {
 
   async doGet (request, reply) {
     const pageContext = this.createPageContext()
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     pageContext.sections = await this._buildSections(authToken, applicationId, applicationLineId)
 
@@ -74,9 +69,8 @@ module.exports = class CheckBeforeSendingController extends BaseController {
   }
 
   async doPost (request, reply) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, application} = await this.createApplicationContext(request, {application: true})
+
     application.declaration = true
     await application.save(authToken)
 

--- a/src/controllers/checkYourEmail.controller.js
+++ b/src/controllers/checkYourEmail.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class CheckYourEmailController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/companyCheckName.controller.js
+++ b/src/controllers/companyCheckName.controller.js
@@ -2,21 +2,12 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
 const CompanyLookupService = require('../services/companyLookup.service')
-const Application = require('../models/application.model')
-const Account = require('../models/account.model')
 
 module.exports = class CompanyCheckNameController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-
-    const [application, account] = await Promise.all([
-      Application.getById(authToken, applicationId),
-      Account.getByApplicationId(authToken, applicationId)
-    ])
+    const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (!application || !account) {
       return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
@@ -54,13 +45,7 @@ module.exports = class CompanyCheckNameController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-
-      const [application, account] = await Promise.all([
-        Application.getById(authToken, applicationId),
-        Account.getByApplicationId(authToken, applicationId)
-      ])
+      const {authToken, application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
       if (application && account) {
         const company = await CompanyLookupService.getCompany(account.companyNumber)

--- a/src/controllers/companyCheckStatus.controller.js
+++ b/src/controllers/companyCheckStatus.controller.js
@@ -3,10 +3,7 @@
 const Handlebars = require('handlebars')
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
 const CompanyLookupService = require('../services/companyLookup.service')
-const Account = require('../models/account.model')
-const Application = require('../models/application.model')
 
 module.exports = class CompanyStatusController extends BaseController {
   constructor (...args) {
@@ -16,15 +13,12 @@ module.exports = class CompanyStatusController extends BaseController {
   }
 
   async doGet (request, reply, errors) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    const account = await Account.getByApplicationId(authToken, applicationId)
     const company = await CompanyLookupService.getCompany(account.companyNumber)
 
     if (!company) {

--- a/src/controllers/companyCheckType.controller.js
+++ b/src/controllers/companyCheckType.controller.js
@@ -3,10 +3,7 @@
 const Handlebars = require('handlebars')
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
 const CompanyLookupService = require('../services/companyLookup.service')
-const Account = require('../models/account.model')
-const Application = require('../models/application.model')
 
 module.exports = class CompanyTypeController extends BaseController {
   constructor (...args) {
@@ -16,15 +13,13 @@ module.exports = class CompanyTypeController extends BaseController {
   }
 
   async doGet (request, reply, errors) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const pageContext = this.createPageContext(errors)
+    const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    const account = await Account.getByApplicationId(authToken, applicationId)
     const company = await CompanyLookupService.getCompany(account.companyNumber)
 
     const companyType = company ? Constants.Company.Type[company.type] : undefined
@@ -36,8 +31,6 @@ module.exports = class CompanyTypeController extends BaseController {
     this.route.pageHeading = Handlebars.compile(this.orginalPageHeading)({
       companyType: companyType
     })
-
-    const pageContext = this.createPageContext(errors)
 
     pageContext.companyNumber = account.companyNumber
     pageContext.companyName = company.name

--- a/src/controllers/confirmRules.controller.js
+++ b/src/controllers/confirmRules.controller.js
@@ -2,9 +2,6 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
-const StandardRule = require('../models/standardRule.model')
 const ConfirmRules = require('../models/confirmRules.model')
 
 module.exports = class ConfirmRulesController extends BaseController {
@@ -15,16 +12,11 @@ module.exports = class ConfirmRulesController extends BaseController {
 
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationId, applicationLineId, application, standardRule} = await this.createApplicationContext(request, {application: true, standardRule: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
-
-    const standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
 
     pageContext.guidanceUrl = standardRule.guidanceUrl
     pageContext.code = standardRule.code
@@ -34,9 +26,7 @@ module.exports = class ConfirmRulesController extends BaseController {
   }
 
   async doPost (request, reply, errors) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+    const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class CostTimeController extends BaseController {
   async doGet (request, reply) {
     const pageContext = this.createPageContext()
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/declaration/base/declarations.controller.js
+++ b/src/controllers/declaration/base/declarations.controller.js
@@ -2,8 +2,6 @@
 
 const Constants = require('../../../constants')
 const BaseController = require('../../base.controller')
-const CookieService = require('../../../services/cookie.service')
-const Application = require('../../../models/application.model')
 
 module.exports = class DeclarationsController extends BaseController {
   constructor (...args) {
@@ -14,9 +12,7 @@ module.exports = class DeclarationsController extends BaseController {
 
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -52,10 +48,8 @@ module.exports = class DeclarationsController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-      const application = await Application.getById(authToken, applicationId)
+      const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
+
       Object.assign(application, this.getRequestData(request))
       await application.save(authToken)
       if (this.updateCompleteness) {

--- a/src/controllers/drainageTypeDrain.controller.js
+++ b/src/controllers/drainageTypeDrain.controller.js
@@ -6,9 +6,9 @@ const BaseController = require('./base.controller')
 module.exports = class DrainageTypeDrainController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const appContext = await this.createApplicationContext(request, {application: true})
+    const {application} = await this.createApplicationContext(request, {application: true})
 
-    if (appContext.application.isSubmitted()) {
+    if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 

--- a/src/controllers/drainageTypeDrain.controller.js
+++ b/src/controllers/drainageTypeDrain.controller.js
@@ -2,17 +2,13 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class DrainageTypeDrainController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const appContext = await this.createApplicationContext(request, {application: true})
 
-    if (application.isSubmitted()) {
+    if (appContext.application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 

--- a/src/controllers/error/alreadySubmitted.controller.js
+++ b/src/controllers/error/alreadySubmitted.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../../constants')
 const BaseController = require('../base.controller')
-const CookieService = require('../../services/cookie.service')
-const Application = require('../../models/application.model')
 
 module.exports = class AlreadySubmittedController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     pageContext.startOpenOrSavedRoute = Constants.Routes.START_OR_OPEN_SAVED.path
     pageContext.applicationRef = application.applicationNumber

--- a/src/controllers/error/pageNotFound.controller.js
+++ b/src/controllers/error/pageNotFound.controller.js
@@ -3,17 +3,12 @@
 const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 const CookieService = require('../../services/cookie.service')
-const Application = require('../../models/application.model')
-const ApplicationLine = require('../../models/applicationLine.model')
 
 module.exports = class PageNotFoundController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = applicationId ? await Application.getById(authToken, applicationId) : undefined
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const applicationLine = applicationLineId ? await ApplicationLine.getById(authToken, applicationLineId) : undefined
+
+    const {application, applicationLine} = await this.createApplicationContext(request, {application: true, applicationLine: true})
 
     pageContext.hasApplication = PageNotFoundController.hasApplication(application, applicationLine)
     pageContext.taskListRoute = Constants.Routes.TASK_LIST.path
@@ -23,6 +18,7 @@ module.exports = class PageNotFoundController extends BaseController {
   }
 
   static hasApplication (application, applicationLine) {
+    // Refactored out into a helper to aid unit testing
     return application && applicationLine
   }
 

--- a/src/controllers/managementSystem.controller.js
+++ b/src/controllers/managementSystem.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class ManagementSystemController extends BaseController {
   async doGet (request, reply) {
     const pageContext = this.createPageContext()
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/paymentBacs.controller.js
+++ b/src/controllers/paymentBacs.controller.js
@@ -2,17 +2,12 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
-const ApplicationLine = require('../models/applicationLine.model')
 const Payment = require('../models/payment.model')
 
 module.exports = class PaymentBacsController extends BaseController {
   async doGet (request, reply) {
     const pageContext = this.createPageContext()
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -22,10 +17,11 @@ module.exports = class PaymentBacsController extends BaseController {
   }
 
   async doPost (request, reply) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const payment = await Payment.getBacsPaymentDetails(authToken, applicationLineId)
-    const {value = 0} = await ApplicationLine.getById(authToken, applicationLineId)
+    const {authToken, applicationLine} = await this.createApplicationContext(request, {application: false, applicationLine: true})
+
+    const {value = 0} = applicationLine
+    const payment = await Payment.getBacsPaymentDetails(authToken, applicationLine.id)
+
     payment.value = value
     payment.category = Constants.Dynamics.PAYMENT_CATEGORY
     payment.statusCode = Constants.Dynamics.PaymentStatusCodes.ISSUED

--- a/src/controllers/paymentType.controller.js
+++ b/src/controllers/paymentType.controller.js
@@ -2,18 +2,12 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
-const ApplicationLine = require('../models/applicationLine.model')
 const {CARD_PAYMENT, BACS_PAYMENT} = Constants.Dynamics.PaymentTypes
 
 module.exports = class PaymentTypeController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application, applicationLine} = await this.createApplicationContext(request, {application: true, applicationLine: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -31,7 +25,6 @@ module.exports = class PaymentTypeController extends BaseController {
     })
 
     // Default to 0 when the balance hasn't been set
-    const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
     const {value = 0} = applicationLine
 
     pageContext.cost = value.toLocaleString()

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class PermitCategoryController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/permitHolderType.controller.js
+++ b/src/controllers/permitHolderType.controller.js
@@ -2,16 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class PermitHolderTypeController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -4,15 +4,12 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 const CookieService = require('../services/cookie.service')
 const StandardRule = require('../models/standardRule.model')
-const Application = require('../models/application.model')
 const ApplicationLine = require('../models/applicationLine.model')
 
 module.exports = class PermitSelectController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -30,8 +27,8 @@ module.exports = class PermitSelectController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
+      const {authToken, applicationId} = await this.createApplicationContext(request)
+
       // Look up the Standard Rule based on the chosen permit type
       const standardRule = await StandardRule.getByCode(authToken, request.payload['chosen-permit'])
 

--- a/src/controllers/preApplication.controller.js
+++ b/src/controllers/preApplication.controller.js
@@ -2,16 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class PreApplicationController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/controllers/siteGridReference.controller.js
+++ b/src/controllers/siteGridReference.controller.js
@@ -2,19 +2,14 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
 const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.model')
-const Application = require('../models/application.model')
 
 module.exports = class SiteGridReferenceController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const appContext = await this.createApplicationContext(request, {application: true})
 
-    if (application.isSubmitted()) {
+    if (appContext.application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
@@ -23,7 +18,7 @@ module.exports = class SiteGridReferenceController extends BaseController {
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
+        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, appContext)
       }
     }
     return this.showView(request, reply, 'siteGridReference', pageContext)
@@ -33,12 +28,10 @@ module.exports = class SiteGridReferenceController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+      const appContext = await this.createApplicationContext(request)
 
       await SiteNameAndLocation.saveGridReference(request, request.payload['site-grid-reference'],
-        authToken, applicationId, applicationLineId)
+        appContext.authToken, appContext.applicationId, appContext.applicationLineId)
 
       return this.redirect(request, reply, Constants.Routes.ADDRESS.POSTCODE_SITE.path)
     }

--- a/src/controllers/siteGridReference.controller.js
+++ b/src/controllers/siteGridReference.controller.js
@@ -7,9 +7,9 @@ const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.mode
 module.exports = class SiteGridReferenceController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const appContext = await this.createApplicationContext(request, {application: true})
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
-    if (appContext.application.isSubmitted()) {
+    if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
@@ -18,7 +18,7 @@ module.exports = class SiteGridReferenceController extends BaseController {
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, appContext)
+        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
       }
     }
     return this.showView(request, reply, 'siteGridReference', pageContext)
@@ -28,10 +28,10 @@ module.exports = class SiteGridReferenceController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const appContext = await this.createApplicationContext(request)
+      const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
       await SiteNameAndLocation.saveGridReference(request, request.payload['site-grid-reference'],
-        appContext.authToken, appContext.applicationId, appContext.applicationLineId)
+        authToken, applicationId, applicationLineId)
 
       return this.redirect(request, reply, Constants.Routes.ADDRESS.POSTCODE_SITE.path)
     }

--- a/src/controllers/siteName.controller.js
+++ b/src/controllers/siteName.controller.js
@@ -2,19 +2,14 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.model')
 
 module.exports = class SiteNameController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const appContext = await this.createApplicationContext(request, {application: true})
 
-    if (application.isSubmitted()) {
+    if (appContext.application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
@@ -23,7 +18,7 @@ module.exports = class SiteNameController extends BaseController {
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-name': await SiteNameAndLocation.getSiteName(request, authToken, applicationId, applicationLineId)
+        'site-name': await SiteNameAndLocation.getSiteName(request, appContext.authToken, appContext.applicationId, appContext.applicationLineId)
       }
     }
 
@@ -34,12 +29,9 @@ module.exports = class SiteNameController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
+      const appContext = await this.createApplicationContext(request)
 
-      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'],
-        authToken, applicationId, applicationLineId)
+      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], appContext)
 
       return this.redirect(request, reply, Constants.Routes.SITE_GRID_REFERENCE.path)
     }

--- a/src/controllers/siteName.controller.js
+++ b/src/controllers/siteName.controller.js
@@ -7,9 +7,9 @@ const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.mode
 module.exports = class SiteNameController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const appContext = await this.createApplicationContext(request, {application: true})
+    const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
-    if (appContext.application.isSubmitted()) {
+    if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
@@ -18,7 +18,7 @@ module.exports = class SiteNameController extends BaseController {
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-name': await SiteNameAndLocation.getSiteName(request, appContext.authToken, appContext.applicationId, appContext.applicationLineId)
+        'site-name': await SiteNameAndLocation.getSiteName(request, authToken, applicationId, applicationLineId)
       }
     }
 
@@ -29,9 +29,9 @@ module.exports = class SiteNameController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const appContext = await this.createApplicationContext(request)
+      const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
-      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], appContext)
+      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], authToken, applicationId, applicationLineId)
 
       return this.redirect(request, reply, Constants.Routes.SITE_GRID_REFERENCE.path)
     }

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -44,6 +44,6 @@ module.exports = class StartOrOpenSavedController extends BaseController {
       nextPage = Constants.Routes.CHECK_YOUR_EMAIL
     }
 
-    return this.redirect(request, reply, nextPage.path)
+    return this.redirect(request, reply, nextPage.path, cookie)
   }
 }

--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -2,18 +2,12 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
-const StandardRule = require('../models/standardRule.model')
 const TaskList = require('../models/taskList/taskList.model')
 
 module.exports = class TaskListController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {authToken, applicationLineId, application, standardRule} = await this.createApplicationContext(request, {application: true, standardRule: true})
 
     // If the application has been submitted
     if (application.isSubmitted()) {
@@ -25,7 +19,7 @@ module.exports = class TaskListController extends BaseController {
       }
     }
 
-    pageContext.standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
+    pageContext.standardRule = standardRule
     pageContext.taskList = await TaskList.getByApplicationLineId(authToken, applicationLineId)
 
     pageContext.formValues = request.payload

--- a/src/controllers/technicalQualification.controller.js
+++ b/src/controllers/technicalQualification.controller.js
@@ -2,17 +2,12 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 const {WAMITAB_QUALIFICATION, REGISTERED_ON_A_COURSE, DEEMED_COMPETENCE, ESA_EU_SKILLS} = Constants.Dynamics.TechnicalQualification
 
 module.exports = class TechnicalQualificationController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
@@ -55,9 +50,8 @@ module.exports = class TechnicalQualificationController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, reply, errors)
     } else {
-      const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-      const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-      const application = await Application.getById(authToken, applicationId)
+      const {authToken, application} = await this.createApplicationContext(request, {application: true})
+
       application.technicalQualification = request.payload['technical-qualification']
       await application.save(authToken)
 

--- a/src/controllers/upload/technicalQualification/courseRegistration.controller.js
+++ b/src/controllers/upload/technicalQualification/courseRegistration.controller.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const UploadController = require('../base/upload.controller')
-const StandardRule = require('../../../models/standardRule.model')
 const TechnicalQualification = require('../../../models/taskList/technicalQualification.model')
-const CookieService = require('../../../services/cookie.service')
 const Constants = require('../../../constants')
 const {TECHNICAL_QUALIFICATION} = Constants.UploadSubject
 
@@ -17,9 +15,7 @@ module.exports = class CourseRegistrationController extends UploadController {
   }
 
   async getSpecificPageContext (request) {
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationLineId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID)
-    const standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
+    const {standardRule} = await this.createApplicationContext(request, {standardRule: true})
     const {MEDIUM, HIGH} = Constants.Dynamics.WamitabRiskLevel
     return {
       wamitabRiskIsMediumOrHigh: [MEDIUM, HIGH].includes(standardRule.wamitabRiskLevel)

--- a/src/controllers/wasteRecoveryPlan.controller.js
+++ b/src/controllers/wasteRecoveryPlan.controller.js
@@ -2,15 +2,11 @@
 
 const Constants = require('../constants')
 const BaseController = require('./base.controller')
-const CookieService = require('../services/cookie.service')
-const Application = require('../models/application.model')
 
 module.exports = class WasteRecoveryPlanController extends BaseController {
   async doGet (request, reply, errors) {
     const pageContext = this.createPageContext(errors)
-    const authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
-    const applicationId = CookieService.get(request, Constants.COOKIE_KEY.APPLICATION_ID)
-    const application = await Application.getById(authToken, applicationId)
+    const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
       return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)

--- a/src/models/taskList/siteNameAndLocation.model.js
+++ b/src/models/taskList/siteNameAndLocation.model.js
@@ -27,38 +27,38 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     return siteName
   }
 
-  static async saveSiteName (request, siteName, appContext) {
+  static async saveSiteName (request, siteName, authToken, applicationId, applicationLineId) {
     try {
       // Get the Location for this application
-      let location = await Location.getByApplicationId(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
+      let location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
       if (!location) {
         // Create a Location in Dynamics
         location = new Location({
           siteName: siteName,
-          applicationId: appContext.applicationId,
-          applicationLineId: appContext.applicationLineId
+          applicationId: applicationId,
+          applicationLineId: applicationLineId
         })
       } else {
         // Update existing Site
         location.siteName = siteName
       }
-      await location.save(appContext.authToken)
-      await SiteNameAndLocation.updateCompleteness(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
+      await location.save(authToken)
+      await SiteNameAndLocation.updateCompleteness(authToken, applicationId, applicationLineId)
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
     }
   }
 
-  static async getGridReference (request, appContext) {
+  static async getGridReference (request, authToken, applicationId, applicationLineId) {
     let gridReference
     try {
       // Get the Location for this application
-      let location = await Location.getByApplicationId(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
+      let location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
 
       if (location) {
         // Get the LocationDetail for this application (if there is one)
-        let locationDetail = await LocationDetail.getByLocationId(appContext.authToken, location.id)
+        let locationDetail = await LocationDetail.getByLocationId(authToken, location.id)
         if (locationDetail) {
           gridReference = locationDetail.gridReference
         }

--- a/src/models/taskList/siteNameAndLocation.model.js
+++ b/src/models/taskList/siteNameAndLocation.model.js
@@ -27,38 +27,38 @@ module.exports = class SiteNameAndLocation extends BaseModel {
     return siteName
   }
 
-  static async saveSiteName (request, siteName, authToken, applicationId, applicationLineId) {
+  static async saveSiteName (request, siteName, appContext) {
     try {
       // Get the Location for this application
-      let location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
+      let location = await Location.getByApplicationId(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
       if (!location) {
         // Create a Location in Dynamics
         location = new Location({
           siteName: siteName,
-          applicationId: applicationId,
-          applicationLineId: applicationLineId
+          applicationId: appContext.applicationId,
+          applicationLineId: appContext.applicationLineId
         })
       } else {
         // Update existing Site
         location.siteName = siteName
       }
-      await location.save(authToken)
-      await SiteNameAndLocation.updateCompleteness(authToken, applicationId, applicationLineId)
+      await location.save(appContext.authToken)
+      await SiteNameAndLocation.updateCompleteness(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
     } catch (error) {
       LoggingService.logError(error, request)
       throw error
     }
   }
 
-  static async getGridReference (request, authToken, applicationId, applicationLineId) {
+  static async getGridReference (request, appContext) {
     let gridReference
     try {
       // Get the Location for this application
-      let location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
+      let location = await Location.getByApplicationId(appContext.authToken, appContext.applicationId, appContext.applicationLineId)
 
       if (location) {
         // Get the LocationDetail for this application (if there is one)
-        let locationDetail = await LocationDetail.getByLocationId(authToken, location.id)
+        let locationDetail = await LocationDetail.getByLocationId(appContext.authToken, location.id)
         if (locationDetail) {
           gridReference = locationDetail.gridReference
         }

--- a/test/models/taskList/siteNameAndLocation.model.test.js
+++ b/test/models/taskList/siteNameAndLocation.model.test.js
@@ -118,7 +118,8 @@ lab.experiment('Task List: Site Name and Location Model tests:', () => {
 
   lab.test('saveSiteName() method correctly saves a site name', async () => {
     const spy = sinon.spy(Location.prototype, 'save')
-    await SiteNameAndLocation.saveSiteName(request, fakeLocation.siteName, authToken, applicationId, applicationLineId)
+    const appContext = {}
+    await SiteNameAndLocation.saveSiteName(request, fakeLocation.siteName, appContext)
     Code.expect(spy.callCount).to.equal(1)
   })
 
@@ -129,12 +130,14 @@ lab.experiment('Task List: Site Name and Location Model tests:', () => {
     LocationDetail.getByLocationId = (authToken, locationId) => {
       return undefined
     }
-    const result = await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
+    const appContext = {}
+    const result = await SiteNameAndLocation.getGridReference(request, appContext)
     Code.expect(result).to.be.equal(undefined)
   })
 
   lab.test('getGridReference() method correctly retrieves a site name when there is a saved Location and LocationDetail', async () => {
-    const result = await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
+    const appContext = {}
+    const result = await SiteNameAndLocation.getGridReference(request, appContext)
     Code.expect(result).to.be.equal(fakeLocationDetail.gridReference)
   })
 

--- a/test/routes/error/pageNotFound.route.test.js
+++ b/test/routes/error/pageNotFound.route.test.js
@@ -10,6 +10,7 @@ const GeneralTestHelper = require('../generalTestHelper.test')
 
 const CookieService = require('../../../src/services/cookie.service')
 const Application = require('../../../src/models/application.model')
+const ApplicationLine = require('../../../src/models/applicationLine.model')
 const PageNotFoundController = require('../../../src/controllers/error/pageNotFound.controller')
 const {COOKIE_RESULT} = require('../../../src/constants')
 
@@ -34,6 +35,7 @@ lab.beforeEach(() => {
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
   sandbox.stub(Application, 'getById').value(() => new Application({}))
+  sandbox.stub(ApplicationLine, 'getById').value(() => new ApplicationLine({}))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(PageNotFoundController, 'hasApplication').value(() => false)
 })

--- a/test/routes/siteName.route.test.js
+++ b/test/routes/siteName.route.test.js
@@ -109,7 +109,7 @@ lab.experiment('Site Name page tests:', () => {
   lab.experiment('GET:', () => {
     lab.test(`GET ${routePath} returns the site page correctly when it is a new application`, async () => {
       // Empty site name response
-      SiteNameAndLocation.getSiteName = (request, authToken, applicationId, applicationLineId) => {
+      SiteNameAndLocation.getSiteName = () => {
         return undefined
       }
       checkPageElements(getRequest, '')
@@ -122,11 +122,11 @@ lab.experiment('Site Name page tests:', () => {
 
   lab.experiment('POST:', () => {
     lab.experiment('Success:', () => {
-      lab.test(`POST ${routePath} (new Site) redirects to the Site Grid Reference route`, async () => {
+      lab.test(`POST ${routePath} (new Site) redirects to the next route ${nextRoutePath}`, async () => {
         postRequest.payload['site-name'] = 'My Site'
 
-      // Empty site name response
-        SiteNameAndLocation.getSiteName = (request, authToken, applicationId, applicationLineId) => {
+        // Empty site name response
+        SiteNameAndLocation.getSiteName = () => {
           return undefined
         }
 
@@ -138,6 +138,7 @@ lab.experiment('Site Name page tests:', () => {
       lab.test(`POST ${routePath} (existing Site) redirects to the next route ${nextRoutePath}`, async () => {
         postRequest.payload['site-name'] = 'My Site'
         const res = await server.inject(postRequest)
+
         Code.expect(res.statusCode).to.equal(302)
         Code.expect(res.headers['location']).to.equal(nextRoutePath)
       })


### PR DESCRIPTION
This change adds a new createApplicationContext() method to the base controller that is responsible for querying for commonly-used entities that are used within the controllers.

Entities can be queried for by passing in flags to the method and the entities that have been requested are queried for using async queries run in parallel to ensure optimal performance.