### PR TITLE
BACS Payment screen redirection fix and other improvements

### DIFF
--- a/server.js
+++ b/server.js
@@ -152,14 +152,16 @@ const start = async () => {
   // Load views
   server.views(require('./src/views'))
 
-  server.ext('onPreResponse', (request, reply) => {
+  server.ext('onPreResponse', (request, h) => {
+    const response = request.response
+
     // if the response is a Boom error object and the status code is 404
-    if (request.response.isBoom && request.response.output.statusCode === 404) {
-      return reply.redirect(Constants.Routes.ERROR.PAGE_NOT_FOUND.path)
-    } else if (request.response.isBoom && request.response.output.statusCode === 403) {
-      return reply.redirect(Constants.Routes.ERROR.COOKIES_DISABLED.path)
+    if (response.isBoom && response.output.statusCode === 404) {
+      return h.redirect(Constants.Routes.ERROR.PAGE_NOT_FOUND.path)
+    } else if (response.isBoom && response.output.statusCode === 403) {
+      return h.redirect(Constants.Routes.ERROR.COOKIES_DISABLED.path)
     } else {
-      return reply.continue
+      return h.continue
     }
   })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -349,8 +349,8 @@ Constants.Dynamics = {
     STANDARD: 910400000,
     BESPOKE: 910400001
   },
-  APPLICATION_RECEIVED: 910400000,
   StatusCode: {
+    APPLICATION_RECEIVED: 910400000,
     DRAFT: 1
   },
   TechnicalQualification: {

--- a/src/controllers/address/base/addressManual.controller.js
+++ b/src/controllers/address/base/addressManual.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('../../base.controller')
 const CookieService = require('../../../services/cookie.service')
 
 module.exports = class AddressManualController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -38,12 +38,12 @@ module.exports = class AddressManualController extends BaseController {
       }
     }
 
-    return this.showView(request, reply, 'address/manualEntry', pageContext)
+    return this.showView(request, h, 'address/manualEntry', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
@@ -57,7 +57,7 @@ module.exports = class AddressManualController extends BaseController {
 
       await this.getModel().saveManualAddress(request, authToken, applicationId, applicationLineId, addressDto)
 
-      return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+      return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
     }
   }
 }

--- a/src/controllers/address/base/addressSelect.controller.js
+++ b/src/controllers/address/base/addressSelect.controller.js
@@ -6,12 +6,12 @@ const CookieService = require('../../../services/cookie.service')
 const Address = require('../../../models/address.model')
 
 module.exports = class AddressSelectController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     let addresses, address
@@ -48,12 +48,12 @@ module.exports = class AddressSelectController extends BaseController {
     pageContext.changePostcodeLink = this.getPostcodeRoute()
     pageContext.manualAddressLink = this.getManualEntryRoute()
 
-    return this.showView(request, reply, 'address/selectAddress', pageContext)
+    return this.showView(request, h, 'address/selectAddress', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
@@ -63,7 +63,7 @@ module.exports = class AddressSelectController extends BaseController {
       }
       await this.getModel().saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
 
-      return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+      return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
     }
   }
 }

--- a/src/controllers/address/base/postcode.controller.js
+++ b/src/controllers/address/base/postcode.controller.js
@@ -6,12 +6,12 @@ const CookieService = require('../../../services/cookie.service')
 const Address = require('../../../models/address.model')
 
 module.exports = class PostcodeController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -22,7 +22,7 @@ module.exports = class PostcodeController extends BaseController {
       if (address) {
         // If the manual entry flag is set then redirect off to the mamual address entry page instead
         if (!address.fromAddressLookup) {
-          return this.redirect(request, reply, this.getManualEntryRoute())
+          return this.redirect(request, h, this.getManualEntryRoute())
         }
         pageContext.formValues = {
           postcode: address.postcode
@@ -42,10 +42,10 @@ module.exports = class PostcodeController extends BaseController {
     this.customisePageContext(pageContext)
     pageContext.manualAddressLink = this.getManualEntryRoute()
 
-    return this.showView(request, reply, 'address/postcode', pageContext)
+    return this.showView(request, h, 'address/postcode', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     const {authToken} = await this.createApplicationContext(request)
     const postcode = request.payload['postcode']
     const errorPath = 'postcode'
@@ -69,9 +69,9 @@ module.exports = class PostcodeController extends BaseController {
     }
 
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
-      return this.redirect(request, reply, this.getAddressSelectionPath())
+      return this.redirect(request, h, this.getAddressSelectionPath())
     }
   }
 

--- a/src/controllers/applicationReceived.controller.js
+++ b/src/controllers/applicationReceived.controller.js
@@ -6,7 +6,7 @@ const Payment = require('../models/payment.model')
 const LoggingService = require('../services/logging.service')
 
 module.exports = class ApplicationReceivedController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
 
     const {authToken, applicationId, applicationLineId, application, contact} = await this.createApplicationContext(request, {application: true, contact: true})
@@ -34,10 +34,10 @@ module.exports = class ApplicationReceivedController extends BaseController {
     }
 
     if (bacsPayment || application.isPaidFor()) {
-      return this.showView(request, reply, 'applicationReceived', pageContext)
+      return this.showView(request, h, 'applicationReceived', pageContext)
     } else {
       // If bacs has not been selected for payment and the application has not been paid for
-      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_PAID.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.NOT_PAID.path)
     }
   }
 }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -78,59 +78,59 @@ module.exports = class BaseController {
     }
   }
 
-  redirect (request, reply, viewPath, cookie) {
+  redirect (request, h, viewPath, cookie) {
     if (!cookie) {
       cookie = request.state[Constants.DEFRA_COOKIE_KEY]
     }
-    return reply
+    return h
       .redirect(viewPath)
       .state(Constants.DEFRA_COOKIE_KEY, cookie, Constants.COOKIE_PATH)
   }
 
-  showView (request, reply, viewPath, pageContext, code = 200) {
-    return reply
+  showView (request, h, viewPath, pageContext, code = 200) {
+    return h
       .view(viewPath, pageContext)
       .code(code)
       .state(Constants.DEFRA_COOKIE_KEY, request.state[Constants.DEFRA_COOKIE_KEY], Constants.COOKIE_PATH)
   }
 
-  async _handler (request, reply, errors) {
+  async _handler (request, h, errors) {
     switch (request.method.toUpperCase()) {
       case 'GET':
-        return this.doGet(request, reply, errors)
+        return this.doGet(request, h, errors)
       case 'POST':
         if (this.validator && this.validator.customValidators) {
           // Apply custom validation if required
           errors = await this.validator.customValidate(request.payload, errors)
         }
-        return this.doPost(request, reply, errors)
+        return this.doPost(request, h, errors)
     }
   }
 
-  async handler (request, reply, errors) {
+  async handler (request, h, errors) {
     if (this.cookieValidationRequired) {
       // Validate the cookie
       const cookieValidationResult = await CookieService.validateCookie(request)
 
       if (cookieValidationResult === COOKIE_RESULT.COOKIE_NOT_FOUND) {
-        return reply.redirect(Constants.Routes.ERROR.START_AT_BEGINNING.path)
+        return h.redirect(Constants.Routes.ERROR.START_AT_BEGINNING.path)
       } else if (cookieValidationResult === COOKIE_RESULT.COOKIE_EXPIRED) {
-        return reply.redirect(Constants.Routes.ERROR.TIMEOUT.path)
+        return h.redirect(Constants.Routes.ERROR.TIMEOUT.path)
       } else if (cookieValidationResult === COOKIE_RESULT.APPLICATION_NOT_FOUND) {
-        return reply.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
+        return h.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
       }
     }
     switch (this.route) {
       case Constants.Routes.ERROR:
       case Constants.Routes.PAGE_NOT_FOUND:
-        return this._handler(request, reply, errors)
+        return this._handler(request, h, errors)
       default:
         try {
-          const response = await this._handler(request, reply, errors)
+          const response = await this._handler(request, h, errors)
           return response
         } catch (error) {
           LoggingService.logError(error, request)
-          return reply.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
+          return h.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
         }
     }
   }

--- a/src/controllers/checkBeforeSending.controller.js
+++ b/src/controllers/checkBeforeSending.controller.js
@@ -72,6 +72,7 @@ module.exports = class CheckBeforeSendingController extends BaseController {
     const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
     application.declaration = true
+    application.statusCode = Constants.Dynamics.StatusCode.APPLICATION_RECEIVED
     await application.save(authToken)
 
     return this.redirect(request, reply, Constants.Routes.PAY_TYPE.path)

--- a/src/controllers/checkBeforeSending.controller.js
+++ b/src/controllers/checkBeforeSending.controller.js
@@ -54,7 +54,7 @@ module.exports = class CheckBeforeSendingController extends BaseController {
     return sections.reduce((acc, cur) => acc.concat(cur), [])
   }
 
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
@@ -62,19 +62,19 @@ module.exports = class CheckBeforeSendingController extends BaseController {
 
     // If all the task list items are not complete
     if (!TaskList.isComplete(authToken, application.id)) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_COMPLETE.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.NOT_COMPLETE.path)
     } else {
-      return this.showView(request, reply, 'checkBeforeSending', pageContext)
+      return this.showView(request, h, 'checkBeforeSending', pageContext)
     }
   }
 
-  async doPost (request, reply) {
+  async doPost (request, h) {
     const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
     application.declaration = true
     application.statusCode = Constants.Dynamics.StatusCode.APPLICATION_RECEIVED
     await application.save(authToken)
 
-    return this.redirect(request, reply, Constants.Routes.PAY_TYPE.path)
+    return this.redirect(request, h, Constants.Routes.PAY_TYPE.path)
   }
 }

--- a/src/controllers/checkYourEmail.controller.js
+++ b/src/controllers/checkYourEmail.controller.js
@@ -4,20 +4,20 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class CheckYourEmailController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.formValues = request.payload
-    return this.showView(request, reply, 'checkYourEmail', pageContext)
+    return this.showView(request, h, 'checkYourEmail', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/companyCheckName.controller.js
+++ b/src/controllers/companyCheckName.controller.js
@@ -5,16 +5,16 @@ const BaseController = require('./base.controller')
 const CompanyLookupService = require('../services/companyLookup.service')
 
 module.exports = class CompanyCheckNameController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (!application || !account) {
-      return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+      return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
     }
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     const company = await CompanyLookupService.getCompany(account.companyNumber)
@@ -38,12 +38,12 @@ module.exports = class CompanyCheckNameController extends BaseController {
 
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView(request, reply, 'companyCheckName', pageContext)
+    return this.showView(request, h, 'companyCheckName', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
@@ -66,7 +66,7 @@ module.exports = class CompanyCheckNameController extends BaseController {
 
         await application.save(authToken)
       }
-      return this.redirect(request, reply, Constants.Routes.DIRECTOR_DATE_OF_BIRTH.path)
+      return this.redirect(request, h, Constants.Routes.DIRECTOR_DATE_OF_BIRTH.path)
     }
   }
 }

--- a/src/controllers/companyCheckStatus.controller.js
+++ b/src/controllers/companyCheckStatus.controller.js
@@ -12,17 +12,17 @@ module.exports = class CompanyStatusController extends BaseController {
     this.orginalPageHeading = route.pageHeading
   }
 
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     const company = await CompanyLookupService.getCompany(account.companyNumber)
 
     if (!company) {
-      return this.redirect(request, reply, Constants.Routes.COMPANY_CHECK_NAME.path)
+      return this.redirect(request, h, Constants.Routes.COMPANY_CHECK_NAME.path)
     }
 
     let companyStatus
@@ -32,7 +32,7 @@ module.exports = class CompanyStatusController extends BaseController {
     } else {
       const activeDirectors = await CompanyLookupService.getActiveDirectors(account.companyNumber)
       if (activeDirectors.length) {
-        return this.redirect(request, reply, Constants.Routes.COMPANY_CHECK_NAME.path)
+        return this.redirect(request, h, Constants.Routes.COMPANY_CHECK_NAME.path)
       } else {
         companyStatus = Constants.Company.Status.NO_DIRECTORS
       }
@@ -48,6 +48,6 @@ module.exports = class CompanyStatusController extends BaseController {
     pageContext.companyStatus = companyStatus
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView(request, reply, 'companyCheckStatus', pageContext)
+    return this.showView(request, h, 'companyCheckStatus', pageContext)
   }
 }

--- a/src/controllers/companyCheckType.controller.js
+++ b/src/controllers/companyCheckType.controller.js
@@ -12,12 +12,12 @@ module.exports = class CompanyTypeController extends BaseController {
     this.orginalPageHeading = route.pageHeading
   }
 
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     const company = await CompanyLookupService.getCompany(account.companyNumber)
@@ -25,7 +25,7 @@ module.exports = class CompanyTypeController extends BaseController {
     const companyType = company ? Constants.Company.Type[company.type] : undefined
 
     if (!companyType) {
-      return this.redirect(request, reply, Constants.Routes.COMPANY_CHECK_STATUS.path)
+      return this.redirect(request, h, Constants.Routes.COMPANY_CHECK_STATUS.path)
     }
 
     this.route.pageHeading = Handlebars.compile(this.orginalPageHeading)({
@@ -37,6 +37,6 @@ module.exports = class CompanyTypeController extends BaseController {
     pageContext.companyType = companyType
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView(request, reply, 'companyCheckType', pageContext)
+    return this.showView(request, h, 'companyCheckType', pageContext)
   }
 }

--- a/src/controllers/companyNumber.controller.js
+++ b/src/controllers/companyNumber.controller.js
@@ -6,12 +6,12 @@ const Account = require('../models/account.model')
 const Utilities = require('../utilities/utilities')
 
 module.exports = class CompanyNumberController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -23,12 +23,12 @@ module.exports = class CompanyNumberController extends BaseController {
         }
       }
     }
-    return this.showView(request, reply, 'companyNumber', pageContext)
+    return this.showView(request, h, 'companyNumber', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
@@ -48,7 +48,7 @@ module.exports = class CompanyNumberController extends BaseController {
         await application.save(authToken)
       }
 
-      return this.redirect(request, reply, Constants.Routes.COMPANY_CHECK_TYPE.path)
+      return this.redirect(request, h, Constants.Routes.COMPANY_CHECK_TYPE.path)
     }
   }
 }

--- a/src/controllers/confirmRules.controller.js
+++ b/src/controllers/confirmRules.controller.js
@@ -5,26 +5,26 @@ const BaseController = require('./base.controller')
 const ConfirmRules = require('../models/taskList/confirmRules.model')
 
 module.exports = class ConfirmRulesController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationLineId, application, standardRule} = await this.createApplicationContext(request, {application: true, standardRule: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.guidanceUrl = standardRule.guidanceUrl
     pageContext.code = standardRule.code
     pageContext.isComplete = await ConfirmRules.isComplete(authToken, applicationLineId)
 
-    return this.showView(request, reply, 'confirmRules', pageContext)
+    return this.showView(request, h, 'confirmRules', pageContext)
   }
 
-  async doPost (request, reply) {
+  async doPost (request, h) {
     const {authToken, applicationLineId} = await this.createApplicationContext(request)
 
     await ConfirmRules.updateCompleteness(authToken, applicationLineId)
 
-    return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+    return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
   }
 }

--- a/src/controllers/contactDetails.controller.js
+++ b/src/controllers/contactDetails.controller.js
@@ -8,12 +8,12 @@ const Account = require('../models/account.model')
 const ContactDetails = require('../models/taskList/contactDetails.model')
 
 module.exports = class ContactDetailsController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -38,12 +38,12 @@ module.exports = class ContactDetailsController extends BaseController {
       }
     }
 
-    return this.showView(request, reply, 'contactDetails', pageContext)
+    return this.showView(request, h, 'contactDetails', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
       const {
@@ -97,7 +97,7 @@ module.exports = class ContactDetailsController extends BaseController {
 
       await ContactDetails.updateCompleteness(authToken, applicationId, applicationLineId)
 
-      return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+      return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
     }
   }
 }

--- a/src/controllers/cookies.controller.js
+++ b/src/controllers/cookies.controller.js
@@ -66,9 +66,9 @@ const sections = [
 ]
 
 module.exports = class CookiesController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.sections = sections
-    return this.showView(request, reply, 'cookies', pageContext)
+    return this.showView(request, h, 'cookies', pageContext)
   }
 }

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -4,19 +4,19 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class CostTimeController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    return this.showView(request, reply, 'costTime', pageContext)
+    return this.showView(request, h, 'costTime', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/declaration/base/declarations.controller.js
+++ b/src/controllers/declaration/base/declarations.controller.js
@@ -10,12 +10,12 @@ module.exports = class DeclarationsController extends BaseController {
     this.nextPath = nextRoute.path
   }
 
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     switch (this.route) {
@@ -41,12 +41,12 @@ module.exports = class DeclarationsController extends BaseController {
 
     Object.assign(pageContext, this.getSpecificPageContext())
 
-    return this.showView(request, reply, this.view, pageContext)
+    return this.showView(request, h, this.view, pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
@@ -56,7 +56,7 @@ module.exports = class DeclarationsController extends BaseController {
         await this.updateCompleteness(authToken, applicationId, applicationLineId)
       }
 
-      return this.redirect(request, reply, this.nextPath)
+      return this.redirect(request, h, this.nextPath)
     }
   }
 

--- a/src/controllers/directorDateOfBirth.controller.js
+++ b/src/controllers/directorDateOfBirth.controller.js
@@ -10,16 +10,16 @@ const ApplicationContact = require('../models/applicationContact.model')
 const Contact = require('../models/contact.model')
 
 module.exports = class DirectorDateOfBirthController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const {authToken, applicationId, application, account} = await this.createApplicationContext(request, {application: true, account: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (!account) {
       LoggingService.logError(`Application ${applicationId} does not have an Account`, request)
-      return this.redirect(request, reply, Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
     }
 
     // Get the directors that relate to this application
@@ -56,15 +56,15 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
       }
     }
 
-    return this.showView(request, reply, 'directorDateOfBirth', pageContext)
+    return this.showView(request, h, 'directorDateOfBirth', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     const {authToken, applicationId, account} = await this.createApplicationContext(request, {account: true})
 
     if (!account) {
       LoggingService.logError(`Application ${applicationId} does not have an Account`, request)
-      return this.redirect(request, reply, Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
     }
 
     const directors = await this._getDirectors(authToken, applicationId, account.id)
@@ -73,7 +73,7 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
     errors = await this._validateDynamicFormContent(request, directors)
 
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       // Save Director dates of birth in their corresponding ApplicationContact record
       for (let i = 0; i < directors.length; i++) {
@@ -96,7 +96,7 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
         await applicationContact.save(authToken)
       }
 
-      return this.redirect(request, reply, Constants.Routes.COMPANY_DECLARE_OFFENCES.path)
+      return this.redirect(request, h, Constants.Routes.COMPANY_DECLARE_OFFENCES.path)
     }
   }
 

--- a/src/controllers/drainageTypeDrain.controller.js
+++ b/src/controllers/drainageTypeDrain.controller.js
@@ -5,26 +5,26 @@ const BaseController = require('./base.controller')
 const DrainageTypeDrain = require('../models/taskList/drainageTypeDrain.model')
 
 module.exports = class DrainageTypeDrainController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationLineId, application, standardRule} = await this.createApplicationContext(request, {application: true, standardRule: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.guidanceUrl = standardRule.guidanceUrl
     pageContext.code = standardRule.code
     pageContext.isComplete = await DrainageTypeDrain.isComplete(authToken, applicationLineId)
 
-    return this.showView(request, reply, 'drainageTypeDrain', pageContext)
+    return this.showView(request, h, 'drainageTypeDrain', pageContext)
   }
 
-  async doPost (request, reply) {
+  async doPost (request, h) {
     const {authToken, applicationLineId} = await this.createApplicationContext(request)
 
     await DrainageTypeDrain.updateCompleteness(authToken, applicationLineId)
 
-    return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+    return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
   }
 }

--- a/src/controllers/error/alreadySubmitted.controller.js
+++ b/src/controllers/error/alreadySubmitted.controller.js
@@ -4,13 +4,13 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class AlreadySubmittedController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     pageContext.startOpenOrSavedRoute = Constants.Routes.START_OR_OPEN_SAVED.path
     pageContext.applicationRef = application.applicationNumber
 
-    return this.showView(request, reply, 'error/alreadySubmitted', pageContext)
+    return this.showView(request, h, 'error/alreadySubmitted', pageContext)
   }
 }

--- a/src/controllers/error/cookiesDisabled.controller.js
+++ b/src/controllers/error/cookiesDisabled.controller.js
@@ -4,10 +4,10 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class CookiesDisabledController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.cookieInfoLink = Constants.Routes.COOKIES.path
 
-    return this.showView(request, reply, 'error/cookiesDisabled', pageContext)
+    return this.showView(request, h, 'error/cookiesDisabled', pageContext)
   }
 }

