### PR TITLE
Handle missing contact email

### DIFF
--- a/src/controllers/applicationReceived.controller.js
+++ b/src/controllers/applicationReceived.controller.js
@@ -13,7 +13,7 @@ module.exports = class ApplicationReceivedController extends BaseController {
     const bacsPayment = await Payment.getByApplicationLineIdAndType(authToken, applicationLineId, Constants.Dynamics.PaymentTypes.BACS_PAYMENT)
 
     pageContext.applicationName = application.applicationName
-    pageContext.contactEmail = contact.email
+    pageContext.contactEmail = contact ? contact.email : 'UNKNOWN EMAIL ADDRESS'
 
     if (bacsPayment) {
       pageContext.bacs = {


### PR DESCRIPTION
Although this situation should never occur once the completeness checks have been implemented on the Task List prior to submission, this change prevents the Application Received page from crashing if there is no contact email specified in the application.