### PR TITLE
Display permits for a category in permit select

### DIFF
--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -4,6 +4,7 @@ const Constants = require('../constants')
 const BaseController = require('./base.controller')
 const CookieService = require('../services/cookie.service')
 const StandardRule = require('../models/standardRule.model')
+const StandardRuleType = require('../models/standardRuleType.model')
 const ApplicationLine = require('../models/applicationLine.model')
 
 module.exports = class PermitSelectController extends BaseController {
@@ -18,7 +19,11 @@ module.exports = class PermitSelectController extends BaseController {
 
     pageContext.formValues = request.payload
 
-    pageContext.standardRules = await StandardRule.list(authToken)
+    const standardRuleTypeId = CookieService.get(request, Constants.COOKIE_KEY.STANDARD_RULE_TYPE_ID)
+    const {category = 'all categories'} = await StandardRuleType.getById(authToken, standardRuleTypeId)
+    pageContext.category = category
+
+    pageContext.standardRules = await StandardRule.list(authToken, standardRuleTypeId)
     pageContext.permitCategoryRoute = Constants.Routes.PERMIT_CATEGORY.path
 
     return this.showView(request, h, 'permitSelect', pageContext)
@@ -32,6 +37,10 @@ module.exports = class PermitSelectController extends BaseController {
 
       // Look up the Standard Rule based on the chosen permit type
       const standardRule = await StandardRule.getByCode(authToken, request.payload['chosen-permit'])
+
+      if (!standardRule.canApplyOnline) {
+        return this.redirect(request, h, Constants.Routes.APPLY_OFFLINE.path)
+      }
 
       // Create a new Application Line in Dynamics and set the applicationLineId in the cookie
       const applicationLine = new ApplicationLine({

--- a/src/models/account.model.js
+++ b/src/models/account.model.js
@@ -21,18 +21,6 @@ class Account extends BaseModel {
     ]
   }
 
-  static async getById (authToken, id) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const query = `accounts(${id})?$select=${Account.selectedDynamicsFields()}`
-    try {
-      const result = await dynamicsDal.search(query)
-      return Account.dynamicsToModel(result)
-    } catch (error) {
-      LoggingService.logError(`Unable to get Account by ID: ${error}`)
-      throw error
-    }
-  }
-
   static async getByApplicationId (authToken, applicationId) {
     const dynamicsDal = new DynamicsDalService(authToken)
     const application = await Application.getById(authToken, applicationId)

--- a/src/models/address.model.js
+++ b/src/models/address.model.js
@@ -23,22 +23,6 @@ class Address extends BaseModel {
     ]
   }
 
-  static async getById (authToken, id) {
-    let address
-    if (id) {
-      const dynamicsDal = new DynamicsDalService(authToken)
-      const query = `defra_addresses(${id})`
-      try {
-        const result = await dynamicsDal.search(query)
-        address = Address.dynamicsToModel(result)
-      } catch (error) {
-        LoggingService.logError(`Unable to get Address ID: ${error}`)
-        throw error
-      }
-    }
-    return address
-  }
-
   static async getByUprn (authToken, uprn) {
     if (!authToken) {
       const errorMessage = `Unable to get ${this._entity} by UPRN: Auth Token not supplied`

--- a/src/models/annotation.model.js
+++ b/src/models/annotation.model.js
@@ -19,18 +19,6 @@ class Annotation extends BaseModel {
     ]
   }
 
-  static async getById (authToken, id) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const query = `annotations(${id})?$select=${Annotation.selectedDynamicsFields()}`
-    try {
-      const result = await dynamicsDal.search(query)
-      return Annotation.dynamicsToModel(result)
-    } catch (error) {
-      LoggingService.logError(`Unable to get Annotation by ID: ${error}`)
-      throw error
-    }
-  }
-
   static async listByApplicationIdAndSubject (authToken, applicationId, subject) {
     if (applicationId) {
       const dynamicsDal = new DynamicsDalService(authToken)

--- a/src/models/application.model.js
+++ b/src/models/application.model.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Constants = require('../constants')
-const DynamicsDalService = require('../services/dynamicsDal.service')
 const BaseModel = require('./base.model')
 const LoggingService = require('../services/logging.service')
 
@@ -37,21 +36,6 @@ class Application extends BaseModel {
     super(...args)
     const declaration = {args}
     this.declaration = Boolean(declaration)
-  }
-
-  static async getById (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const query = encodeURI(`defra_applications(${applicationId})?$select=${Application.selectedDynamicsFields()}`)
-    try {
-      const result = await dynamicsDal.search(query)
-      const application = Application.dynamicsToModel(result)
-      application.id = applicationId
-
-      return application
-    } catch (error) {
-      LoggingService.logError(`Unable to get Application by applicationId: ${error}`)
-      throw error
-    }
   }
 
   isSubmitted () {

--- a/src/models/applicationLine.model.js
+++ b/src/models/applicationLine.model.js
@@ -21,20 +21,6 @@ class ApplicationLine extends BaseModel {
     ]
   }
 
-  static async getById (authToken, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const query = encodeURI(`defra_applicationlines(${applicationLineId})`)
-    try {
-      const result = await dynamicsDal.search(query)
-      const applicationLine = ApplicationLine.dynamicsToModel(result)
-      applicationLine.id = applicationLineId
-      return applicationLine
-    } catch (error) {
-      LoggingService.logError(`Unable to get ApplicationLine by Id: ${error}`)
-      throw error
-    }
-  }
-
   static async getValidRulesetIds (authToken, applicationLineId) {
     const dynamicsDal = new DynamicsDalService(authToken)
     const rulesetIds = Object.keys(RulesetIds).map((prop) => RulesetIds[prop])

--- a/src/models/base.model.js
+++ b/src/models/base.model.js
@@ -239,6 +239,24 @@ module.exports = class BaseModel {
     return !this.id
   }
 
+  static async getById (authToken, id, customFilter = () => true) {
+    // See the explanation of a custom filter in the method selectedDynamicsFields above
+    let model
+    if (id) {
+      const dynamicsDal = new DynamicsDalService(authToken)
+      const query = `${this.entity}(${id})`
+      try {
+        const result = await dynamicsDal.search(query)
+        model = this.dynamicsToModel(result, customFilter)
+        model.id = id
+      } catch (error) {
+        LoggingService.logError(`Unable to get ${this.name} ID: ${error}`)
+        throw error
+      }
+    }
+    return model
+  }
+
   async _deleteBoundReferences (dynamicsDal) {
     // This method deletes any bound references as specified in the mapping method if the new value of any key is undefined.
     //

--- a/src/models/contact.model.js
+++ b/src/models/contact.model.js
@@ -24,15 +24,7 @@ class Contact extends BaseModel {
   }
 
   static async getById (authToken, id) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const query = `contacts(${id})?$select=${Contact.selectedDynamicsFields((field) => field !== 'defra_dateofbirthdaycompanieshouse')}`
-    try {
-      const result = await dynamicsDal.search(query)
-      return Contact.dynamicsToModel(result)
-    } catch (error) {
-      LoggingService.logError(`Unable to get Contact by ID: ${error}`)
-      throw error
-    }
+    return super.getById(authToken, id, ({dynamics}) => dynamics !== 'defra_dateofbirthdaycompanieshouse')
   }
 
   static async list (authToken, accountId = undefined, contactType = Constants.Dynamics.COMPANY_DIRECTOR) {

--- a/src/models/standardRuleType.model.js
+++ b/src/models/standardRuleType.model.js
@@ -2,9 +2,8 @@
 
 const {OFFLINE_CATEGORIES} = require('../constants')
 const BaseModel = require('./base.model')
-// TODO: Fake online categories until the crm contains them
-// const DynamicsDalService = require('../services/dynamicsDal.service')
-// const LoggingService = require('../services/logging.service')
+const DynamicsDalService = require('../services/dynamicsDal.service')
+const LoggingService = require('../services/logging.service')
 
 class StandardRuleType extends BaseModel {
   static get entity () {
@@ -25,27 +24,19 @@ class StandardRuleType extends BaseModel {
   }
 
   static async list (authToken) {
-    // TODO: Fake online categories until the crm contains them
-    return [new StandardRuleType({
-      id: 'dummy-category',
-      category: 'Dummy category',
-      hint: 'Select this to go to permit select page',
-      categoryName: 'Dummy'
-    })]
-    //
-    // const dynamicsDal = new DynamicsDalService(authToken)
-    // const orderBy = 'defra_category asc'
-    //
-    // const query = encodeURI(`defra_standardruletypes?$select=${StandardRuleType.selectedDynamicsFields()}&$orderby=${orderBy}`)
-    // try {
-    //   const response = await dynamicsDal.search(query)
-    //
-    //   // Parse response into Standard Rule Type objects
-    //   return response.value.map((standardRuleType) => StandardRuleType.dynamicsToModel(standardRuleType))
-    // } catch (error) {
-    //   LoggingService.logError(`Unable to list StandardRuleTypes: ${error}`)
-    //   throw error
-    // }
+    const dynamicsDal = new DynamicsDalService(authToken)
+    const orderBy = 'defra_category asc'
+
+    const query = encodeURI(`defra_standardruletypes?$select=${StandardRuleType.selectedDynamicsFields()}&$orderby=${orderBy}`)
+    try {
+      const response = await dynamicsDal.search(query)
+
+      // Parse response into Standard Rule Type objects
+      return response.value.map((standardRuleType) => StandardRuleType.dynamicsToModel(standardRuleType))
+    } catch (error) {
+      LoggingService.logError(`Unable to list StandardRuleTypes: ${error}`)
+      throw error
+    }
   }
 
   static async getCategories (authToken) {

--- a/src/validators/permitSelect.validator.js
+++ b/src/validators/permitSelect.validator.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Joi = require('joi')
-const Constants = require('../constants')
 const BaseValidator = require('./base.validator')
 
 module.exports = class PermitSelectValidator extends BaseValidator {
@@ -10,8 +9,7 @@ module.exports = class PermitSelectValidator extends BaseValidator {
 
     this.errorMessages = {
       'chosen-permit': {
-        'any.required': `Select the permit you want`,
-        'any.allowOnly': `Select a valid permit`
+        'any.required': `Select the permit you want`
       }
     }
   }
@@ -21,7 +19,6 @@ module.exports = class PermitSelectValidator extends BaseValidator {
       'chosen-permit': Joi
         .string()
         .required()
-        .valid(Constants.ALLOWED_PERMITS)
     }
   }
 }

--- a/src/views/applyOffline.html
+++ b/src/views/applyOffline.html
@@ -2,6 +2,8 @@
 
   {{> common/betaBanner }}
 
+  {{> common/backLink }}
+
   <div class="grid-row">
     <div class="column-two-thirds">
 

--- a/src/views/permitCategory.html
+++ b/src/views/permitCategory.html
@@ -2,6 +2,8 @@
 
   {{> common/betaBanner }}
 
+  {{> common/backLink }}
+
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -22,15 +24,10 @@
             <div class="multiple-choice">
               <input id="chosen-category-{{this.categoryName}}-input" type="radio" name="chosen-category" value="{{this.id}}">
               <label id="chosen-category-{{this.categoryName}}-label" class="selection-button-radio" for="chosen-category-{{this.categoryName}}-input">
-                <span id="chosen-category-{{this.categoryName}}-category">
-                  {{this.category}}
+                <span id="chosen-category-{{this.categoryName}}-category">{{this.category}}</span>
                   {{#if this.hint}}
-                  <br>
-                  <span class="text-secondary" id="chosen-category-{{this.categoryName}}-hint">
-                    {{this.hint}}
-                  </span>
+                  <span id="chosen-category-{{this.categoryName}}-hint">{{this.hint}}</span>
                   {{/if}}
-                </span>
               </label>
             </div>
             {{/each}}

--- a/src/views/permitSelect.html
+++ b/src/views/permitSelect.html
@@ -2,6 +2,8 @@
 
   {{> common/betaBanner }}
 
+  {{> common/backLink }}
+
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -15,15 +17,7 @@
         <fieldset aria-labelledby="permit-select-heading">
           <legend class="visuallyhidden">{{ pageHeading }}</legend>
 
-          <!-- Not in use for MVP
-          <div class="panel panel-border-wide">
-            <p id="select-permit-hint-text">Showing permits for <span id="permit-type-description">DESCRIPTION HERE</span>.
-                <a id="back-to-all-permit-groups-link" href="/{{ permitCategoryRoute }}">
-                Back to all permit groups
-              </a>
-            </p>
-          </div>
-           -->
+          <p id="select-permit-hint-text">Showing permits for <span id="permit-type-description">{{category}}</span>.</p>
 
           <div id="chosen-permit" class="form-group {{#getFormErrorGroupClass errors.chosen-permit}}{{/getFormErrorGroupClass}}">
             {{> common/fieldError fieldId='chosen-permit-error' message=errors.chosen-permit }}
@@ -34,10 +28,12 @@
               <label id="chosen-permit-{{this.codeForId}}-label" class="selection-button-radio permit-item" for="chosen-permit-{{this.codeForId}}-input">
                 <span id="chosen-permit-{{this.codeForId}}-name" class="permit-name">
                   {{this.permitName}}
+                  {{#if this.limits}}
                   <br>
                   <span id="chosen-permit-{{this.codeForId}}-weight" class="permit-weight">
                     {{this.limits}}
                   </span>
+                  {{/if}}
                 </span>
                 <span id="chosen-permit-{{this.codeForId}}-code" class="permit-code">{{this.code}}</span>
               </label>

--- a/test/models/annotation.model.test.js
+++ b/test/models/annotation.model.test.js
@@ -66,10 +66,10 @@ lab.experiment('Annotation Model tests:', () => {
   lab.test('getById() method correctly retrieves an Annotation object', async () => {
     DynamicsDalService.prototype.search = () => fakeDynamicsRecord()
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const annotation = await Annotation.getById('AUTH_TOKEN', fakeApplication.id)
+    const annotation = await Annotation.getById('AUTH_TOKEN', testAnnotationId)
     Code.expect(spy.callCount).to.equal(1)
     Code.expect(annotation.applicationId).to.equal(fakeAnnotation.applicationId)
-    Code.expect(annotation.id).to.equal(fakeAnnotation.id)
+    Code.expect(annotation.id).to.equal(testAnnotationId)
   })
 
   lab.test('listByApplicationIdAndSubject() method returns a list of Annotation objects', async () => {

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -91,23 +91,34 @@ lab.afterEach(() => {
 
 lab.experiment('Contact Model tests:', () => {
   lab.test('getById() method returns a single Contact object', async () => {
+    const dynamicsData = {
+      '@odata.etag': 'W/"1155486"',
+      contactid: '7a8e4354-4f24-e711-80fd-5065f38a1b01',
+      firstname: 'Marlon',
+      lastname: 'Herzog',
+      telephone1: '055 8767 0835',
+      emailaddress1: 'Amparo.Abbott49@example.com',
+      defra_dateofbirthdaycompanieshouse: 1,
+      defra_dobmonthcompanieshouse: 2,
+      defra_dobyearcompanieshouse: 1970
+    }
     DynamicsDalService.prototype.search = () => {
       // Dynamics Contact objects
-      return {
-        '@odata.etag': 'W/"1155486"',
-        contactid: '7a8e4354-4f24-e711-80fd-5065f38a1b01',
-        firstname: 'Marlon',
-        lastname: 'Herzog',
-        telephone1: '055 8767 0835',
-        emailaddress1: 'Amparo.Abbott49@example.com',
-        defra_dateofbirthdaycompanieshouse: 1,
-        defra_dobmonthcompanieshouse: 2,
-        defra_dobyearcompanieshouse: 1970
-      }
+      return dynamicsData
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    await Contact.getById()
+    const contact = await Contact.getById('AUTH_TOKEN', dynamicsData.contactid)
+    Code.expect(contact).to.equal({
+      id: dynamicsData.contactid,
+      firstName: dynamicsData.firstname,
+      lastName: dynamicsData.lastname,
+      email: dynamicsData.emailaddress1,
+      dob: {
+        month: dynamicsData.defra_dobmonthcompanieshouse,
+        year: dynamicsData.defra_dobyearcompanieshouse
+      }
+    })
     Code.expect(spy.callCount).to.equal(1)
   })
 

--- a/test/models/standardRuleType.model.test.js
+++ b/test/models/standardRuleType.model.test.js
@@ -3,7 +3,7 @@
 const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
-// const sinon = require('sinon')
+const sinon = require('sinon')
 
 const StandardRuleType = require('../../src/models/standardRuleType.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
@@ -17,16 +17,15 @@ const fakeStandardRuleType = {
   categoryName: 'STANDARD_RULE_TYPE_NAME'
 }
 
-// TODO: Re-activate once the defra_standardruletypes entity in dynamics contains the defra_category and defra_hint fields
-// const fakeDynamicsRecord = (options = {}) => {
-//   const standardRuleType = Object.assign({}, fakeStandardRuleType, options)
-//   return {
-//     defra_name: standardRuleType.categoryName,
-//     defra_category: standardRuleType.category,
-//     defra_hint: standardRuleType.hint,
-//     defra_standardruletypeid: standardRuleType.id
-//   }
-// }
+const fakeDynamicsRecord = (options = {}) => {
+  const standardRuleType = Object.assign({}, fakeStandardRuleType, options)
+  return {
+    defra_name: standardRuleType.categoryName,
+    defra_category: standardRuleType.category,
+    defra_hint: standardRuleType.hint,
+    defra_standardruletypeid: standardRuleType.id
+  }
+}
 
 lab.beforeEach(() => {
   // Stub methods
@@ -39,70 +38,69 @@ lab.afterEach(() => {
 })
 
 lab.experiment('StandardRuleType Model tests:', () => {
-  // TODO: Re-activate these tests once the defra_standardruletypes entity in dynamics contains the defra_category and defra_hint fields
-  // lab.test('list() method returns a list of StandardRuleType objects', async () => {
-  //   const categories = ['Electrical', 'Metal', 'Plastic']
-  //   DynamicsDalService.prototype.search = () => {
-  //     return {
-  //       value: categories.map((category) => fakeDynamicsRecord({category}))
-  //     }
-  //   }
-  //
-  //   const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-  //   const standardRuleList = await StandardRuleType.list()
-  //   Code.expect(Array.isArray(standardRuleList)).to.be.true()
-  //   Code.expect(standardRuleList.length).to.equal(categories.length)
-  //   standardRuleList.forEach((standardRuleType, index) => {
-  //     Code.expect(standardRuleType).to.equal(Object.assign({}, fakeStandardRuleType, {category: categories[index]}))
-  //   })
-  //   Code.expect(spy.callCount).to.equal(1)
-  // })
-  //
-  // lab.test('getCategories() method returns a list of sorted online and offline Category objects', async () => {
-  //   const categories = ['Electrical', 'Metal', 'Plastic']
-  //
-  //   const offlineCategories = [
-  //     {categoryName: 'Flood', category: 'Flood risk activities'},
-  //     {categoryName: 'Radioactive', category: 'Radioactive substances for non-nuclear sites'},
-  //     {categoryName: 'Water', category: 'Water discharges'}
-  //   ]
-  //
-  //   DynamicsDalService.prototype.search = () => {
-  //     return {
-  //       value: categories.map((category) => fakeDynamicsRecord({category}))
-  //     }
-  //   }
-  //
-  //   const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-  //   const standardRuleList = await StandardRuleType.getCategories()
-  //   Code.expect(Array.isArray(standardRuleList)).to.be.true()
-  //   Code.expect(standardRuleList.length).to.equal(categories.length + offlineCategories.length)
-  //   let onlineIndex = 0
-  //   let offlineIndex = 0
-  //   standardRuleList.forEach((standardRuleType) => {
-  //     if (categories.indexOf(standardRuleType.category) !== -1) {
-  //       // Online category
-  //       Code.expect(standardRuleType).to.equal({
-  //         id: fakeStandardRuleType.id,
-  //         categoryName: fakeStandardRuleType.categoryName.toLowerCase(),
-  //         category: categories[onlineIndex],
-  //         hint: fakeStandardRuleType.hint
-  //       })
-  //       onlineIndex++
-  //     } else {
-  //       // Offline category
-  //       const {category, categoryName} = offlineCategories[offlineIndex]
-  //       Code.expect(standardRuleType).to.equal({
-  //         id: `offline-category-${categoryName.toLowerCase()}`,
-  //         categoryName,
-  //         category,
-  //         hint: ''
-  //       })
-  //       offlineIndex++
-  //     }
-  //   })
-  //   Code.expect(spy.callCount).to.equal(1)
-  // })
+  lab.test('list() method returns a list of StandardRuleType objects', async () => {
+    const categories = ['Electrical', 'Metal', 'Plastic']
+    DynamicsDalService.prototype.search = () => {
+      return {
+        value: categories.map((category) => fakeDynamicsRecord({category}))
+      }
+    }
+
+    const spy = sinon.spy(DynamicsDalService.prototype, 'search')
+    const standardRuleList = await StandardRuleType.list()
+    Code.expect(Array.isArray(standardRuleList)).to.be.true()
+    Code.expect(standardRuleList.length).to.equal(categories.length)
+    standardRuleList.forEach((standardRuleType, index) => {
+      Code.expect(standardRuleType).to.equal(Object.assign({}, fakeStandardRuleType, {category: categories[index]}))
+    })
+    Code.expect(spy.callCount).to.equal(1)
+  })
+
+  lab.test('getCategories() method returns a list of sorted online and offline Category objects', async () => {
+    const categories = ['Electrical', 'Metal', 'Plastic']
+
+    const offlineCategories = [
+      {categoryName: 'Flood', category: 'Flood risk activities'},
+      {categoryName: 'Radioactive', category: 'Radioactive substances for non-nuclear sites'},
+      {categoryName: 'Water', category: 'Water discharges'}
+    ]
+
+    DynamicsDalService.prototype.search = () => {
+      return {
+        value: categories.map((category) => fakeDynamicsRecord({category}))
+      }
+    }
+
+    const spy = sinon.spy(DynamicsDalService.prototype, 'search')
+    const standardRuleList = await StandardRuleType.getCategories()
+    Code.expect(Array.isArray(standardRuleList)).to.be.true()
+    Code.expect(standardRuleList.length).to.equal(categories.length + offlineCategories.length)
+    let onlineIndex = 0
+    let offlineIndex = 0
+    standardRuleList.forEach((standardRuleType) => {
+      if (categories.indexOf(standardRuleType.category) !== -1) {
+        // Online category
+        Code.expect(standardRuleType).to.equal({
+          id: fakeStandardRuleType.id,
+          categoryName: fakeStandardRuleType.categoryName.toLowerCase(),
+          category: categories[onlineIndex],
+          hint: fakeStandardRuleType.hint
+        })
+        onlineIndex++
+      } else {
+        // Offline category
+        const {category, categoryName} = offlineCategories[offlineIndex]
+        Code.expect(standardRuleType).to.equal({
+          id: `offline-category-${categoryName.toLowerCase()}`,
+          categoryName,
+          category,
+          hint: ''
+        })
+        offlineIndex++
+      }
+    })
+    Code.expect(spy.callCount).to.equal(1)
+  })
 
   lab.test('save() method should fail as this entity is readOnly', async () => {
     let error

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -93,12 +93,6 @@ lab.experiment('What do you want the permit for? (permit category) page tests:',
       }
     })
 
-    lab.test('The page should NOT have a back link', async () => {
-      const doc = await getDoc(getRequest)
-      checkCommonElements(doc)
-      Code.expect(doc.getElementById('back-link')).to.not.exist()
-    })
-
     lab.experiment('success', () => {
       let categories
 
@@ -184,20 +178,10 @@ lab.experiment('What do you want the permit for? (permit category) page tests:',
       Code.expect(res.headers['location']).to.equal(nextRoutePath)
     })
 
-    lab.experiment('invalid', () => {
-      const checkValidationMessage = async (fieldId, expectedErrorMessage) => {
-        const doc = await getDoc(postRequest)
-        // Panel summary error item
-        Code.expect(doc.getElementById('error-summary-list-item-0').firstChild.nodeValue).to.equal(expectedErrorMessage)
-
-        // Chosen category field error
-        Code.expect(doc.getElementById(`${fieldId}-error`).firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
-      }
-
-      lab.test('when category not selected', async () => {
-        postRequest.payload = {}
-        await checkValidationMessage('chosen-category', 'Select what you want the permit for')
-      })
+    lab.test('invalid when category not selected', async () => {
+      postRequest.payload = {}
+      const doc = await getDoc(postRequest)
+      await GeneralTestHelper.checkValidationMessage(doc, 'chosen-category', 'Select what you want the permit for')
     })
   })
 })

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -9,46 +9,45 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 const CookieService = require('../../src/services/cookie.service')
+const LoggingService = require('../../src/services/logging.service')
 
-const StandardRule = require('../../src/models/standardRule.model')
 const Application = require('../../src/models/application.model')
 const ApplicationLine = require('../../src/models/applicationLine.model')
 const Payment = require('../../src/models/payment.model')
+const StandardRule = require('../../src/models/standardRule.model')
+const StandardRuleType = require('../../src/models/standardRuleType.model')
 const {COOKIE_RESULT} = require('../../src/constants')
-
-let sandbox
 
 const routePath = '/permit/select'
 const nextRoutePath = '/task-list'
+const offlineRoutePath = '/start/apply-offline'
+const errorPath = '/errors/technical-problem'
 
-const getRequest = {
-  method: 'GET',
-  url: routePath,
-  headers: {},
-  payload: {}
-}
-
-let postRequest
-
-const fakeApplication = {
-  id: 'APPLICATION_ID',
-  applicationName: 'APPLICATION_NAME'
-}
-
-const fakeStandardRule = {
-  id: 'bd610c23-8ba7-e711-810a-5065f38a5b01',
-  permitName: 'Metal recycling, vehicle storage, depollution and dismantling facility',
-  limits: 'Less than 25,000 tonnes a year of waste metal and less than 5,000 tonnes a year of waste motor vehicles',
-  code: 'SR2015 No 18',
-  codeForId: 'sr2015-no-18'
-}
+let fakeApplication
+let fakeStandardRule
+let fakeStandardRuleType
+let sandbox
 
 lab.beforeEach(() => {
-  postRequest = {
-    method: 'POST',
-    url: routePath,
-    headers: {},
-    payload: {}
+  fakeApplication = {
+    id: 'APPLICATION_ID',
+    applicationName: 'APPLICATION_NAME'
+  }
+
+  fakeStandardRule = {
+    id: 'bd610c23-8ba7-e711-810a-5065f38a5b01',
+    permitName: 'Metal recycling, vehicle storage, depollution and dismantling facility',
+    limits: 'Less than 25,000 tonnes a year of waste metal and less than 5,000 tonnes a year of waste motor vehicles',
+    code: 'SR2015 No 18',
+    codeForId: 'sr2015-no-18',
+    canApplyOnline: true
+  }
+
+  fakeStandardRuleType = {
+    id: 'STANDARD_RULE_TYPE_ID',
+    category: 'category',
+    hint: 'category_HINT',
+    categoryName: 'category_NAME'
   }
 
   // Create a sinon sandbox to stub methods
@@ -59,10 +58,12 @@ lab.beforeEach(() => {
   sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(ApplicationLine.prototype, 'save').value(() => {})
+  sandbox.stub(LoggingService, 'logError').value(() => {})
   sandbox.stub(Payment, 'getByApplicationLineIdAndType').value(() => {})
   sandbox.stub(Payment.prototype, 'isPaid').value(() => false)
   sandbox.stub(StandardRule, 'list').value(() => [fakeStandardRule])
   sandbox.stub(StandardRule, 'getByCode').value(() => fakeStandardRule)
+  sandbox.stub(StandardRuleType, 'getById').value(() => new Application(fakeStandardRuleType))
 })
 
 lab.afterEach(() => {
@@ -73,111 +74,142 @@ lab.afterEach(() => {
 lab.experiment('Select a permit page tests:', () => {
   new GeneralTestHelper(lab, routePath).test()
 
-  lab.test('The page should NOT have a back link', async () => {
-    const res = await server.inject(getRequest)
+  const getDoc = async (request) => {
+    const res = await server.inject(request)
     Code.expect(res.statusCode).to.equal(200)
 
     const parser = new DOMParser()
-    const doc = parser.parseFromString(res.payload, 'text/html')
+    return parser.parseFromString(res.payload, 'text/html')
+  }
 
-    const element = doc.getElementById('back-link')
-    Code.expect(element).to.not.exist()
+  const checkCommonElements = async (doc) => {
+    Code.expect(doc.getElementById('page-heading').firstChild.nodeValue).to.equal('Select a permit')
+    Code.expect(doc.getElementById('submit-button').firstChild.nodeValue).to.equal('Continue')
+    Code.expect(doc.getElementById('select-permit-hint-text')).to.exist()
+    Code.expect(doc.getElementById('permit-type-description').firstChild.nodeValue).to.equal(fakeStandardRuleType.category)
+  }
+
+  lab.experiment(`GET ${routePath}`, () => {
+    let getRequest
+
+    lab.beforeEach(() => {
+      getRequest = {
+        method: 'GET',
+        url: routePath,
+        headers: {}
+      }
+    })
+
+    lab.experiment('success', () => {
+      let permits
+
+      const newPermit = (options) => new StandardRule(Object.assign({}, fakeStandardRule, options))
+
+      lab.beforeEach(() => {
+        permits = [
+          newPermit({id: 'permit-0', permitName: 'Permit one', limits: '', code: 'permit code 0', codeForId: 'permit-code-0'}),
+          newPermit({id: 'permit-1', permitName: 'Permit two', limits: 'limit two', code: 'permit code 1', codeForId: 'permit-code-1'}),
+          newPermit({id: 'permit-2', permitName: 'Permit three', limits: '', code: 'permit code 2', codeForId: 'permit-code-2'}),
+          newPermit({id: 'permit-3', permitName: 'Permit four', limits: '', code: 'permit code 3', codeForId: 'permit-code-3'})
+        ]
+        StandardRule.list = () => permits
+      })
+
+      lab.test('should include permits ', async () => {
+        const doc = await getDoc(getRequest)
+        checkCommonElements(doc)
+
+        permits.forEach(({id, permitName, code, limits, codeForId}) => {
+          const prefix = `chosen-permit-${codeForId}`
+          Code.expect(doc.getElementById(`${prefix}-input`).getAttribute('value')).to.equal(code)
+          Code.expect(doc.getElementById(`${prefix}-label`)).to.exist()
+          Code.expect(doc.getElementById(`${prefix}-name`).firstChild.nodeValue.trim()).to.equal(permitName)
+          Code.expect(doc.getElementById(`${prefix}-code`).firstChild.nodeValue.trim()).to.equal(code)
+          if (limits) {
+            Code.expect(doc.getElementById(`${prefix}-weight`).firstChild.nodeValue.trim()).to.equal(limits)
+          } else {
+            Code.expect(doc.getElementById(`${prefix}-weight`)).to.not.exist()
+          }
+        })
+      })
+    })
+
+    lab.experiment('failure', () => {
+      lab.test('redirects to error screen when failing to get the application ID', async () => {
+        const spy = sinon.spy(LoggingService, 'logError')
+        Application.getById = () => {
+          throw new Error('read failed')
+        }
+
+        const res = await server.inject(getRequest)
+        Code.expect(spy.callCount).to.equal(1)
+        Code.expect(res.statusCode).to.equal(302)
+        Code.expect(res.headers['location']).to.equal(errorPath)
+      })
+
+      lab.test('redirects to error screen when failing to get the permits', async () => {
+        const spy = sinon.spy(LoggingService, 'logError')
+        StandardRule.list = () => {
+          throw new Error('search failed')
+        }
+
+        const res = await server.inject(getRequest)
+        Code.expect(spy.callCount).to.equal(1)
+        Code.expect(res.statusCode).to.equal(302)
+        Code.expect(res.headers['location']).to.equal(errorPath)
+      })
+
+      lab.test('redirects to error screen when failing to get the category', async () => {
+        const spy = sinon.spy(LoggingService, 'logError')
+        StandardRuleType.getById = () => {
+          throw new Error('read failed')
+        }
+
+        const res = await server.inject(getRequest)
+        Code.expect(spy.callCount).to.equal(1)
+        Code.expect(res.statusCode).to.equal(302)
+        Code.expect(res.headers['location']).to.equal(errorPath)
+      })
+    })
   })
 
-  lab.test(`GET ${routePath} returns the permit selection page correctly`, async () => {
-    const res = await server.inject(getRequest)
-    Code.expect(res.statusCode).to.equal(200)
+  lab.experiment(`POST ${routePath}`, () => {
+    let postRequest
 
-    const parser = new DOMParser()
-    const doc = parser.parseFromString(res.payload, 'text/html')
+    lab.beforeEach(() => {
+      postRequest = {
+        method: 'POST',
+        url: routePath,
+        headers: {},
+        payload: {}
+      }
+    })
 
-    let element = doc.getElementById('page-heading').firstChild
-    Code.expect(element.nodeValue).to.equal('Select a permit')
+    lab.experiment('success', () => {
+      lab.test(`redirects to "${nextRoutePath}" when permit selected is an online permit`, async () => {
+        postRequest.payload['chosen-permit'] = fakeStandardRule.id
+        const res = await server.inject(postRequest)
 
-    // Not visible for MVP
-    element = doc.getElementById('select-permit-hint-text')
-    Code.expect(element).to.not.exist()
+        // Make sure a redirection has taken place correctly
+        Code.expect(res.statusCode).to.equal(302)
+        Code.expect(res.headers['location']).to.equal(nextRoutePath)
+      })
 
-    // Not visible for MVP
-    element = doc.getElementById('permit-type-description')
-    Code.expect(element).to.not.exist()
+      lab.test(`redirects to "${offlineRoutePath}" when permit selected is an offline permit`, async () => {
+        fakeStandardRule.canApplyOnline = false
+        postRequest.payload['chosen-permit'] = fakeStandardRule.id
+        const res = await server.inject(postRequest)
 
-    // Not visible for MVP
-    element = doc.getElementById('back-to-all-permit-groups-link')
-    Code.expect(element).to.not.exist()
+        // Make sure a redirection has taken place correctly
+        Code.expect(res.statusCode).to.equal(302)
+        Code.expect(res.headers['location']).to.equal(offlineRoutePath)
+      })
+    })
 
-    element = doc.getElementById('chosen-permit-sr2015-no-18-name').firstChild
-    Code.expect(element.nodeValue).to.include('Metal recycling, vehicle storage, depollution and dismantling facility')
-
-    element = doc.getElementById('chosen-permit-sr2015-no-18-weight').firstChild
-    Code.expect(element.nodeValue).to.include('Less than 25,000 tonnes a year of waste metal and less than 5,000 tonnes a year of waste motor vehicles')
-
-    element = doc.getElementById('chosen-permit-sr2015-no-18-code').firstChild
-    Code.expect(element.nodeValue).to.equal('SR2015 No 18')
-
-    element = doc.getElementById('submit-button').firstChild
-    Code.expect(element.nodeValue).to.equal('Continue')
-  })
-
-  lab.test('POST /permit/select success redirects to the next route', async () => {
-    postRequest.payload['chosen-permit'] = 'SR2010 No 4'
-
-    const res = await server.inject(postRequest)
-    Code.expect(res.statusCode).to.equal(302)
-    Code.expect(res.headers['location']).to.equal(nextRoutePath)
-  })
-
-  lab.test('POST /permit/select shows the error message summary panel when the site data is invalid', async () => {
-    postRequest.payload['chosen-permit'] = ''
-
-    const res = await server.inject(postRequest)
-    Code.expect(res.statusCode).to.equal(200)
-
-    const parser = new DOMParser()
-    const doc = parser.parseFromString(res.payload, 'text/html')
-
-    const element = doc.getElementById('error-summary')
-
-    Code.expect(element).to.exist()
-  })
-
-  lab.test('POST /permit/select shows an error message when no permit is selected', async () => {
-    const res = await server.inject(postRequest)
-    Code.expect(res.statusCode).to.equal(200)
-
-    const parser = new DOMParser()
-    const doc = parser.parseFromString(res.payload, 'text/html')
-
-    let element
-    let errorMessage = 'Select the permit you want'
-
-    // Panel summary error item
-    element = doc.getElementById('error-summary-list-item-0').firstChild
-    Code.expect(element.nodeValue).to.equal(errorMessage)
-
-    // Chosen permit ID error
-    element = doc.getElementById('chosen-permit-error').firstChild.firstChild
-    Code.expect(element.nodeValue).to.equal(errorMessage)
-  })
-
-  lab.test('POST /permit/select shows an error message when the permit value is not allowed', async () => {
-    postRequest.payload['chosen-permit'] = 'not a real permit'
-
-    const res = await server.inject(postRequest)
-    Code.expect(res.statusCode).to.equal(200)
-
-    const parser = new DOMParser()
-    const doc = parser.parseFromString(res.payload, 'text/html')
-
-    let element
-    let errorMessage = 'Select a valid permit'
-
-    // Panel summary error item
-    element = doc.getElementById('error-summary-list-item-0').firstChild
-    Code.expect(element.nodeValue).to.equal(errorMessage)
-
-    // Chosen permit ID error
-    element = doc.getElementById('chosen-permit-error').firstChild.firstChild
-    Code.expect(element.nodeValue).to.equal(errorMessage)
+    lab.test('invalid when permit not selected', async () => {
+      postRequest.payload = {}
+      const doc = await getDoc(postRequest)
+      await GeneralTestHelper.checkValidationMessage(doc, 'chosen-permit', 'Select the permit you want')
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-986
https://eaflood.atlassian.net/browse/WE-987

Also as part of continuing improvements and using the [DRY](https://www.codementor.io/joshuaaroke/dry-code-vs-wet-code-89xjwv11w) method I have moved the getById method into the base model as each implementation in each inherited models were identical in functionality.