--- a/src/controllers/error/notComplete.controller.js
+++ b/src/controllers/error/notComplete.controller.js
@@ -4,10 +4,10 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class NotCompleteController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.taskListRoute = Constants.Routes.TASK_LIST.path
 
-    return this.showView(request, reply, 'error/notComplete', pageContext)
+    return this.showView(request, h, 'error/notComplete', pageContext)
   }
 }

--- a/src/controllers/error/notPaid.controller.js
+++ b/src/controllers/error/notPaid.controller.js
@@ -4,13 +4,13 @@
 const BaseController = require('../base.controller')
 
 module.exports = class NotPaidController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
     // TODO: We don't know that the payment route is yet
     pageContext.payForApplicationRoute = 'UNKNOWN ROUTE'
     // pageContext.payForApplicationRoute = Constants.Routes.PAY_FOR_APPLICATION.path
 
-    return this.showView(request, reply, 'error/notPaid', pageContext)
+    return this.showView(request, h, 'error/notPaid', pageContext)
   }
 }

--- a/src/controllers/error/notSubmitted.controller.js
+++ b/src/controllers/error/notSubmitted.controller.js
@@ -4,10 +4,10 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class NotSubmittedController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.checkYourAnswersRoute = Constants.Routes.CHECK_BEFORE_SENDING.path
 
