### PR TITLE
Make the Gov Pay returnUrl a configurable parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@
 # - PRODUCTION
 NODE_ENV=DEVELOPMENT
 
+# The Waste Permits application URL that we redirect back to after sending the user to Gov.UK Pay
+WASTE_PERMITS_APP_URL=https://wp-dev.aws.defra.cloud
+
 # The logging level. Set to DEBUG to see debug logs. Set to INFO to see the usual INFO and ERROR logs.
 LOG_LEVEL=INFO
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -7,6 +7,7 @@ const config = module.exports = {}
 
 config.LOG_LEVEL = process.env.LOG_LEVEL
 
+config.wastePermitsAppUrl = process.env.WASTE_PERMITS_APP_URL || 'https://www.gov.uk'
 config.port = process.env.PORT || 8000
 config.nodeEnvironment = process.env.NODE_ENV || 'PRODUCTION'
 

--- a/src/controllers/payment/cardPayment.controller.js
+++ b/src/controllers/payment/cardPayment.controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const config = require('../../config/config')
 const Constants = require('../../constants')
 const BaseController = require('../base.controller')
 const Payment = require('../../models/payment.model')
@@ -21,14 +22,8 @@ module.exports = class CardPaymentController extends BaseController {
     payment.category = Constants.Dynamics.PAYMENT_CATEGORY
     await payment.save(authToken)
 
-    // TODO remove this - only needed for local dev instead of the returnUrl specified below. This is because
-    // Gov Pay needs an https address to redirect to, otherwise it throws a runtime error
-
-    // let returnUrl = 'http://defra.gov.uk'
-    let returnUrl = `${request.server.info.protocol}://${request.info.host}${Constants.Routes.PAYMENT.PAYMENT_RESULT.path}`
-
-    // Ensure that it redirects back to an https address otherwise the payment will fail
-    returnUrl = returnUrl.replace('http://', 'https://')
+    // Note - Gov Pay needs an https address to redirect to, otherwise it throws a runtime error
+    let returnUrl = `${config.wastePermitsAppUrl}${Constants.Routes.PAYMENT.PAYMENT_RESULT.path}`
 
     LoggingService.logDebug(`Making Gov.UK Pay card payment. Will redirect back to: ${returnUrl}`)
 


### PR DESCRIPTION
This makes the Gov Pay return URL a configurable parameter, rather than relying on the protocol and host name reported by the individual Hapi server instance.