### PR TITLE
Move view declaration to corresponding route

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -149,148 +149,181 @@ Constants.Routes = {
   ADDRESS: {
     MANUAL_INVOICE: {
       path: '/invoice/address/address-manual',
+      view: 'address/manualEntry',
       pageHeading: `Where should we send invoices for the annual costs after the permit has been issued?`
     },
     MANUAL_SITE: {
       path: '/site/address/address-manual',
+      view: 'address/manualEntry',
       pageHeading: `Enter the site address`
     },
     POSTCODE_INVOICE: {
       path: '/invoice/address/postcode',
+      view: 'address/postcode',
       pageHeading: `Where should we send invoices for the annual costs after the permit has been issued?`,
       taskListHeading: 'Give invoicing details'
     },
     POSTCODE_SITE: {
       path: '/site/address/postcode',
+      view: 'address/postcode',
       pageHeading: `What's the postcode for the site?`
     },
     SELECT_INVOICE: {
       path: '/invoice/address/select-address',
+      view: 'address/selectAddress',
       pageHeading: `Where should we send invoices for the annual costs after the permit has been issued?`
     },
     SELECT_SITE: {
       path: '/site/address/select-address',
+      view: 'address/selectAddress',
       pageHeading: `What's the site address?`
     }
   },
   APPLICATION_RECEIVED: {
     path: `${Constants.APPLICATION_RECEIVED_URL}/{slug?}`,
+    view: 'applicationReceived',
     pageHeading: `Application received`,
     pageHeadingAlternate: `Application and card payment received`
   },
   APPLY_OFFLINE: {
     path: '/start/apply-offline',
+    view: 'applyOffline',
     pageHeading: `Apply for {{{chosenOption}}}`
   },
   CHECK_BEFORE_SENDING: {
     path: '/check-before-sending',
+    view: 'checkBeforeSending',
     pageHeading: 'Check your answers',
     taskListHeading: 'Send application and pay'
   },
   CHECK_YOUR_EMAIL: {
     path: '/save-return/check-your-email',
+    view: 'saveAndReturn/checkYourEmail',
     pageHeading: 'Check your email',
     taskListHeading: 'Check your email'
   },
   COMPANY_CHECK_NAME: {
     path: '/permit-holder/company/check-name',
+    view: 'companyCheckName',
     pageHeading: `Is this the right company?`
   },
   COMPANY_CHECK_STATUS: {
     path: '/permit-holder/company/status-not-active',
+    view: 'companyCheckStatus',
     pageHeading: `We can't issue a permit to that company because it {{{companyStatus}}}`
   },
   COMPANY_CHECK_TYPE: {
     path: '/permit-holder/company/wrong-type',
+    view: 'companyCheckType',
     pageHeading: `That company can’t apply because it’s {{{companyType}}}`
   },
   COMPANY_DECLARE_OFFENCES: {
     path: '/permit-holder/company/declare-offences',
+    view: 'declaration/company/offences',
     pageHeading: 'Does anyone connected with your business have a conviction for a relevant offence?'
   },
   COMPANY_DECLARE_BANKRUPTCY: {
     path: '/permit-holder/company/bankruptcy-insolvency',
+    view: 'declaration/company/bankruptcy',
     pageHeading: 'Do you have current or past bankruptcy or insolvency proceedings to declare?'
   },
   COMPANY_NUMBER: {
     path: '/permit-holder/company/number',
+    view: 'companyNumber',
     pageHeading: `What's the UK company registration number?`,
     taskListHeading: `What's the company name or registration number?`
   },
   CONFIDENTIALITY: {
     path: '/confidentiality',
+    view: 'declaration/confidentiality/confidentiality',
     pageHeading: 'Is part of your application commercially confidential?',
     taskListHeading: 'Confirm confidentiality needs'
   },
   CONFIRM_RULES: {
     path: '/confirm-rules',
+    view: 'confirmRules',
     pageHeading: 'Confirm your operation meets the rules',
     taskListHeading: 'Confirm you can meet the rules'
   },
   CONTACT_DETAILS: {
     path: '/contact-details',
+    view: 'contactDetails',
     pageHeading: 'Who should we contact about this application?',
     taskListHeading: 'Give contact details'
   },
   COOKIES: {
     path: '/information/cookies',
+    view: 'cookies',
     pageHeading: 'Cookies'
   },
   COST_TIME: {
     path: '/costs-times',
+    view: 'costTime',
     pageHeading: 'Costs and processing time',
     taskListHeading: 'Check costs and processing time'
   },
   DIRECTOR_DATE_OF_BIRTH: {
     path: '/permit-holder/company/director-date-of-birth',
+    view: 'directorDateOfBirth',
     pageHeading: `What's the director's date of birth?`,
     pageHeadingAlternate: `What are the directors' dates of birth?`
   },
   DRAINAGE_TYPE_DRAIN: {
     path: '/drainage-type/drain',
+    view: 'drainageTypeDrain',
     pageHeading: 'Confirm you have suitable vehicle storage areas',
     taskListHeading: 'Confirm you have suitable vehicle storage areas'
   },
   ERROR: {
     ALREADY_SUBMITTED: {
       path: `${Constants.ALREADY_SUBMITTED_URL}/{slug?}`,
+      view: 'error/alreadySubmitted',
       pageHeading: `You’ve sent your application so you can't go back and change it`
     },
     COOKIES_DISABLED: {
       path: '/errors/cookies-off',
+      view: 'error/cookiesDisabled',
       pageHeading: 'You must switch on cookies to use this service'
     },
     NOT_PAID: {
       path: '/errors/order/card-payment-not-complete',
+      view: 'error/notPaid',
       pageHeading: 'You need to pay for your application'
     },
     NOT_SUBMITTED: {
       path: '/errors/order/check-answers-not-complete',
+      view: 'error/notSubmitted',
       pageHeading: 'You need to check your answers and submit your application'
     },
     PAGE_NOT_FOUND: {
       path: '/errors/page-not-found',
+      view: 'error/pageNotFound',
       pageHeading: `We can't find that page`
     },
     RECOVERY_FAILED: {
       path: '/errors/recovery-failed',
+      view: 'error/recoveryFailed',
       pageHeading: 'Sorry, we can’t find that application'
     },
     START_AT_BEGINNING: {
       path: '/errors/order/start-at-beginning',
+      view: 'error/startAtBeginning',
       pageHeading: 'Please start at the beginning of the application'
     },
     TECHNICAL_PROBLEM: {
       path: '/errors/technical-problem',
+      view: 'error/technicalProblem',
       pageHeading: 'Something went wrong'
     },
     TIMEOUT: {
       path: '/errors/timeout',
+      view: 'error/timeout',
       pageHeading: 'Your application has timed out'
     }
   },
   FIRE_PREVENTION_PLAN: {
     path: '/fire-prevention-plan',
+    view: 'upload/firePreventionPlan/firePreventionPlan',
     pageHeading: 'Upload the fire prevention plan',
     taskListHeading: 'Upload the fire prevention plan'
   },
@@ -300,12 +333,14 @@ Constants.Routes = {
   },
   MANAGEMENT_SYSTEM: {
     path: '/management-system',
+    view: 'managementSystem',
     pageHeading: 'Which management system will you use?',
     taskListHeading: 'Tell us which management system you use'
   },
   PAYMENT: {
     BACS_PAYMENT: {
       path: '/pay/bacs',
+      view: 'payment/paymentBacs',
       pageHeading: 'You’ve chosen to pay by bank transfer using Bacs'
     },
     CARD_PAYMENT: {
@@ -313,6 +348,7 @@ Constants.Routes = {
     },
     CARD_PROBLEM: {
       path: `${Constants.PAYMENT_CARD_PROBLEM_URL}/{slug?}`,
+      view: 'payment/cardProblem',
       pageHeading: 'Your card payment failed'
     },
     PAYMENT_RESULT: {
@@ -321,114 +357,140 @@ Constants.Routes = {
     },
     PAYMENT_TYPE: {
       path: '/pay/type',
+      view: 'payment/paymentType',
       pageHeading: 'How do you want to pay?'
     }
   },
   PERMIT_CATEGORY: {
     path: '/permit/category',
+    view: 'permitCategory',
     pageHeading: 'What do you want the permit for?'
   },
   PERMIT_HOLDER_TYPE: {
     path: '/permit-holder/type',
+    view: 'permitHolderType',
     pageHeading: 'Who will be the permit holder?',
     taskListHeading: 'Give company details'
   },
   PERMIT_SELECT: {
     path: '/permit/select',
+    view: 'permitSelect',
     pageHeading: 'Select a permit'
   },
   PRE_APPLICATION: {
     path: '/pre-application',
+    view: 'preApplication',
     pageHeading: 'Have you discussed this application with us?',
     taskListHeading: `Tell us if you've discussed this application with us`
   },
   PRIVACY: {
     path: '/information/privacy',
+    view: 'privacy',
     pageHeading: 'Privacy: how we use your personal information'
   },
   SAVE_AND_RETURN_SENT_CHECK: {
     path: '/save-return/email-sent-check',
+    view: 'saveAndReturn/emailSent',
     pageHeading: 'Check your email'
   },
   SAVE_AND_RETURN_RECOVER: {
     path: `${Constants.SAVE_AND_RETURN_URL}/{slug}`,
+    view: 'saveAndReturn/recover',
     pageHeading: 'We found your application'
   },
   SAVE_AND_RETURN_CONFIRM: {
     path: '/save-return/confirm',
+    view: 'saveAndReturn/emailConfirm',
     pageHeading: 'Make sure this is right'
   },
   SAVE_AND_RETURN_SENT_RESENT: {
     path: '/save-return/email-sent-resent',
+    view: 'saveAndReturn/emailSent',
     pageHeading: 'We’ve resent the email - check again'
   },
   SAVE_AND_RETURN_COMPLETE: {
     path: '/save-return/email-sent-task-check',
+    view: 'saveAndReturn/emailSent',
     pageHeading: 'You’ve saved your application'
   },
   SAVE_AND_RETURN_EMAIL: {
     path: '/save-return/email',
+    view: 'saveAndReturn/emailEnter',
     pageHeading: 'Save your application',
     taskListHeading: 'Save your application'
   },
   SEARCH_YOUR_EMAIL: {
     path: '/save-return/search-your-email',
+    view: 'saveAndReturn/checkYourEmail',
     pageHeading: 'Search for ’standard rules permit application’ in your emails',
     taskListHeading: 'Search for ’standard rules permit application’ in your emails'
   },
   SITE_GRID_REFERENCE: {
     path: '/site/grid-reference',
+    view: 'siteGridReference',
     pageHeading: `What's the grid reference for the centre of the site?`
   },
   SITE_PLAN: {
     path: '/site-plan',
+    view: 'upload/sitePlan/sitePlan',
     pageHeading: 'Upload the site plan',
     taskListHeading: 'Upload the site plan'
   },
   SITE_NAME: {
     path: '/site/site-name',
+    view: 'siteName',
     pageHeading: `What's the site name?`,
     taskListHeading: 'Give site name and location'
   },
   START_OR_OPEN_SAVED: {
     path: `/start/start-or-open-saved`,
+    view: 'startOrOpenSaved',
     pageHeading: 'Apply for a standard rules environmental permit'
   },
   TASK_LIST: {
     path: '/task-list',
+    view: 'taskList',
     pageHeading: 'Apply for a standard rules environmental permit'
   },
   TECHNICAL_QUALIFICATION: {
     path: '/technical-competence',
+    view: 'technicalQualification',
     pageHeading: 'What evidence of technical competence do you have?',
     taskListHeading: 'Prove technical competence'
   },
   TECHNICAL_MANAGERS: {
     path: '/technical-competence/technical-managers',
+    view: 'upload/technicalQualification/technicalManagers',
     pageHeading: 'Upload details for all technically competent managers'
   },
   UPLOAD_COURSE_REGISTRATION: {
     path: '/technical-competence/upload-course-registration',
+    view: 'upload/technicalQualification/courseRegistration',
     pageHeading: 'Getting a qualification: upload your evidence'
   },
   UPLOAD_DEEMED_EVIDENCE: {
     path: '/technical-competence/upload-deemed-evidence',
+    view: 'upload/technicalQualification/deemedEvidence',
     pageHeading: 'Deemed competence or an assessment: upload your evidence'
   },
   UPLOAD_ESA_EU_SKILLS: {
     path: '/technical-competence/upload-esa-eu-skills',
+    view: 'upload/technicalQualification/esaEuSkills',
     pageHeading: 'Energy & Utility Skills / ESA: upload your evidence'
   },
   UPLOAD_WAMITAB_QUALIFICATION: {
     path: '/technical-competence/upload-wamitab-qualification',
+    view: 'upload/technicalQualification/wamitabQualification',
     pageHeading: 'WAMITAB or EPOC: upload your evidence'
   },
   VERSION: {
     path: '/version',
+    view: 'version',
     pageHeading: 'Waste Permits'
   },
   WASTE_RECOVERY_PLAN: {
     path: '/waste-recovery-plan',
+    view: 'wasteRecoveryPlan',
     pageHeading: 'Have we checked your waste recovery plan?',
     taskListHeading: 'Get your waste recovery plan checked'
   }

--- a/src/controllers/address/base/addressManual.controller.js
+++ b/src/controllers/address/base/addressManual.controller.js
@@ -35,7 +35,7 @@ module.exports = class AddressManualController extends BaseController {
       }
     }
 
-    return this.showView({request, h, viewPath: 'address/manualEntry', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/address/base/addressSelect.controller.js
+++ b/src/controllers/address/base/addressSelect.controller.js
@@ -45,7 +45,7 @@ module.exports = class AddressSelectController extends BaseController {
     pageContext.changePostcodeLink = this.getPostcodeRoute()
     pageContext.manualAddressLink = this.getManualEntryRoute()
 
-    return this.showView({request, h, viewPath: 'address/selectAddress', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/address/base/postcode.controller.js
+++ b/src/controllers/address/base/postcode.controller.js
@@ -38,7 +38,7 @@ module.exports = class PostcodeController extends BaseController {
     this.customisePageContext(pageContext)
     pageContext.manualAddressLink = this.getManualEntryRoute()
 
-    return this.showView({request, h, viewPath: 'address/postcode', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/applicationReceived.controller.js
+++ b/src/controllers/applicationReceived.controller.js
@@ -42,7 +42,7 @@ module.exports = class ApplicationReceivedController extends BaseController {
     }
 
     if (bacsPayment || cardPayment || application.isPaid()) {
-      return this.showView({request, h, viewPath: 'applicationReceived', pageContext})
+      return this.showView({request, h, pageContext})
     } else {
       // If the application has not been paid for
       return this.redirect({request, h, redirectPath: Constants.Routes.ERROR.NOT_PAID.path})

--- a/src/controllers/applyOffline.controller.js
+++ b/src/controllers/applyOffline.controller.js
@@ -86,6 +86,6 @@ module.exports = class ApplyOfflineController extends BaseController {
       pageContext.offlineCategoryOther = true
     }
 
-    return this.showView({request, h, viewPath: 'applyOffline', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -7,7 +7,15 @@ const RecoveryService = require('../services/recovery.service')
 const {COOKIE_RESULT} = Constants
 
 module.exports = class BaseController {
-  constructor ({route, validator, cookieValidationRequired = true, applicationRequired = true, submittedRequired = false, paymentRequired = false, viewPath, nextRoute}) {
+  constructor ({
+    route,
+    nextRoute,
+    validator,
+    cookieValidationRequired = true,
+    applicationRequired = true,
+    submittedRequired = false,
+    paymentRequired = false
+  }) {
     if (!route) {
       console.error(`Error - Unable to find Constants.Routes for: ${Object.getPrototypeOf(this).constructor.name}`)
     }
@@ -21,10 +29,6 @@ module.exports = class BaseController {
 
     if (validator) {
       this.validator = validator
-    }
-
-    if (viewPath) {
-      this.viewPath = viewPath
     }
 
     this.orginalPageHeading = route.pageHeading
@@ -101,9 +105,9 @@ module.exports = class BaseController {
       .state(Constants.DEFRA_COOKIE_KEY, cookie, Constants.COOKIE_PATH)
   }
 
-  showView ({request, h, viewPath, pageContext, code = 200}) {
+  showView ({request, h, pageContext, code = 200}) {
     return h
-      .view(viewPath, pageContext)
+      .view(this.route.view, pageContext)
       .code(code)
       .state(Constants.DEFRA_COOKIE_KEY, request.state[Constants.DEFRA_COOKIE_KEY], Constants.COOKIE_PATH)
   }

--- a/src/controllers/checkBeforeSending.controller.js
+++ b/src/controllers/checkBeforeSending.controller.js
@@ -70,7 +70,7 @@ module.exports = class CheckBeforeSendingController extends BaseController {
       return this.redirect({request, h, redirectPath: `${Constants.Routes.TASK_LIST.path}?showError=true`})
     }
 
-    return this.showView({request, h, viewPath: 'checkBeforeSending', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/companyCheckName.controller.js
+++ b/src/controllers/companyCheckName.controller.js
@@ -35,7 +35,7 @@ module.exports = class CompanyCheckNameController extends BaseController {
 
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView({request, h, viewPath: 'companyCheckName', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/companyCheckStatus.controller.js
+++ b/src/controllers/companyCheckStatus.controller.js
@@ -39,6 +39,6 @@ module.exports = class CompanyStatusController extends BaseController {
     pageContext.companyStatus = companyStatus
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView({request, h, viewPath: 'companyCheckStatus', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/companyCheckType.controller.js
+++ b/src/controllers/companyCheckType.controller.js
@@ -28,6 +28,6 @@ module.exports = class CompanyTypeController extends BaseController {
     pageContext.companyType = companyType
     pageContext.enterCompanyNumberRoute = Constants.Routes.COMPANY_NUMBER.path
 
-    return this.showView({request, h, viewPath: 'companyCheckType', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/companyNumber.controller.js
+++ b/src/controllers/companyNumber.controller.js
@@ -20,7 +20,7 @@ module.exports = class CompanyNumberController extends BaseController {
         }
       }
     }
-    return this.showView({request, h, viewPath: 'companyNumber', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/confirmRules.controller.js
+++ b/src/controllers/confirmRules.controller.js
@@ -14,7 +14,7 @@ module.exports = class ConfirmRulesController extends BaseController {
     pageContext.code = standardRule.code
     pageContext.isComplete = await ConfirmRules.isComplete(authToken, application.id, applicationLineId)
 
-    return this.showView({request, h, viewPath: 'confirmRules', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/contactDetails.controller.js
+++ b/src/controllers/contactDetails.controller.js
@@ -35,7 +35,7 @@ module.exports = class ContactDetailsController extends BaseController {
       }
     }
 
-    return this.showView({request, h, viewPath: 'contactDetails', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/cookies.controller.js
+++ b/src/controllers/cookies.controller.js
@@ -69,6 +69,6 @@ module.exports = class CookiesController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
     pageContext.sections = sections
-    return this.showView({request, h, viewPath: 'cookies', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -15,7 +15,7 @@ module.exports = class CostTimeController extends BaseController {
 
     pageContext.cost = value.toLocaleString()
 
-    return this.showView({request, h, viewPath: 'costTime', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/declaration/base/declarations.controller.js
+++ b/src/controllers/declaration/base/declarations.controller.js
@@ -32,7 +32,7 @@ module.exports = class DeclarationsController extends BaseController {
 
     Object.assign(pageContext, this.getSpecificPageContext())
 
-    return this.showView({request, h, viewPath: this.view, pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/declaration/company/bankruptcy.controller.js
+++ b/src/controllers/declaration/company/bankruptcy.controller.js
@@ -4,10 +4,6 @@ const DeclarationsController = require('../base/declarations.controller')
 const CompanyDetails = require('../../../models/taskList/companyDetails.model')
 
 module.exports = class BankruptcyController extends DeclarationsController {
-  get view () {
-    return 'declaration/company/bankruptcy'
-  }
-
   getFormData (data) {
     return super.getFormData(data, 'bankruptcy', 'bankruptcyDetails')
   }

--- a/src/controllers/declaration/company/offences.controller.js
+++ b/src/controllers/declaration/company/offences.controller.js
@@ -3,10 +3,6 @@
 const DeclarationsController = require('../base/declarations.controller')
 
 module.exports = class OffencesController extends DeclarationsController {
-  get view () {
-    return 'declaration/company/offences'
-  }
-
   getFormData (data) {
     return super.getFormData(data, 'relevantOffences', 'relevantOffencesDetails')
   }

--- a/src/controllers/declaration/confidentiality/confidentiality.controller.js
+++ b/src/controllers/declaration/confidentiality/confidentiality.controller.js
@@ -4,10 +4,6 @@ const DeclarationsController = require('../base/declarations.controller')
 const Confidentiality = require('../../../models/taskList/confidentiality.model')
 
 module.exports = class ConfidentialityController extends DeclarationsController {
-  get view () {
-    return 'declaration/confidentiality/confidentiality'
-  }
-
   getFormData (data) {
     return super.getFormData(data, 'confidentiality', 'confidentialityDetails')
   }

--- a/src/controllers/directorDateOfBirth.controller.js
+++ b/src/controllers/directorDateOfBirth.controller.js
@@ -54,7 +54,7 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
       }
     }
 
-    return this.showView({request, h, viewPath: 'directorDateOfBirth', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/drainageTypeDrain.controller.js
+++ b/src/controllers/drainageTypeDrain.controller.js
@@ -14,7 +14,7 @@ module.exports = class DrainageTypeDrainController extends BaseController {
     pageContext.code = standardRule.code
     pageContext.isComplete = await DrainageTypeDrain.isComplete(authToken, application.id, applicationLineId)
 
-    return this.showView({request, h, viewPath: 'drainageTypeDrain', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/error/alreadySubmitted.controller.js
+++ b/src/controllers/error/alreadySubmitted.controller.js
@@ -12,6 +12,6 @@ module.exports = class AlreadySubmittedController extends BaseController {
     pageContext.startOpenOrSavedRoute = Constants.Routes.START_OR_OPEN_SAVED.path
     pageContext.applicationRef = application.applicationNumber
 
-    return this.showView({request, h, viewPath: 'error/alreadySubmitted', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/cookiesDisabled.controller.js
+++ b/src/controllers/error/cookiesDisabled.controller.js
@@ -8,6 +8,6 @@ module.exports = class CookiesDisabledController extends BaseController {
     const pageContext = this.createPageContext(errors)
     pageContext.cookieInfoLink = Constants.Routes.COOKIES.path
 
-    return this.showView({request, h, viewPath: 'error/cookiesDisabled', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/notPaid.controller.js
+++ b/src/controllers/error/notPaid.controller.js
@@ -9,6 +9,6 @@ module.exports = class NotPaidController extends BaseController {
 
     pageContext.payForApplicationRoute = Constants.Routes.PAYMENT.PAYMENT_TYPE.path
 
-    return this.showView({request, h, viewPath: 'error/notPaid', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/notSubmitted.controller.js
+++ b/src/controllers/error/notSubmitted.controller.js
@@ -8,6 +8,6 @@ module.exports = class NotSubmittedController extends BaseController {
     const pageContext = this.createPageContext(errors)
     pageContext.checkYourAnswersRoute = Constants.Routes.CHECK_BEFORE_SENDING.path
 
-    return this.showView({request, h, viewPath: 'error/notSubmitted', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/pageNotFound.controller.js
+++ b/src/controllers/error/pageNotFound.controller.js
@@ -15,7 +15,7 @@ module.exports = class PageNotFoundController extends BaseController {
     pageContext.taskListRoute = Constants.Routes.TASK_LIST.path
     pageContext.startOpenOrSavedRoute = Constants.Routes.START_OR_OPEN_SAVED.path
 
-    return this.showView({request, h, viewPath: 'error/pageNotFound', pageContext, code: 404})
+    return this.showView({request, h, pageContext, code: 404})
   }
 
   static hasApplication (application, applicationLine) {

--- a/src/controllers/error/recoveryFailed.controller.js
+++ b/src/controllers/error/recoveryFailed.controller.js
@@ -6,6 +6,6 @@ module.exports = class RecoveryFailedController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
-    return this.showView({request, h, viewPath: 'error/recoveryFailed', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/startAtBeginning.controller.js
+++ b/src/controllers/error/startAtBeginning.controller.js
@@ -8,6 +8,6 @@ module.exports = class StartAtBeginningController extends BaseController {
     const pageContext = this.createPageContext(errors)
     pageContext.applyForPermitLink = Constants.Routes.START_OR_OPEN_SAVED.path
 
-    return this.showView({request, h, viewPath: 'error/startAtBeginning', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/technicalProblem.controller.js
+++ b/src/controllers/error/technicalProblem.controller.js
@@ -11,6 +11,6 @@ module.exports = class TechnicalProblemController extends BaseController {
       pageContext.error = error
     }
 
-    return this.showView({request, h, viewPath: 'error/technicalProblem', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/error/timeout.controller.js
+++ b/src/controllers/error/timeout.controller.js
@@ -11,6 +11,6 @@ module.exports = class TimeoutController extends BaseController {
     pageContext.startAgainLink = Constants.Routes.START_OR_OPEN_SAVED.path
     pageContext.cookieTimeout = config.cookieTimeout / (1000 * 60 * 60)
 
-    return this.showView({request, h, viewPath: 'error/timeout', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/managementSystem.controller.js
+++ b/src/controllers/managementSystem.controller.js
@@ -5,7 +5,7 @@ const BaseController = require('./base.controller')
 module.exports = class ManagementSystemController extends BaseController {
   async doGet (request, h) {
     const pageContext = this.createPageContext()
-    return this.showView({request, h, viewPath: 'managementSystem', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/payment/paymentBacs.controller.js
+++ b/src/controllers/payment/paymentBacs.controller.js
@@ -18,7 +18,7 @@ module.exports = class PaymentBacsController extends BaseController {
       return this.redirect({request, h, redirectPath: Constants.Routes.ERROR.ALREADY_SUBMITTED.path})
     }
 
-    return this.showView({request, h, viewPath: 'payment/paymentBacs', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/payment/paymentType.controller.js
+++ b/src/controllers/payment/paymentType.controller.js
@@ -38,7 +38,7 @@ module.exports = class PaymentTypeController extends BaseController {
 
     pageContext.cost = value.toLocaleString()
 
-    return this.showView({request, h, viewPath: this.viewPath, pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -26,7 +26,7 @@ module.exports = class PermitCategoryController extends BaseController {
 
     pageContext.formValues = request.payload
 
-    return this.showView({request, h, viewPath: 'permitCategory', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/permitHolderType.controller.js
+++ b/src/controllers/permitHolderType.controller.js
@@ -15,7 +15,7 @@ module.exports = class PermitHolderTypeController extends BaseController {
 
     pageContext.holderTypes = PermitHolderTypeController.getHolderTypes()
 
-    return this.showView({request, h, viewPath: 'permitHolderType', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/permitSelect.controller.js
+++ b/src/controllers/permitSelect.controller.js
@@ -22,7 +22,7 @@ module.exports = class PermitSelectController extends BaseController {
     pageContext.standardRules = await StandardRule.list(authToken, standardRuleTypeId)
     pageContext.permitCategoryRoute = Constants.Routes.PERMIT_CATEGORY.path
 
-    return this.showView({request, h, viewPath: 'permitSelect', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/preApplication.controller.js
+++ b/src/controllers/preApplication.controller.js
@@ -6,7 +6,7 @@ module.exports = class PreApplicationController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
 
-    return this.showView({request, h, viewPath: 'preApplication', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/privacy.controller.js
+++ b/src/controllers/privacy.controller.js
@@ -5,6 +5,6 @@ const BaseController = require('./base.controller')
 module.exports = class PrivacyController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    return this.showView({request, h, viewPath: 'privacy', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/saveAndReturn/checkYourEmail.controller.js
+++ b/src/controllers/saveAndReturn/checkYourEmail.controller.js
@@ -12,7 +12,7 @@ module.exports = class CheckYourEmailController extends BaseController {
 
     pageContext.formValues = request.payload || {}
     pageContext.email = CookieService.get(request, Constants.COOKIE_KEY.SAVE_AND_RETURN_EMAIL)
-    return this.showView({request, h, viewPath: 'saveAndReturn/checkYourEmail', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/saveAndReturn/emailConfirm.controller.js
+++ b/src/controllers/saveAndReturn/emailConfirm.controller.js
@@ -23,7 +23,7 @@ module.exports = class EmailConfirmController extends BaseController {
         'save-and-return-email': application.saveAndReturnEmail
       }
     }
-    return this.showView({request, h, viewPath: 'saveAndReturn/emailConfirm', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/saveAndReturn/emailSent.controller.js
+++ b/src/controllers/saveAndReturn/emailSent.controller.js
@@ -29,7 +29,7 @@ module.exports = class EmailSentController extends BaseController {
         pageContext.notGotEmail = true
       }
     }
-    return this.showView({request, h, viewPath: 'saveAndReturn/emailSent', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/saveAndReturn/enterEmail.controller.js
+++ b/src/controllers/saveAndReturn/enterEmail.controller.js
@@ -23,7 +23,7 @@ module.exports = class EnterEmailController extends BaseController {
         'save-and-return-email': application.saveAndReturnEmail
       }
     }
-    return this.showView({request, h, viewPath: 'saveAndReturn/emailEnter', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/saveAndReturn/recover.controller.js
+++ b/src/controllers/saveAndReturn/recover.controller.js
@@ -17,7 +17,7 @@ module.exports = class RecoverController extends BaseController {
     this.path = `${Constants.SAVE_AND_RETURN_URL}/${slug}`
     const pageContext = this.createPageContext()
     Object.assign(pageContext, {slug, applicationNumber, standardRuleId, standardRuleTypeId, code, permitName})
-    return this.showView({request, h, viewPath: 'saveAndReturn/recover', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {

--- a/src/controllers/siteGridReference.controller.js
+++ b/src/controllers/siteGridReference.controller.js
@@ -18,7 +18,7 @@ module.exports = class SiteGridReferenceController extends BaseController {
         'site-grid-reference': await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
       }
     }
-    return this.showView({request, h, viewPath: 'siteGridReference', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/siteName.controller.js
+++ b/src/controllers/siteName.controller.js
@@ -19,7 +19,7 @@ module.exports = class SiteNameController extends BaseController {
       }
     }
 
-    return this.showView({request, h, viewPath: 'siteName', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -16,7 +16,7 @@ module.exports = class StartOrOpenSavedController extends BaseController {
 
     pageContext.formValues = request.payload
 
-    return this.showView({request, h, viewPath: 'startOrOpenSaved', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -25,7 +25,7 @@ module.exports = class TaskListController extends BaseController {
 
     pageContext.permitCategoryRoute = Constants.Routes.PERMIT_CATEGORY.path
 
-    return this.showView({request, h, viewPath: 'taskList', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async _buildError (request) {

--- a/src/controllers/technicalQualification.controller.js
+++ b/src/controllers/technicalQualification.controller.js
@@ -40,7 +40,7 @@ module.exports = class TechnicalQualificationController extends BaseController {
         break
     }
 
-    return this.showView({request, h, viewPath: 'technicalQualification', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/upload/base/upload.controller.js
+++ b/src/controllers/upload/base/upload.controller.js
@@ -34,7 +34,7 @@ module.exports = class UploadController extends BaseController {
       Object.assign(pageContext, await this.getSpecificPageContext(h))
     }
 
-    return this.showView({request, h, viewPath: this.viewPath, pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/controllers/version.controller.js
+++ b/src/controllers/version.controller.js
@@ -27,6 +27,6 @@ module.exports = class VersionController extends BaseController {
     pageContext.githubUrl = `${Constants.GITHUB_LOCATION}/commit/${config.gitSha}`
     pageContext.renderTimestamp = moment().format(Constants.TIMESTAMP_FORMAT)
 
-    return this.showView({request, h, viewPath: 'version', pageContext})
+    return this.showView({request, h, pageContext})
   }
 }

--- a/src/controllers/wasteRecoveryPlan.controller.js
+++ b/src/controllers/wasteRecoveryPlan.controller.js
@@ -7,7 +7,7 @@ module.exports = class WasteRecoveryPlanController extends BaseController {
     const pageContext = this.createPageContext(errors)
 
     pageContext.formValues = request.payload
-    return this.showView({request, h, viewPath: 'wasteRecoveryPlan', pageContext})
+    return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h, errors) {

--- a/src/routes/payment/cardProblem.route.js
+++ b/src/routes/payment/cardProblem.route.js
@@ -5,6 +5,6 @@ const Route = require('../baseRoute')
 const CardProblemController = require('../../controllers/payment/paymentType.controller')
 const PaymentTypeValidator = require('../../validators/paymentType.validator')
 const validator = new PaymentTypeValidator()
-const controller = new CardProblemController({route: Constants.Routes.PAYMENT.CARD_PROBLEM, validator, cookieValidationRequired: false, submittedRequired: true, viewPath: 'payment/cardProblem'})
+const controller = new CardProblemController({route: Constants.Routes.PAYMENT.CARD_PROBLEM, validator, cookieValidationRequired: false, submittedRequired: true})
 
 module.exports = Route.register('GET, POST', controller, validator)

--- a/src/routes/payment/paymentType.route.js
+++ b/src/routes/payment/paymentType.route.js
@@ -5,6 +5,6 @@ const Route = require('../baseRoute')
 const PaymentTypeController = require('../../controllers/payment/paymentType.controller')
 const PaymentTypeValidator = require('../../validators/paymentType.validator')
 const validator = new PaymentTypeValidator()
-const controller = new PaymentTypeController({route: Constants.Routes.PAYMENT.PAYMENT_TYPE, validator, submittedRequired: true, viewPath: 'payment/paymentType'})
+const controller = new PaymentTypeController({route: Constants.Routes.PAYMENT.PAYMENT_TYPE, validator, submittedRequired: true})
 
 module.exports = Route.register('GET, POST', controller, validator)

--- a/src/routes/upload/firePreventionPlan/firePreventionPlan.route.js
+++ b/src/routes/upload/firePreventionPlan/firePreventionPlan.route.js
@@ -7,6 +7,6 @@ const FirePreventionPlanController = require('../../../controllers/upload/firePr
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new FirePreventionPlanController({route: FIRE_PREVENTION_PLAN, validator, nextRoute: TASK_LIST, viewPath: 'upload/firePreventionPlan/firePreventionPlan'})
+const controller = new FirePreventionPlanController({route: FIRE_PREVENTION_PLAN, validator, nextRoute: TASK_LIST})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/sitePlan/sitePlan.route.js
+++ b/src/routes/upload/sitePlan/sitePlan.route.js
@@ -7,6 +7,6 @@ const SitePlanController = require('../../../controllers/upload/sitePlan/sitePla
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new SitePlanController({route: SITE_PLAN, validator, nextRoute: TASK_LIST, viewPath: 'upload/sitePlan/sitePlan'})
+const controller = new SitePlanController({route: SITE_PLAN, validator, nextRoute: TASK_LIST})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/technicalQualification/courseRegistration.route.js
+++ b/src/routes/upload/technicalQualification/courseRegistration.route.js
@@ -7,6 +7,6 @@ const CourseRegistrationController = require('../../../controllers/upload/techni
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new CourseRegistrationController({route: UPLOAD_COURSE_REGISTRATION, validator, nextRoute: TECHNICAL_MANAGERS, viewPath: 'upload/technicalQualification/courseRegistration'})
+const controller = new CourseRegistrationController({route: UPLOAD_COURSE_REGISTRATION, validator, nextRoute: TECHNICAL_MANAGERS})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/technicalQualification/deemedEvidence.route.js
+++ b/src/routes/upload/technicalQualification/deemedEvidence.route.js
@@ -7,6 +7,6 @@ const DeemedEvidenceController = require('../../../controllers/upload/technicalQ
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new DeemedEvidenceController({route: UPLOAD_DEEMED_EVIDENCE, validator, nextRoute: TECHNICAL_MANAGERS, viewPath: 'upload/technicalQualification/deemedEvidence'})
+const controller = new DeemedEvidenceController({route: UPLOAD_DEEMED_EVIDENCE, validator, nextRoute: TECHNICAL_MANAGERS})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/technicalQualification/esaEuSkills.route.js
+++ b/src/routes/upload/technicalQualification/esaEuSkills.route.js
@@ -7,6 +7,6 @@ const EsaEuSkillsController = require('../../../controllers/upload/technicalQual
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new EsaEuSkillsController({route: UPLOAD_ESA_EU_SKILLS, validator, nextRoute: TASK_LIST, viewPath: 'upload/technicalQualification/esaEuSkills'})
+const controller = new EsaEuSkillsController({route: UPLOAD_ESA_EU_SKILLS, validator, nextRoute: TASK_LIST})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/technicalQualification/technicalManagers.route.js
+++ b/src/routes/upload/technicalQualification/technicalManagers.route.js
@@ -11,6 +11,6 @@ const validator = new UploadValidator({
     {type: 'PDF', mimeType: 'application/pdf'},
     {type: 'JPG', mimeType: 'image/jpeg'}
   ]})
-const controller = new TechnicalManagersController({route: TECHNICAL_MANAGERS, validator, nextRoute: TASK_LIST, viewPath: 'upload/technicalQualification/technicalManagers'})
+const controller = new TechnicalManagersController({route: TECHNICAL_MANAGERS, validator, nextRoute: TASK_LIST})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)

--- a/src/routes/upload/technicalQualification/wamitabQualification.route.js
+++ b/src/routes/upload/technicalQualification/wamitabQualification.route.js
@@ -7,6 +7,6 @@ const WamitabQualificationController = require('../../../controllers/upload/tech
 const UploadValidator = require('../../../validators/upload/upload.validator')
 
 const validator = new UploadValidator()
-const controller = new WamitabQualificationController({route: UPLOAD_WAMITAB_QUALIFICATION, validator, nextRoute: TECHNICAL_MANAGERS, viewPath: 'upload/technicalQualification/wamitabQualification'})
+const controller = new WamitabQualificationController({route: UPLOAD_WAMITAB_QUALIFICATION, validator, nextRoute: TECHNICAL_MANAGERS})
 
 module.exports = Route.register('GET, REMOVE, UPLOAD', controller)


### PR DESCRIPTION
To make it easier to re-use views, controllers and validators, it makes sense to configure these components within the route configuration themselves.

This is part of an on-going process to iterate towards a more standard hapi framework implementation and thus make maintenance and re-usability easier in the future.

This change moves the view declaration from each controller into the route that uses that controller.
The layout of the route configuration within the route declaration has changed to make it cleaner and therefore easier to maintain.

Please note that all unit tests for all routes are still successful after this change without having to change any.