-    return this.showView(request, reply, 'error/notSubmitted', pageContext)
+    return this.showView(request, h, 'error/notSubmitted', pageContext)
   }
 }

--- a/src/controllers/error/pageNotFound.controller.js
+++ b/src/controllers/error/pageNotFound.controller.js
@@ -5,7 +5,7 @@ const BaseController = require('../base.controller')
 const CookieService = require('../../services/cookie.service')
 
 module.exports = class PageNotFoundController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
     const {application, applicationLine} = await this.createApplicationContext(request, {application: true, applicationLine: true})
@@ -14,7 +14,7 @@ module.exports = class PageNotFoundController extends BaseController {
     pageContext.taskListRoute = Constants.Routes.TASK_LIST.path
     pageContext.startOpenOrSavedRoute = Constants.Routes.START_OR_OPEN_SAVED.path
 
-    return this.showView(request, reply, 'error/pageNotFound', pageContext, 404)
+    return this.showView(request, h, 'error/pageNotFound', pageContext, 404)
   }
 
   static hasApplication (application, applicationLine) {
@@ -22,12 +22,12 @@ module.exports = class PageNotFoundController extends BaseController {
     return application && applicationLine
   }
 
-  handler (request, reply, errors) {
+  handler (request, h, errors) {
     if (!CookieService.validateCookie(request)) {
       // Re-direct to the start page if they don't have a valid cookie
-      return this.redirect(request, reply, Constants.Routes.START_OR_OPEN_SAVED.path)
+      return this.redirect(request, h, Constants.Routes.START_OR_OPEN_SAVED.path)
     } else {
-      return super.handler(request, reply, errors)
+      return super.handler(request, h, errors)
     }
   }
 }

--- a/src/controllers/error/startAtBeginning.controller.js
+++ b/src/controllers/error/startAtBeginning.controller.js
@@ -4,10 +4,10 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class StartAtBeginningController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.applyForPermitLink = Constants.Routes.START_OR_OPEN_SAVED.path
 
-    return this.showView(request, reply, 'error/startAtBeginning', pageContext)
+    return this.showView(request, h, 'error/startAtBeginning', pageContext)
   }
 }

--- a/src/controllers/error/technicalProblem.controller.js
+++ b/src/controllers/error/technicalProblem.controller.js
@@ -3,9 +3,9 @@
 const BaseController = require('../base.controller')
 
 module.exports = class TechnicalProblemController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
-    return this.showView(request, reply, 'error/technicalProblem', pageContext)
+    return this.showView(request, h, 'error/technicalProblem', pageContext)
   }
 }

--- a/src/controllers/error/timeout.controller.js
+++ b/src/controllers/error/timeout.controller.js
@@ -5,12 +5,12 @@ const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 
 module.exports = class TimeoutController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
     pageContext.startAgainLink = Constants.Routes.START_OR_OPEN_SAVED.path
     pageContext.cookieTimeout = config.cookieTimeout / (1000 * 60 * 60)
 
-    return this.showView(request, reply, 'error/timeout', pageContext)
+    return this.showView(request, h, 'error/timeout', pageContext)
   }
 }

--- a/src/controllers/managementSystem.controller.js
+++ b/src/controllers/managementSystem.controller.js
@@ -4,19 +4,19 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class ManagementSystemController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    return this.showView(request, reply, 'managementSystem', pageContext)
+    return this.showView(request, h, 'managementSystem', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/paymentBacs.controller.js
+++ b/src/controllers/paymentBacs.controller.js
@@ -13,14 +13,6 @@ module.exports = class PaymentBacsController extends BaseController {
       return this.redirect(request, h, Constants.Routes.ERROR.NOT_SUBMITTED.path)
     }
 
-    // TODO confirm if this is needed for BACS screen
-    // returns Boolean(this.paymentReceived)
-
-    // Needs alreadypaid screen??????
-    // if (application.isPaidFor()) {
-    //   return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_PAID.path)
-    // }
-
     return this.showView(request, h, 'paymentBacs', pageContext)
   }
 

--- a/src/controllers/paymentBacs.controller.js
+++ b/src/controllers/paymentBacs.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('./base.controller')
 const Payment = require('../models/payment.model')
 
 module.exports = class PaymentBacsController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (!application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.NOT_SUBMITTED.path)
     }
 
     // TODO confirm if this is needed for BACS screen
@@ -18,13 +18,13 @@ module.exports = class PaymentBacsController extends BaseController {
 
     // Needs alreadypaid screen??????
     // if (application.isPaidFor()) {
-    //   return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_PAID.path)
+    //   return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_PAID.path)
     // }
 
-    return this.showView(request, reply, 'paymentBacs', pageContext)
+    return this.showView(request, h, 'paymentBacs', pageContext)
   }
 
-  async doPost (request, reply) {
+  async doPost (request, h) {
     const {authToken, applicationLine} = await this.createApplicationContext(request, {application: false, applicationLine: true})
 
     const {value = 0} = applicationLine
@@ -35,6 +35,6 @@ module.exports = class PaymentBacsController extends BaseController {
     payment.statusCode = Constants.Dynamics.PaymentStatusCodes.ISSUED
     await payment.save(authToken)
 
-    return this.redirect(request, reply, Constants.Routes.APPLICATION_RECEIVED.path)
+    return this.redirect(request, h, Constants.Routes.APPLICATION_RECEIVED.path)
   }
 }

--- a/src/controllers/paymentBacs.controller.js
+++ b/src/controllers/paymentBacs.controller.js
@@ -9,9 +9,17 @@ module.exports = class PaymentBacsController extends BaseController {
     const pageContext = this.createPageContext()
     const {application} = await this.createApplicationContext(request, {application: true})
 
-    if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+    if (!application.isSubmitted()) {
+      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_SUBMITTED.path)
     }
+
+    // TODO confirm if this is needed for BACS screen
+    // returns Boolean(this.paymentReceived)
+
+    // Needs alreadypaid screen??????
+    // if (application.isPaidFor()) {
+    //   return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_PAID.path)
+    // }
 
     return this.showView(request, reply, 'paymentBacs', pageContext)
   }

--- a/src/controllers/paymentType.controller.js
+++ b/src/controllers/paymentType.controller.js
@@ -9,8 +9,8 @@ module.exports = class PaymentTypeController extends BaseController {
     const pageContext = this.createPageContext(errors)
     const {application, applicationLine} = await this.createApplicationContext(request, {application: true, applicationLine: true})
 
-    if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+    if (!application.isSubmitted()) {
+      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_SUBMITTED.path)
     }
 
     if (request.payload) {

--- a/src/controllers/paymentType.controller.js
+++ b/src/controllers/paymentType.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('./base.controller')
 const {CARD_PAYMENT, BACS_PAYMENT} = Constants.Dynamics.PaymentTypes
 
 module.exports = class PaymentTypeController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application, applicationLine} = await this.createApplicationContext(request, {application: true, applicationLine: true})
 
     if (!application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.NOT_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.NOT_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -29,14 +29,14 @@ module.exports = class PaymentTypeController extends BaseController {
 
     pageContext.cost = value.toLocaleString()
 
-    return this.showView(request, reply, 'paymentType', pageContext)
+    return this.showView(request, h, 'paymentType', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
     let nextPath
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const paymentType = parseInt(request.payload['payment-type'])
       switch (paymentType) {
@@ -49,7 +49,7 @@ module.exports = class PaymentTypeController extends BaseController {
         default:
           throw new Error(`Unexpected payment type (${paymentType})`)
       }
-      return this.redirect(request, reply, nextPath)
+      return this.redirect(request, h, nextPath)
     }
   }
 }

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -4,24 +4,24 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class PermitCategoryController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.formValues = request.payload
 
-    return this.showView(request, reply, 'permitCategory', pageContext)
+    return this.showView(request, h, 'permitCategory', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
-      return this.redirect(request, reply, Constants.Routes.PERMIT_SELECT.path)
+      return this.redirect(request, h, Constants.Routes.PERMIT_SELECT.path)
     }
   }
 }

--- a/src/controllers/permitHolderType.controller.js
+++ b/src/controllers/permitHolderType.controller.js
@@ -4,19 +4,19 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class PermitHolderTypeController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    return this.showView(request, reply, 'permitHolderType', pageContext)
+    return this.showView(request, h, 'permitHolderType', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -7,12 +7,12 @@ const StandardRule = require('../models/standardRule.model')
 const ApplicationLine = require('../models/applicationLine.model')
 
 module.exports = class PermitSelectController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.formValues = request.payload
@@ -20,12 +20,12 @@ module.exports = class PermitSelectController extends BaseController {
     pageContext.standardRules = await StandardRule.list(authToken)
     pageContext.permitCategoryRoute = Constants.Routes.PERMIT_CATEGORY.path
 
-    return this.showView(request, reply, 'permitSelect', pageContext)
+    return this.showView(request, h, 'permitSelect', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId} = await this.createApplicationContext(request)
 
@@ -44,7 +44,7 @@ module.exports = class PermitSelectController extends BaseController {
       // Set the application ID in the cookie
       CookieService.set(request, Constants.COOKIE_KEY.APPLICATION_LINE_ID, applicationLine.id)
 
-      return this.redirect(request, reply, Constants.Routes.TASK_LIST.path)
+      return this.redirect(request, h, Constants.Routes.TASK_LIST.path)
     }
   }
 }

--- a/src/controllers/preApplication.controller.js
+++ b/src/controllers/preApplication.controller.js
@@ -4,19 +4,19 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class PreApplicationController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
-    return this.showView(request, reply, 'preApplication', pageContext)
+    return this.showView(request, h, 'preApplication', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/privacy.controller.js
+++ b/src/controllers/privacy.controller.js
@@ -3,8 +3,8 @@
 const BaseController = require('./base.controller')
 
 module.exports = class PrivacyController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    return this.showView(request, reply, 'privacy', pageContext)
+    return this.showView(request, h, 'privacy', pageContext)
   }
 }

--- a/src/controllers/root.controller.js
+++ b/src/controllers/root.controller.js
@@ -4,8 +4,8 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class RootController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     // For now we are re-directing off to the 'Apply for a standard rules permit' page
-    return this.redirect(request, reply, Constants.Routes.START_OR_OPEN_SAVED.path)
+    return this.redirect(request, h, Constants.Routes.START_OR_OPEN_SAVED.path)
   }
 }

--- a/src/controllers/siteGridReference.controller.js
+++ b/src/controllers/siteGridReference.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('./base.controller')
 const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.model')
 
 module.exports = class SiteGridReferenceController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -21,19 +21,19 @@ module.exports = class SiteGridReferenceController extends BaseController {
         'site-grid-reference': await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
       }
     }
-    return this.showView(request, reply, 'siteGridReference', pageContext)
+    return this.showView(request, h, 'siteGridReference', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
       await SiteNameAndLocation.saveGridReference(request, request.payload['site-grid-reference'],
         authToken, applicationId, applicationLineId)
 
-      return this.redirect(request, reply, Constants.Routes.ADDRESS.POSTCODE_SITE.path)
+      return this.redirect(request, h, Constants.Routes.ADDRESS.POSTCODE_SITE.path)
     }
   }
 }

--- a/src/controllers/siteName.controller.js
+++ b/src/controllers/siteName.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('./base.controller')
 const SiteNameAndLocation = require('../models/taskList/siteNameAndLocation.model')
 
 module.exports = class SiteNameController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationId, applicationLineId, application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -22,18 +22,18 @@ module.exports = class SiteNameController extends BaseController {
       }
     }
 
-    return this.showView(request, reply, 'siteName', pageContext)
+    return this.showView(request, h, 'siteName', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, applicationId, applicationLineId} = await this.createApplicationContext(request)
 
       await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], authToken, applicationId, applicationLineId)
 
-      return this.redirect(request, reply, Constants.Routes.SITE_GRID_REFERENCE.path)
+      return this.redirect(request, h, Constants.Routes.SITE_GRID_REFERENCE.path)
     }
   }
 }

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -6,7 +6,7 @@ const CookieService = require('../services/cookie.service')
 const Application = require('../models/application.model')
 
 module.exports = class StartOrOpenSavedController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
     pageContext.cost = {
@@ -17,17 +17,17 @@ module.exports = class StartOrOpenSavedController extends BaseController {
     pageContext.formValues = request.payload
 
     // For MVP we are only supporting the mobile plant standard rules waste permit
-    // return this.showView(request, reply, 'startOrOpenSaved', pageContext)
+    // return this.showView(request, h, 'startOrOpenSaved', pageContext)
 
-    return this.showView(request, reply, 'startOrOpenSavedMobile', pageContext)
+    return this.showView(request, h, 'startOrOpenSavedMobile', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     }
 
-    const cookie = await CookieService.generateCookie(reply)
+    const cookie = await CookieService.generateCookie(h)
 
     let nextPage
     if (request.payload['started-application'] === 'new') {
@@ -45,6 +45,6 @@ module.exports = class StartOrOpenSavedController extends BaseController {
       nextPage = Constants.Routes.CHECK_YOUR_EMAIL
     }
 
-    return this.redirect(request, reply, nextPage.path, cookie)
+    return this.redirect(request, h, nextPage.path, cookie)
   }
 }

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -33,6 +33,7 @@ module.exports = class StartOrOpenSavedController extends BaseController {
     if (request.payload['started-application'] === 'new') {
       // Create new application in Dynamics and set the applicationId in the cookie
       const application = new Application()
+      application.statusCode = Constants.Dynamics.StatusCode.DRAFT
       await application.save(cookie.authToken)
 
       // Set the application ID in the cookie

--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -5,7 +5,7 @@ const BaseController = require('./base.controller')
 const TaskList = require('../models/taskList/taskList.model')
 
 module.exports = class TaskListController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {authToken, applicationLineId, application, standardRule} = await this.createApplicationContext(request, {application: true, standardRule: true})
 
@@ -13,9 +13,9 @@ module.exports = class TaskListController extends BaseController {
     if (application.isSubmitted()) {
       // If the application has not been paid for
       if (!application.isPaidFor()) {
-        return this.redirect(request, reply, Constants.Routes.ERROR.NOT_PAID.path)
+        return this.redirect(request, h, Constants.Routes.ERROR.NOT_PAID.path)
       } else {
-        return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+        return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
       }
     }
 
@@ -28,11 +28,11 @@ module.exports = class TaskListController extends BaseController {
     // pageContext.permitCategoryRoute = Constants.Routes.PERMIT_CATEGORY.path
     pageContext.permitCategoryRoute = Constants.Routes.PERMIT_SELECT.path
 
-    return this.showView(request, reply, 'taskList', pageContext)
+    return this.showView(request, h, 'taskList', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/controllers/technicalQualification.controller.js
+++ b/src/controllers/technicalQualification.controller.js
@@ -5,12 +5,12 @@ const BaseController = require('./base.controller')
 const {WAMITAB_QUALIFICATION, REGISTERED_ON_A_COURSE, DEEMED_COMPETENCE, ESA_EU_SKILLS} = Constants.Dynamics.TechnicalQualification
 
 module.exports = class TechnicalQualificationController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     if (request.payload) {
@@ -43,19 +43,19 @@ module.exports = class TechnicalQualificationController extends BaseController {
         break
     }
 
-    return this.showView(request, reply, 'technicalQualification', pageContext)
+    return this.showView(request, h, 'technicalQualification', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     if (errors && errors.details) {
-      return this.doGet(request, reply, errors)
+      return this.doGet(request, h, errors)
     } else {
       const {authToken, application} = await this.createApplicationContext(request, {application: true})
 
       application.technicalQualification = request.payload['technical-qualification']
       await application.save(authToken)
 
-      return this.redirect(request, reply, await TechnicalQualificationController._getPath(application.technicalQualification))
+      return this.redirect(request, h, await TechnicalQualificationController._getPath(application.technicalQualification))
     }
   }
 

--- a/src/controllers/version.controller.js
+++ b/src/controllers/version.controller.js
@@ -9,14 +9,14 @@ const CookieService = require('../services/cookie.service')
 const DynamicsSolution = require('../models/dynamicsSolution.model')
 
 module.exports = class VersionController extends BaseController {
-  async doGet (request, reply) {
+  async doGet (request, h) {
     const pageContext = this.createPageContext()
 
     let authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
 
     // If we didn't get an Auth token from the cookie then create a new one
     if (!authToken) {
-      const cookie = await CookieService.generateCookie(reply)
+      const cookie = await CookieService.generateCookie(h)
       authToken = cookie.authToken
     }
 
@@ -27,6 +27,6 @@ module.exports = class VersionController extends BaseController {
     pageContext.githubUrl = `${Constants.GITHUB_LOCATION}/commit/${config.gitSha}`
     pageContext.renderTimestamp = moment().format(Constants.TIMESTAMP_FORMAT)
 
-    return this.showView(request, reply, 'version', pageContext)
+    return this.showView(request, h, 'version', pageContext)
   }
 }

--- a/src/controllers/wasteRecoveryPlan.controller.js
+++ b/src/controllers/wasteRecoveryPlan.controller.js
@@ -4,20 +4,20 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 
 module.exports = class WasteRecoveryPlanController extends BaseController {
-  async doGet (request, reply, errors) {
+  async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     const {application} = await this.createApplicationContext(request, {application: true})
 
     if (application.isSubmitted()) {
-      return this.redirect(request, reply, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
+      return this.redirect(request, h, Constants.Routes.ERROR.ALREADY_SUBMITTED.path)
     }
 
     pageContext.formValues = request.payload
-    return this.showView(request, reply, 'wasteRecoveryPlan', pageContext)
+    return this.showView(request, h, 'wasteRecoveryPlan', pageContext)
   }
 
-  async doPost (request, reply, errors) {
+  async doPost (request, h, errors) {
     // Not implemented yet
-    return this.doGet(request, reply, errors)
+    return this.doGet(request, h, errors)
   }
 }

--- a/src/models/application.model.js
+++ b/src/models/application.model.js
@@ -27,7 +27,7 @@ class Application extends BaseModel {
       {field: 'relevantOffences', dynamics: 'defra_convictionsdeclaration'},
       {field: 'relevantOffencesDetails', dynamics: 'defra_convictionsdeclarationdetails', length: {max: 2000}},
       {field: 'source', dynamics: 'defra_source', constant: Constants.Dynamics.DIGITAL_SOURCE},
-      {field: 'statusCode', dynamics: 'statuscode', constant: Constants.Dynamics.StatusCode.DRAFT},
+      {field: 'statusCode', dynamics: 'statuscode'},
       {field: 'technicalQualification', dynamics: 'defra_technicalability'},
       {field: 'tradingName', dynamics: 'defra_tradingname', length: {max: 170}}
     ]
@@ -55,7 +55,7 @@ class Application extends BaseModel {
   }
 
   isSubmitted () {
-    return this.statusCode && (this.statusCode === Constants.Dynamics.APPLICATION_RECEIVED)
+    return this.statusCode && (this.statusCode === Constants.Dynamics.StatusCode.APPLICATION_RECEIVED)
   }
 
   isPaidFor () {

--- a/src/services/cookie.service.js
+++ b/src/services/cookie.service.js
@@ -12,7 +12,7 @@ module.exports = class CookieService {
     return Date.now() + config.cookieTimeout
   }
 
-  static async generateCookie (reply) {
+  static async generateCookie (h) {
     try {
       // Generate a CRM token
       const authToken = await authService.getToken()
@@ -25,7 +25,7 @@ module.exports = class CookieService {
       }
     } catch (error) {
       LoggingService.logError(error)
-      return reply.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
+      return h.redirect(Constants.Routes.ERROR.TECHNICAL_PROBLEM.path)
     }
   }
 

--- a/test/routes/applicationReceived.route.test.js
+++ b/test/routes/applicationReceived.route.test.js
@@ -70,7 +70,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('ApplicationReceived page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.experiment(`GET ${routePath}`, () => {
     let request

--- a/test/routes/checkBeforeSending.route.test.js
+++ b/test/routes/checkBeforeSending.route.test.js
@@ -87,7 +87,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Check your answers before sending your application page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.experiment(`GET ${routePath}`, () => {
     let request

--- a/test/routes/companyCheckStatus.route.test.js
+++ b/test/routes/companyCheckStatus.route.test.js
@@ -75,7 +75,9 @@ lab.afterEach(() => {
 
 lab.experiment('Check company status page tests:', () => {
   // There is no POST for this route
-  new GeneralTestHelper(lab, routePath).test(false, true, false)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.experiment(`GET ${routePath}`, () => {
     let doc

--- a/test/routes/companyCheckType.route.test.js
+++ b/test/routes/companyCheckType.route.test.js
@@ -90,7 +90,9 @@ lab.afterEach(() => {
 
 lab.experiment('Check company type page tests:', () => {
   // There is no POST for this route
-  new GeneralTestHelper(lab, routePath).test(false, true, false)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.experiment(`GET ${routePath}`, () => {
     let doc

--- a/test/routes/cookies.route.test.js
+++ b/test/routes/cookies.route.test.js
@@ -29,7 +29,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Cookies page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test(`GET ${routePath} success`, async () => {
     const request = {

--- a/test/routes/error/alreadySubmitted.test.js
+++ b/test/routes/error/alreadySubmitted.test.js
@@ -48,7 +48,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Already Submitted page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/cookiesDisabled.route.test.js
+++ b/test/routes/error/cookiesDisabled.route.test.js
@@ -27,7 +27,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Cookies Disabled page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test(`GET ${routePath} returns the disabled cookies page correctly`, async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/notComplete.test.js
+++ b/test/routes/error/notComplete.test.js
@@ -41,7 +41,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Not Complete page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/notPaid.test.js
+++ b/test/routes/error/notPaid.test.js
@@ -41,7 +41,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Not Paid page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/notSubmitted.test.js
+++ b/test/routes/error/notSubmitted.test.js
@@ -41,7 +41,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Not Submitted page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/pageNotFound.route.test.js
+++ b/test/routes/error/pageNotFound.route.test.js
@@ -46,7 +46,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Page Not Found (404) page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/startAtBeginning.test.js
+++ b/test/routes/error/startAtBeginning.test.js
@@ -41,7 +41,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Start at Beginning page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/technicalProblem.route.test.js
+++ b/test/routes/error/technicalProblem.route.test.js
@@ -26,7 +26,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Technical Problem page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test(`GET ${routePath} returns the technical problem page correctly`, async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/error/timeout.route.test.js
+++ b/test/routes/error/timeout.route.test.js
@@ -27,7 +27,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Timeout page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/generalTestHelper.test.js
+++ b/test/routes/generalTestHelper.test.js
@@ -39,7 +39,10 @@ module.exports = class GeneralTestHelper {
     Code.expect(doc.getElementById(`${fieldId}-error`).firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
   }
 
-  test (excludeCookieGetTests = false, excludeCookiePostTests = false, excludeAlreadySubnmittedTest = false) {
+  test (options = {
+          excludeCookieGetTests: false,
+          excludeCookiePostTests: false,
+          excludeAlreadySubnmittedTest: false}) {
     const {lab, routePath} = this
 
     lab.beforeEach(() => {
@@ -60,7 +63,7 @@ module.exports = class GeneralTestHelper {
     lab.afterEach(() => { })
 
     lab.experiment('General tests:', () => {
-      if (!excludeCookieGetTests) {
+      if (!options.excludeCookieGetTests) {
         lab.test(`GET ${routePath} redirects to timeout screen when the cookie is not found`, async () => {
           CookieService.validateCookie = () => COOKIE_RESULT.COOKIE_NOT_FOUND
 
@@ -78,7 +81,7 @@ module.exports = class GeneralTestHelper {
         })
       }
 
-      if (!excludeCookiePostTests) {
+      if (!options.excludeCookiePostTests) {
         lab.test(`POST ${routePath} redirects to timeout screen when the cookie is not found`, async () => {
           CookieService.validateCookie = () => COOKIE_RESULT.COOKIE_NOT_FOUND
 
@@ -96,7 +99,7 @@ module.exports = class GeneralTestHelper {
         })
       }
 
-      if (!excludeAlreadySubnmittedTest) {
+      if (!options.excludeAlreadySubnmittedTest) {
         lab.test('Redirects to the Already Submitted screen if the application has already been submitted', async () => {
           Application.prototype.isSubmitted = () => true
 

--- a/test/routes/privacy.route.test.js
+++ b/test/routes/privacy.route.test.js
@@ -29,7 +29,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Privacy page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test(`GET ${routePath} success`, async () => {
     const request = {

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -56,7 +56,10 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Start or Open Saved page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(true, true, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.experiment('General page tests:', () => {
     lab.test('The page should NOT have a back link', async () => {

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -274,7 +274,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Task List page tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, false, true)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   lab.test('The page should NOT have a back link', async () => {
     const res = await server.inject(getRequest)

--- a/test/routes/upload/firePreventionPlan/firePreventionPlan.route.test.js
+++ b/test/routes/upload/firePreventionPlan/firePreventionPlan.route.test.js
@@ -38,7 +38,9 @@ lab.afterEach(() => {
 })
 
 lab.experiment('FirePrevention Upload FirePrevention plan tests:', () => {
-  new GeneralTestHelper(lab, routePath).test(false, true, false)
+  new GeneralTestHelper(lab, routePath).test({
+    excludeCookiePostTests: true,
+    excludeAlreadySubnmittedTest: true})
 
   const {uploadPath, removePath} = paths
 

--- a/test/routes/upload/sitePlan/sitePlan.route.test.js
+++ b/test/routes/upload/sitePlan/sitePlan.route.test.js
@@ -38,7 +38,8 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Site Upload Site plan tests:', () => {
-  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test(false, true, false)
+  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test({
+    excludeCookiePostTests: true})
 
   const {uploadPath, removePath} = paths
 

--- a/test/routes/upload/technicalQualification/courseRegistration.route.test.js
+++ b/test/routes/upload/technicalQualification/courseRegistration.route.test.js
@@ -45,7 +45,8 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Company Declare Upload Course registration tests:', () => {
-  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test(false, true, false)
+  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test({
+    excludeCookiePostTests: true})
 
   const {uploadPath, removePath} = paths
 

--- a/test/routes/upload/technicalQualification/deemedEvidence.route.test.js
+++ b/test/routes/upload/technicalQualification/deemedEvidence.route.test.js
@@ -38,7 +38,8 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Company Declare Upload Deemed evidence tests:', () => {
-  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test(false, true, false)
+  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test({
+    excludeCookiePostTests: true})
 
   const {uploadPath, removePath} = paths
 

--- a/test/routes/upload/technicalQualification/esaEuSkills.route.test.js
+++ b/test/routes/upload/technicalQualification/esaEuSkills.route.test.js
@@ -38,7 +38,8 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Company Declare Upload ESA EU skills tests:', () => {
-  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test(false, true, false)
+  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test({
+    excludeCookiePostTests: true})
 
   const {uploadPath, removePath} = paths
 

--- a/test/routes/upload/technicalQualification/wamitabQualification.route.test.js
+++ b/test/routes/upload/technicalQualification/wamitabQualification.route.test.js
@@ -38,7 +38,8 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Company Declare Upload Wamitab tests:', () => {
-  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test(false, true, false)
+  new GeneralTestHelper(lab, paths.routePath, paths.nextRoutePath).test({
+    excludeCookiePostTests: true})
 
   const {uploadPath, removePath} = paths
 


### PR DESCRIPTION
Fixed BACS payment screen so that it redirects to the 'not submitted' error screen if the application has not been submitted.

Refactored General test helper to accept options as a single object rather than multiple booleans.

Following the Hapi 17 upgrade, replaced references to 'reply' with 'h' (response toolkit) https://hapijs.com/api#response-toolkit