### PR TITLE
Prevent duplicate requests to the CRM in a single FE request

### DIFF
--- a/src/controllers/address/base/addressManual.controller.js
+++ b/src/controllers/address/base/addressManual.controller.js
@@ -7,13 +7,13 @@ const RecoveryService = require('../../../services/recovery.service')
 module.exports = class AddressManualController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
     if (request.payload) {
       // If we have Address details in the payload then display them in the form
       pageContext.formValues = request.payload
     } else {
-      const address = await this.getModel().getAddress(request, authToken, applicationId, applicationLineId)
+      const address = await this.getModel().getAddress(request, applicationId, applicationLineId)
       if (address) {
         pageContext.formValues = {
           'building-name-or-number': address.buildingNameOrNumber,
@@ -41,7 +41,7 @@ module.exports = class AddressManualController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+      const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
       const addressDto = {
         buildingNameOrNumber: request.payload['building-name-or-number'],
@@ -51,7 +51,7 @@ module.exports = class AddressManualController extends BaseController {
         postcode: request.payload['postcode']
       }
 
-      await this.getModel().saveManualAddress(request, authToken, applicationId, applicationLineId, addressDto)
+      await this.getModel().saveManualAddress(request, applicationId, applicationLineId, addressDto)
 
       return this.redirect({request, h, redirectPath: this.getNextRoute()})
     }

--- a/src/controllers/address/base/addressSelect.controller.js
+++ b/src/controllers/address/base/addressSelect.controller.js
@@ -8,15 +8,15 @@ const Address = require('../../../models/address.model')
 module.exports = class AddressSelectController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
-
+    const context = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = context
     let addresses, address
     let postcode = CookieService.get(request, this.getPostcodeCookieKey())
     if (postcode) {
       postcode = postcode.toUpperCase()
 
-      addresses = await Address.listByPostcode(authToken, postcode)
-      address = await this.getModel().getAddress(request, authToken, applicationId, applicationLineId)
+      addresses = await Address.listByPostcode(context, postcode)
+      address = await this.getModel().getAddress(request, applicationId, applicationLineId)
 
       if (!errors && address && addresses) {
         // Set a flag on the selected address
@@ -51,13 +51,14 @@ module.exports = class AddressSelectController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+      const context = await RecoveryService.createApplicationContext(h)
+      const {applicationId, applicationLineId} = context
 
       const addressDto = {
         uprn: request.payload['select-address'],
         postcode: CookieService.get(request, this.getPostcodeCookieKey())
       }
-      await this.getModel().saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
+      await this.getModel().saveSelectedAddress(request, applicationId, applicationLineId, addressDto)
 
       return this.redirect({request, h, redirectPath: this.getNextRoute()})
     }

--- a/src/controllers/address/base/postcode.controller.js
+++ b/src/controllers/address/base/postcode.controller.js
@@ -8,13 +8,13 @@ const Address = require('../../../models/address.model')
 module.exports = class PostcodeController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
     if (request.payload) {
       // If we have Address details in the payload then display them in the form
       pageContext.formValues = request.payload
     } else {
-      const address = await this.getModel().getAddress(request, authToken, applicationId, applicationLineId)
+      const address = await this.getModel().getAddress(request, applicationId, applicationLineId)
       if (address) {
         // If the manual entry flag is set then redirect off to the mamual address entry page instead
         if (!address.fromAddressLookup) {
@@ -42,7 +42,7 @@ module.exports = class PostcodeController extends BaseController {
   }
 
   async doPost (request, h, errors) {
-    const {authToken} = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
     const postcode = request.payload['postcode']
     const errorPath = 'postcode'
 
@@ -51,7 +51,7 @@ module.exports = class PostcodeController extends BaseController {
 
     let addresses
     try {
-      addresses = await Address.listByPostcode(authToken, postcode)
+      addresses = await Address.listByPostcode(context, postcode)
     } catch (error) {
       if (!errors) {
         // Add error if the entered postcode led to an error being returned from AddressBase

--- a/src/controllers/applicationReceived.controller.js
+++ b/src/controllers/applicationReceived.controller.js
@@ -9,10 +9,11 @@ const LoggingService = require('../services/logging.service')
 module.exports = class ApplicationReceivedController extends BaseController {
   async doGet (request, h) {
     const pageContext = this.createPageContext()
-    const {authToken, applicationId, applicationLineId, application, contact} = await RecoveryService.createApplicationContext(h, {application: true, contact: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true, contact: true})
+    const {applicationId, applicationLineId, application, contact} = context
 
-    const bacsPayment = await Payment.getBacsPayment(authToken, applicationLineId)
-    const cardPayment = await Payment.getCardPayment(authToken, applicationLineId)
+    const bacsPayment = await Payment.getBacsPayment(context, applicationLineId)
+    const cardPayment = await Payment.getCardPayment(context, applicationLineId)
 
     pageContext.applicationName = application.applicationName
     if (contact && contact.email) {

--- a/src/controllers/applyOffline.controller.js
+++ b/src/controllers/applyOffline.controller.js
@@ -44,7 +44,8 @@ module.exports = class ApplyOfflineController extends BaseController {
   }
 
   async doGet (request, h, errors) {
-    const {authToken, standardRuleId, permitHolderType} = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
+    const {standardRuleId, permitHolderType} = context
 
     let offlineCategory
     let standardRule
@@ -53,7 +54,7 @@ module.exports = class ApplyOfflineController extends BaseController {
       const standardRuleTypeId = CookieService.get(request, Constants.COOKIE_KEY.STANDARD_RULE_TYPE_ID)
       offlineCategory = ApplyOfflineController.getOfflineCategory(standardRuleTypeId)
       if (standardRuleId) {
-        standardRule = await StandardRule.getById(authToken, standardRuleId)
+        standardRule = await StandardRule.getById(context, standardRuleId)
       }
       if ((!standardRule && !offlineCategory) || (standardRule && standardRule.canApplyOnline)) {
         LoggingService.logError(`Unable to get offline category for : ${standardRuleTypeId}`)

--- a/src/controllers/companyCheckName.controller.js
+++ b/src/controllers/companyCheckName.controller.js
@@ -42,7 +42,8 @@ module.exports = class CompanyCheckNameController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, application, account} = await RecoveryService.createApplicationContext(h, {application: true, account: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true, account: true})
+      const {application, account} = context
 
       if (application && account) {
         const company = await CompanyLookupService.getCompany(account.companyNumber)
@@ -50,9 +51,9 @@ module.exports = class CompanyCheckNameController extends BaseController {
         account.accountName = company.name
         account.isValidatedWithCompaniesHouse = true
 
-        await account.save(authToken, false)
+        await account.save(context, false)
 
-        await account.confirm(authToken)
+        await account.confirm(context)
 
         // The company trading name is only set if the corresponding checkbox is ticked
         if (request.payload['use-business-trading-name'] === 'on') {
@@ -61,7 +62,7 @@ module.exports = class CompanyCheckNameController extends BaseController {
           application.tradingName = undefined
         }
 
-        await application.save(authToken)
+        await application.save(context)
       }
       return this.redirect({request, h, redirectPath: Constants.Routes.DIRECTOR_DATE_OF_BIRTH.path})
     }

--- a/src/controllers/companyNumber.controller.js
+++ b/src/controllers/companyNumber.controller.js
@@ -27,22 +27,23 @@ module.exports = class CompanyNumberController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, application} = await RecoveryService.createApplicationContext(h, {application: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true})
+      const {application} = context
 
       const companyNumber = Utilities.stripWhitespace(request.payload['company-number'])
 
       // See if there is an existing account with this company number. If not, create one.
-      const account = (await Account.getByCompanyNumber(authToken, companyNumber)) || new Account()
+      const account = (await Account.getByCompanyNumber(context, companyNumber)) || new Account()
 
       if (account.isNew()) {
         account.companyNumber = companyNumber
-        await account.save(authToken, true)
+        await account.save(context, true)
       }
 
       // Update the Application with the Account (if it has changed)
       if (application && application.accountId !== account.id) {
         application.accountId = account.id
-        await application.save(authToken)
+        await application.save(context)
       }
 
       return this.redirect({request, h, redirectPath: Constants.Routes.COMPANY_CHECK_TYPE.path})

--- a/src/controllers/confirmRules.controller.js
+++ b/src/controllers/confirmRules.controller.js
@@ -8,19 +8,21 @@ const RecoveryService = require('../services/recovery.service')
 module.exports = class ConfirmRulesController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationLineId, application, standardRule} = await RecoveryService.createApplicationContext(h, {application: true, standardRule: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true, standardRule: true})
+    const {applicationLineId, application, standardRule} = context
 
     pageContext.guidanceUrl = standardRule.guidanceUrl
     pageContext.code = standardRule.code
-    pageContext.isComplete = await ConfirmRules.isComplete(authToken, application.id, applicationLineId)
+    pageContext.isComplete = await ConfirmRules.isComplete(context, application.id, applicationLineId)
 
     return this.showView({request, h, pageContext})
   }
 
   async doPost (request, h) {
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = context
 
-    await ConfirmRules.updateCompleteness(authToken, applicationId, applicationLineId)
+    await ConfirmRules.updateCompleteness(context, applicationId, applicationLineId)
 
     return this.redirect({request, h, redirectPath: Constants.Routes.TASK_LIST.path})
   }

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -8,7 +8,8 @@ const RecoveryService = require('../services/recovery.service')
 module.exports = class CostTimeController extends BaseController {
   async doGet (request, h) {
     const pageContext = this.createPageContext()
-    const {applicationLine = {}} = await RecoveryService.createApplicationContext(h, {applicationLine: true})
+    const context = await RecoveryService.createApplicationContext(h, {applicationLine: true})
+    const {applicationLine = {}} = context
 
     // Default to 0 when the balance hasn't been set
     const {value = 0} = applicationLine
@@ -19,9 +20,10 @@ module.exports = class CostTimeController extends BaseController {
   }
 
   async doPost (request, h) {
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = context
 
-    await CostTime.updateCompleteness(authToken, applicationId, applicationLineId)
+    await CostTime.updateCompleteness(context, applicationId, applicationLineId)
 
     return this.redirect({request, h, redirectPath: Constants.Routes.TASK_LIST.path})
   }

--- a/src/controllers/declaration/base/declarations.controller.js
+++ b/src/controllers/declaration/base/declarations.controller.js
@@ -7,7 +7,8 @@ const RecoveryService = require('../../../services/recovery.service')
 module.exports = class DeclarationsController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {application} = await RecoveryService.createApplicationContext(h, {application: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true})
+    const {application} = context
 
     switch (this.route) {
       case Constants.Routes.COMPANY_DECLARE_OFFENCES:
@@ -39,12 +40,13 @@ module.exports = class DeclarationsController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId, application} = await RecoveryService.createApplicationContext(h, {application: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true})
+      const {applicationId, applicationLineId, application} = context
 
       Object.assign(application, this.getRequestData(request))
-      await application.save(authToken)
+      await application.save(context)
       if (this.updateCompleteness) {
-        await this.updateCompleteness(authToken, applicationId, applicationLineId)
+        await this.updateCompleteness(context, applicationId, applicationLineId)
       }
 
       return this.redirect({request, h, redirectPath: this.nextPath})

--- a/src/controllers/drainageTypeDrain.controller.js
+++ b/src/controllers/drainageTypeDrain.controller.js
@@ -42,7 +42,8 @@ module.exports = class drainageTypeController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId, application, standardRule} = await RecoveryService.createApplicationContext(h, {application: true, standardRule: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true, standardRule: true})
+      const {applicationId, applicationLineId, application, standardRule} = context
 
       const type = parseInt(request.payload['drainage-type'])
 
@@ -62,13 +63,13 @@ module.exports = class drainageTypeController extends BaseController {
       }
 
       application.drainageType = drainageType.type
-      await application.save(authToken)
+      await application.save(context)
 
       if (drainageType.allowed) {
-        await DrainageTypeDrain.updateCompleteness(authToken, applicationId, applicationLineId)
+        await DrainageTypeDrain.updateCompleteness(context, applicationId, applicationLineId)
         redirectPath = TASK_LIST.path
       } else {
-        await DrainageTypeDrain.clearCompleteness(authToken, applicationId, applicationLineId)
+        await DrainageTypeDrain.clearCompleteness(context, applicationId, applicationLineId)
         redirectPath = DRAINAGE_TYPE_FAIL.path
       }
 

--- a/src/controllers/payment/paymentResult.controller.js
+++ b/src/controllers/payment/paymentResult.controller.js
@@ -6,19 +6,20 @@ const RecoveryService = require('../../services/recovery.service')
 
 module.exports = class PaymentResultController extends BaseController {
   async doGet (request, h) {
-    const {authToken, application, applicationReturn, cardPayment} = await RecoveryService.createApplicationContext(h, {application: true, applicationReturn: true, cardPayment: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true, applicationReturn: true, cardPayment: true})
+    const {application, applicationReturn, cardPayment} = context
 
     if (!application.isSubmitted()) {
       return this.redirect({request, h, redirectPath: Constants.Routes.ERROR.NOT_SUBMITTED.path})
     }
 
-    const paymentStatus = await cardPayment.getCardPaymentResult(authToken)
+    const paymentStatus = await cardPayment.getCardPaymentResult(context)
     let redirectPath = `${Constants.APPLICATION_RECEIVED_URL}/${applicationReturn.slug}`
 
     // Look at the result of the payment and redirect off to the appropriate result screen
     if (paymentStatus === 'success') {
       application.paymentReceived = true
-      await application.save(authToken)
+      await application.save(context)
     } else {
       redirectPath = `${Constants.PAYMENT_CARD_PROBLEM_URL}/${applicationReturn.slug}?status=${encodeURIComponent(paymentStatus)}`
     }

--- a/src/controllers/payment/paymentType.controller.js
+++ b/src/controllers/payment/paymentType.controller.js
@@ -8,7 +8,8 @@ const {CARD_PAYMENT, BACS_PAYMENT} = Constants.Dynamics.PaymentTypes
 
 module.exports = class PaymentTypeController extends BaseController {
   async doGet (request, h, errors) {
-    const {application, applicationLine, applicationReturn} = await RecoveryService.createApplicationContext(h, {application: true, applicationLine: true, applicationReturn: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true, applicationLine: true, applicationReturn: true})
+    const {application, applicationLine, applicationReturn} = context
 
     if (!application.isSubmitted()) {
       return this.redirect({request, h, redirectPath: Constants.Routes.ERROR.NOT_SUBMITTED.path})

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -15,9 +15,9 @@ module.exports = class PermitCategoryController extends BaseController {
 
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken} = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
 
-    const categories = await StandardRuleType.getCategories(authToken)
+    const categories = await StandardRuleType.getCategories(context)
     categories.forEach((category) => {
       category.categoryName = category.categoryName.toLowerCase()
     })

--- a/src/controllers/permitHolderType.controller.js
+++ b/src/controllers/permitHolderType.controller.js
@@ -23,7 +23,8 @@ module.exports = class PermitHolderTypeController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, application} = await RecoveryService.createApplicationContext(h, {application: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true})
+      const {application} = context
 
       const permitHolder = PermitHolderTypeController.getHolderTypes()
         .filter(({id}) => request.payload['chosen-holder-type'] === id)
@@ -39,7 +40,7 @@ module.exports = class PermitHolderTypeController extends BaseController {
         CookieService.set(request, PERMIT_HOLDER_TYPE, permitHolder)
         if (permitHolder.canApplyOnline) {
           application.applicantType = permitHolder.dynamicsApplicantTypeId
-          await application.save(authToken)
+          await application.save(context)
 
           return this.redirect({request, h, redirectPath: Constants.Routes.PERMIT_CATEGORY.path})
         }

--- a/src/controllers/saveAndReturn/checkYourEmail.controller.js
+++ b/src/controllers/saveAndReturn/checkYourEmail.controller.js
@@ -19,10 +19,10 @@ module.exports = class CheckYourEmailController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken} = await RecoveryService.createApplicationContext(h)
+      const context = await RecoveryService.createApplicationContext(h)
       const saveAndReturnEmail = request.payload['save-and-return-email']
       try {
-        const totalSent = await Application.sendAllRecoveryEmails(authToken, request.headers.origin, saveAndReturnEmail)
+        const totalSent = await Application.sendAllRecoveryEmails(context, request.headers.origin, saveAndReturnEmail)
         if (totalSent === 0) {
           return this.doGet(request, h, this.setCustomError('custom.missing', 'save-and-return-email'))
         }

--- a/src/controllers/saveAndReturn/enterEmail.controller.js
+++ b/src/controllers/saveAndReturn/enterEmail.controller.js
@@ -8,9 +8,10 @@ const RecoveryService = require('../../services/recovery.service')
 module.exports = class EnterEmailController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId, application} = await RecoveryService.createApplicationContext(h, {application: true})
+    const context = await RecoveryService.createApplicationContext(h, {application: true})
+    const {applicationId, applicationLineId, application} = context
 
-    const isComplete = await SaveAndReturn.isComplete(authToken, applicationId, applicationLineId)
+    const isComplete = await SaveAndReturn.isComplete(context, applicationId, applicationLineId)
     if (isComplete) {
       return this.redirect({request, h, redirectPath: Constants.Routes.SAVE_AND_RETURN_COMPLETE.path})
     }
@@ -30,10 +31,11 @@ module.exports = class EnterEmailController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, application} = await RecoveryService.createApplicationContext(h, {application: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true})
+      const {application} = context
       application.saveAndReturnEmail = request.payload['save-and-return-email']
 
-      await application.save(authToken)
+      await application.save(context)
 
       return this.redirect({request, h, redirectPath: Constants.Routes.SAVE_AND_RETURN_CONFIRM.path})
     }

--- a/src/controllers/siteGridReference.controller.js
+++ b/src/controllers/siteGridReference.controller.js
@@ -8,14 +8,14 @@ const RecoveryService = require('../services/recovery.service')
 module.exports = class SiteGridReferenceController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
     if (request.payload) {
       // If we have Site details in the payload then display them in the form
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, authToken, applicationId, applicationLineId)
+        'site-grid-reference': await SiteNameAndLocation.getGridReference(request, applicationId, applicationLineId)
       }
     }
     return this.showView({request, h, pageContext})
@@ -25,10 +25,10 @@ module.exports = class SiteGridReferenceController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+      const context = await RecoveryService.createApplicationContext(h)
+      const {applicationId, applicationLineId} = context
 
-      await SiteNameAndLocation.saveGridReference(request, request.payload['site-grid-reference'],
-        authToken, applicationId, applicationLineId)
+      await SiteNameAndLocation.saveGridReference(request, request.payload['site-grid-reference'], applicationId, applicationLineId)
 
       return this.redirect({request, h, redirectPath: Constants.Routes.ADDRESS.POSTCODE_SITE.path})
     }

--- a/src/controllers/siteName.controller.js
+++ b/src/controllers/siteName.controller.js
@@ -8,14 +8,14 @@ const RecoveryService = require('../services/recovery.service')
 module.exports = class SiteNameController extends BaseController {
   async doGet (request, h, errors) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+    const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
     if (request.payload) {
       // If we have Location name in the payload then display them in the form
       pageContext.formValues = request.payload
     } else {
       pageContext.formValues = {
-        'site-name': await SiteNameAndLocation.getSiteName(request, authToken, applicationId, applicationLineId)
+        'site-name': await SiteNameAndLocation.getSiteName(request, applicationId, applicationLineId)
       }
     }
 
@@ -26,9 +26,9 @@ module.exports = class SiteNameController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
+      const {applicationId, applicationLineId} = await RecoveryService.createApplicationContext(h)
 
-      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], authToken, applicationId, applicationLineId)
+      await SiteNameAndLocation.saveSiteName(request, request.payload['site-name'], applicationId, applicationLineId)
 
       return this.redirect({request, h, redirectPath: Constants.Routes.SITE_GRID_REFERENCE.path})
     }

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -25,13 +25,14 @@ module.exports = class StartOrOpenSavedController extends BaseController {
     }
 
     const cookie = await CookieService.generateCookie(h)
+    const {authToken} = cookie
 
     let nextPage
     if (request.payload['started-application'] === 'new') {
       // Create new application in Dynamics and set the applicationId in the cookie
       const application = new Application()
       application.statusCode = Constants.Dynamics.StatusCode.DRAFT
-      await application.save(cookie.authToken)
+      await application.save({authToken})
 
       // Set the application ID in the cookie
       cookie.applicationId = application.id

--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -8,8 +8,9 @@ const RecoveryService = require('../services/recovery.service')
 module.exports = class TaskListController extends BaseController {
   async doGet (request, h, errors, firstTimeIn = true) {
     const pageContext = this.createPageContext(errors)
-    const {authToken, applicationLineId, standardRule} = await RecoveryService.createApplicationContext(h, {standardRule: true})
-    const taskList = await TaskList.getByApplicationLineId(authToken, applicationLineId)
+    const context = await RecoveryService.createApplicationContext(h, {standardRule: true})
+    const {applicationLineId, standardRule} = context
+    const taskList = await TaskList.getByApplicationLineId(context, applicationLineId)
 
     const showError = Boolean(request.query.showError)
     if (showError && firstTimeIn) {

--- a/src/controllers/technicalQualification.controller.js
+++ b/src/controllers/technicalQualification.controller.js
@@ -47,10 +47,11 @@ module.exports = class TechnicalQualificationController extends BaseController {
     if (errors && errors.details) {
       return this.doGet(request, h, errors)
     } else {
-      const {authToken, application} = await RecoveryService.createApplicationContext(h, {application: true})
+      const context = await RecoveryService.createApplicationContext(h, {application: true})
+      const {application} = context
 
       application.technicalQualification = request.payload['technical-qualification']
-      await application.save(authToken)
+      await application.save(context)
 
       return this.redirect({request, h, redirectPath: await TechnicalQualificationController._getPath(application.technicalQualification)})
     }

--- a/src/controllers/version.controller.js
+++ b/src/controllers/version.controller.js
@@ -12,15 +12,15 @@ module.exports = class VersionController extends BaseController {
   async doGet (request, h) {
     const pageContext = this.createPageContext()
 
-    let authToken = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
+    let context = CookieService.get(request, Constants.COOKIE_KEY.AUTH_TOKEN)
 
     // If we didn't get an Auth token from the cookie then create a new one
-    if (!authToken) {
+    if (!context) {
       const cookie = await CookieService.generateCookie(h)
-      authToken = cookie.authToken
+      context = cookie.context
     }
 
-    pageContext.dynamicsSolution = await DynamicsSolution.get(authToken)
+    pageContext.dynamicsSolution = await DynamicsSolution.get(context)
 
     pageContext.applicationVersion = Constants.getVersion()
     pageContext.githubRef = config.gitSha

--- a/src/models/account.model.js
+++ b/src/models/account.model.js
@@ -21,9 +21,9 @@ class Account extends BaseModel {
     ]
   }
 
-  static async getByApplicationId (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const application = await Application.getById(authToken, applicationId)
+  static async getByApplicationId (context, applicationId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
+    const application = await Application.getById(context, applicationId)
     if (application && application.accountId) {
       try {
         const query = encodeURI(`accounts(${application.accountId})?$select=${Account.selectedDynamicsFields()}`)
@@ -36,8 +36,8 @@ class Account extends BaseModel {
     }
   }
 
-  static async getByCompanyNumber (authToken, companyNumber) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByCompanyNumber (context, companyNumber) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     try {
       const filter = `defra_companyhouseid eq '${companyNumber}'`
       const query = encodeURI(`accounts?$select=${Account.selectedDynamicsFields()}&$filter=${filter}`)
@@ -52,15 +52,15 @@ class Account extends BaseModel {
     }
   }
 
-  async save (authToken, isDraft) {
+  async save (context, isDraft) {
     const dataObject = this.modelToDynamics()
     dataObject.defra_companyhouseid = dataObject.defra_companyhouseid ? Utilities.stripWhitespace(dataObject.defra_companyhouseid).toUpperCase() : undefined
     dataObject.defra_draft = isDraft
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 
-  async confirm (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  async confirm (context) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const actionDataObject = {
       CompanyRegistrationNumber: this.companyNumber
     }

--- a/src/models/address.model.js
+++ b/src/models/address.model.js
@@ -23,15 +23,15 @@ class Address extends BaseModel {
     ]
   }
 
-  static async getByUprn (authToken, uprn) {
-    if (!authToken) {
-      const errorMessage = `Unable to get ${this._entity} by UPRN: Auth Token not supplied`
+  static async getByUprn (context, uprn) {
+    if (!context) {
+      const errorMessage = `Unable to get ${this._entity} by UPRN: Context not supplied`
       LoggingService.logError(errorMessage)
       throw new Error(errorMessage)
     }
 
     let address
-    const dynamicsDal = new DynamicsDalService(authToken)
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `defra_uprn eq '${uprn}'`
     const query = `defra_addresses?$select=${this.selectedDynamicsFields()}&$filter=${filter}`
     try {
@@ -47,9 +47,9 @@ class Address extends BaseModel {
     return address
   }
 
-  static async listByPostcode (authToken, postcode) {
+  static async listByPostcode (context, postcode) {
     let addresses
-    const dynamicsDal = new DynamicsDalService(authToken)
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const actionDataObject = {
       postcode: postcode
     }
@@ -81,14 +81,14 @@ class Address extends BaseModel {
     return addresses
   }
 
-  async save (authToken) {
+  async save (context) {
     // Build the address name (i.e. the full address) if it is a manual address entry
     if (!this.fromAddressLookup) {
       this.fullAddress = `${this.buildingNameOrNumber}, ${this.addressLine1}, ${this.addressLine2}, ${this.townOrCity}, ${this.postcode}`
     }
     const dataObject = this.modelToDynamics()
 
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/addressDetail.model.js
+++ b/src/models/addressDetail.model.js
@@ -24,8 +24,8 @@ class AddressDetail extends BaseModel {
     ]
   }
 
-  static async getByApplicationIdAndType (authToken, applicationId, type) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByApplicationIdAndType (context, applicationId, type) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `_defra_applicationid_value eq ${applicationId} and defra_addresstype eq ${type}`
     const query = `defra_addressdetailses?$select=${AddressDetail.selectedDynamicsFields()}&$filter=${filter}`
 
@@ -41,29 +41,29 @@ class AddressDetail extends BaseModel {
     }
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics()
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 
-  static async getDetails (authToken, applicationId, type) {
-    return (await AddressDetail.getByApplicationIdAndType(authToken, applicationId, type.TYPE)) || new AddressDetail({applicationId, addressDetail: type.NAME, type: type.TYPE})
+  static async getDetails (context, applicationId, type) {
+    return (await AddressDetail.getByApplicationIdAndType(context, applicationId, type.TYPE)) || new AddressDetail({applicationId, addressDetail: type.NAME, type: type.TYPE})
   }
 
-  static async getCompanySecretaryDetails (authToken, applicationId) {
-    return this.getDetails(authToken, applicationId, COMPANY_SECRETARY_EMAIL)
+  static async getCompanySecretaryDetails (context, applicationId) {
+    return this.getDetails(context, applicationId, COMPANY_SECRETARY_EMAIL)
   }
 
-  static async getPrimaryContactDetails (authToken, applicationId) {
-    return this.getDetails(authToken, applicationId, PRIMARY_CONTACT_TELEPHONE_NUMBER)
+  static async getPrimaryContactDetails (context, applicationId) {
+    return this.getDetails(context, applicationId, PRIMARY_CONTACT_TELEPHONE_NUMBER)
   }
 
-  static async getBillingInvoicingDetails (authToken, applicationId) {
-    return this.getDetails(authToken, applicationId, BILLING_INVOICING)
+  static async getBillingInvoicingDetails (context, applicationId) {
+    return this.getDetails(context, applicationId, BILLING_INVOICING)
   }
 
-  static async getIndividualPermitHolderDetails (authToken, applicationId) {
-    return this.getDetails(authToken, applicationId, INDIVIDUAL_PERMIT_HOLDER)
+  static async getIndividualPermitHolderDetails (context, applicationId) {
+    return this.getDetails(context, applicationId, INDIVIDUAL_PERMIT_HOLDER)
   }
 }
 

--- a/src/models/annotation.model.js
+++ b/src/models/annotation.model.js
@@ -19,14 +19,14 @@ class Annotation extends BaseModel {
     ]
   }
 
-  static async getById (authToken, id) {
-    return super.getById(authToken, id, ({dynamics}) => dynamics !== 'documentbody')
+  static async getById (context, id) {
+    return super.getById(context, id, ({dynamics}) => dynamics !== 'documentbody')
   }
 
-  static async getByApplicationIdSubjectAndFilename (authToken, applicationId, subject, filename) {
+  static async getByApplicationIdSubjectAndFilename (context, applicationId, subject, filename) {
     let payment
     if (applicationId) {
-      const dynamicsDal = new DynamicsDalService(authToken)
+      const dynamicsDal = new DynamicsDalService(context.authToken)
       const filter = `_objectid_value eq ${applicationId} and filename eq '${filename}' and subject eq '${subject}'`
       const query = `annotations?$select=${Annotation.selectedDynamicsFields()}&$filter=${filter}`
       try {
@@ -43,9 +43,9 @@ class Annotation extends BaseModel {
     return payment
   }
 
-  static async listByApplicationIdAndSubject (authToken, applicationId, subject) {
+  static async listByApplicationIdAndSubject (context, applicationId, subject) {
     if (applicationId) {
-      const dynamicsDal = new DynamicsDalService(authToken)
+      const dynamicsDal = new DynamicsDalService(context.authToken)
       const filter = `_objectid_value eq ${applicationId} and objecttypecode eq 'defra_application' and subject eq '${subject}'`
       const query = encodeURI(`annotations?$select=${Annotation.selectedDynamicsFields(({dynamics}) => dynamics !== 'documentbody')}&$filter=${filter}`)
       try {
@@ -58,9 +58,9 @@ class Annotation extends BaseModel {
     }
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics()
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/applicationContact.model.js
+++ b/src/models/applicationContact.model.js
@@ -18,8 +18,8 @@ class ApplicationContact extends BaseModel {
     ]
   }
 
-  static async get (authToken, applicationId, contactId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async get (context, applicationId, contactId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `_defra_applicationid_value eq ${applicationId} and _defra_contactid_value eq ${contactId}`
     const query = `defra_applicationcontacts?$select=${ApplicationContact.selectedDynamicsFields()}&$filter=${filter}`
     try {
@@ -34,9 +34,9 @@ class ApplicationContact extends BaseModel {
     }
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics()
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/applicationLine.model.js
+++ b/src/models/applicationLine.model.js
@@ -22,8 +22,8 @@ class ApplicationLine extends BaseModel {
     ]
   }
 
-  static async getByApplicationId (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByApplicationId (context, applicationId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `_defra_applicationid_value eq ${applicationId}`
     const query = `defra_applicationlines?$select=${ApplicationLine.selectedDynamicsFields()}&$filter=${filter}`
     try {
@@ -38,8 +38,8 @@ class ApplicationLine extends BaseModel {
     }
   }
 
-  static async getValidRulesetIds (authToken, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getValidRulesetIds (context, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const rulesetIds = Object.keys(RulesetIds).map((prop) => RulesetIds[prop])
     const query = encodeURI(`defra_applicationlines(${applicationLineId})?$expand=defra_parametersId($select=${rulesetIds.join()})`)
     let validRuleIds = []
@@ -56,8 +56,8 @@ class ApplicationLine extends BaseModel {
     return validRuleIds
   }
 
-  static async getCompleted (authToken, applicationLineId, completedId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getCompleted (context, applicationLineId, completedId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const query = encodeURI(`defra_applicationlines(${applicationLineId})?$expand=defra_parametersId($select=${completedId})`)
     let completed
     try {
@@ -73,9 +73,9 @@ class ApplicationLine extends BaseModel {
     return completed
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics()
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/applicationReturn.model.js
+++ b/src/models/applicationReturn.model.js
@@ -20,8 +20,8 @@ class ApplicationReturn extends BaseModel {
     ]
   }
 
-  static async getByApplicationId (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByApplicationId (context, applicationId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `_defra_application_value eq ${applicationId}`
     const query = `defra_saveandreturns?$select=${ApplicationReturn.selectedDynamicsFields()}&$filter=${filter}`
     try {
@@ -36,8 +36,8 @@ class ApplicationReturn extends BaseModel {
     }
   }
 
-  static async getBySlug (authToken, slug) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getBySlug (context, slug) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `defra_suffix eq '${slug}'`
     const query = `defra_saveandreturns?$select=${ApplicationReturn.selectedDynamicsFields()}&$filter=${filter}`
     try {

--- a/src/models/checkYourAnswers/base.check.js
+++ b/src/models/checkYourAnswers/base.check.js
@@ -34,27 +34,27 @@ module.exports = class BaseCheck {
   }
 
   async getApplication () {
-    const {authToken, applicationId, application} = this.data
+    const {applicationId, application} = this.data
     if (!application) {
-      this.data.application = await Application.getById(authToken, applicationId)
+      this.data.application = await Application.getById(this.data, applicationId)
     }
     return this.data.application || {}
   }
 
   async getContact () {
-    const {authToken, contact} = this.data
+    const {contact} = this.data
     const {contactId} = await this.getApplication()
     if (!contact) {
-      this.data.contact = contactId ? await Contact.getById(authToken, contactId) : new Contact()
+      this.data.contact = contactId ? await Contact.getById(this.data, contactId) : new Contact()
     }
     return this.data.contact || {}
   }
 
   async getAgentAccount () {
-    const {authToken, agentAccount} = this.data
+    const {agentAccount} = this.data
     const {agentId} = await this.getApplication()
     if (!agentAccount) {
-      this.data.agentAccount = agentId ? await Account.getById(authToken, agentId) : new Account()
+      this.data.agentAccount = agentId ? await Account.getById(this.data, agentId) : new Account()
     }
     return this.data.agentAccount || {}
   }
@@ -68,28 +68,28 @@ module.exports = class BaseCheck {
   }
 
   async getCompanyAccount () {
-    const {authToken, applicationId, companyAccount} = this.data
+    const {applicationId, companyAccount} = this.data
     if (!companyAccount) {
-      this.data.companyAccount = await Account.getByApplicationId(authToken, applicationId)
+      this.data.companyAccount = await Account.getByApplicationId(this.data, applicationId)
     }
     return this.data.companyAccount || {}
   }
 
   async getCompanySecretaryDetails () {
-    const {authToken, applicationId, companySecretaryDetails} = this.data
+    const {applicationId, companySecretaryDetails} = this.data
     if (!companySecretaryDetails) {
-      this.data.companySecretaryDetails = await AddressDetail.getCompanySecretaryDetails(authToken, applicationId)
+      this.data.companySecretaryDetails = await AddressDetail.getCompanySecretaryDetails(this.data, applicationId)
     }
     return this.data.companySecretaryDetails || {}
   }
 
   async getDirectors () {
-    const {authToken, applicationId, directors} = this.data
+    const {applicationId, directors} = this.data
     const {id} = await this.getCompanyAccount()
     if (!directors) {
-      this.data.directors = await Contact.list(authToken, id, COMPANY_DIRECTOR)
+      this.data.directors = await Contact.list(this.data, id, COMPANY_DIRECTOR)
       await Promise.all(this.data.directors.map(async (director) => {
-        let applicationContact = await ApplicationContact.get(authToken, applicationId, director.id)
+        let applicationContact = await ApplicationContact.get(this.data, applicationId, director.id)
         if (applicationContact && applicationContact.directorDob) {
           director.dob.day = Utilities.extractDayFromDate(applicationContact.directorDob)
         }
@@ -99,109 +99,109 @@ module.exports = class BaseCheck {
   }
 
   async getPrimaryContactDetails () {
-    const {authToken, applicationId, primaryContactDetails} = this.data
+    const {applicationId, primaryContactDetails} = this.data
     if (!primaryContactDetails) {
-      this.data.primaryContactDetails = await AddressDetail.getPrimaryContactDetails(authToken, applicationId)
+      this.data.primaryContactDetails = await AddressDetail.getPrimaryContactDetails(this.data, applicationId)
     }
     return this.data.primaryContactDetails || {}
   }
 
   async getIndividualPermitHolder () {
-    const {authToken, applicationId, individualPermitHolder} = this.data
+    const {applicationId, individualPermitHolder} = this.data
     if (!individualPermitHolder) {
-      this.data.individualPermitHolder = await Contact.getIndividualPermitHolderByApplicationId(authToken, applicationId)
+      this.data.individualPermitHolder = await Contact.getIndividualPermitHolderByApplicationId(this.data, applicationId)
     }
     return this.data.individualPermitHolder || {}
   }
 
   async getIndividualPermitHolderDetails () {
-    const {authToken, applicationId, individualPermitHolderDetails} = this.data
+    const {applicationId, individualPermitHolderDetails} = this.data
     if (!individualPermitHolderDetails) {
-      this.data.individualPermitHolderDetails = await AddressDetail.getIndividualPermitHolderDetails(authToken, applicationId)
+      this.data.individualPermitHolderDetails = await AddressDetail.getIndividualPermitHolderDetails(this.data, applicationId)
     }
     return this.data.individualPermitHolderDetails || {}
   }
 
   async getIndividualPermitHolderAddress () {
-    const {authToken, individualPermitHolderAddress} = this.data
+    const {individualPermitHolderAddress} = this.data
     if (!individualPermitHolderAddress) {
       const permitHolderDetails = await this.getIndividualPermitHolderDetails()
-      this.data.individualPermitHolderAddress = await Address.getById(authToken, permitHolderDetails.addressId)
+      this.data.individualPermitHolderAddress = await Address.getById(this.data, permitHolderDetails.addressId)
     }
     return this.data.individualPermitHolderAddress || {}
   }
 
   async getBillingInvoicingDetails () {
-    const {authToken, applicationId} = this.data
+    const {applicationId} = this.data
     if (!this.data.billingInvoicingDetails) {
-      this.data.billingInvoicingDetails = await AddressDetail.getBillingInvoicingDetails(authToken, applicationId)
+      this.data.billingInvoicingDetails = await AddressDetail.getBillingInvoicingDetails(this.data, applicationId)
     }
     return this.data.billingInvoicingDetails || {}
   }
 
   async getStandardRule () {
-    const {authToken, applicationLineId, standardRule} = this.data
+    const {applicationLineId, standardRule} = this.data
     if (!standardRule) {
-      this.data.standardRule = await StandardRule.getByApplicationLineId(authToken, applicationLineId)
+      this.data.standardRule = await StandardRule.getByApplicationLineId(this.data, applicationLineId)
     }
     return this.data.standardRule || {}
   }
 
   async getLocation () {
-    const {authToken, applicationId, applicationLineId, location} = this.data
+    const {applicationId, applicationLineId, location} = this.data
     if (!location) {
-      this.data.location = await Location.getByApplicationId(authToken, applicationId, applicationLineId)
+      this.data.location = await Location.getByApplicationId(this.data, applicationId, applicationLineId)
     }
     return this.data.location || {}
   }
 
   async getLocationDetail () {
-    const {authToken, locationDetail} = this.data
+    const {locationDetail} = this.data
     const {id} = await this.getLocation()
     if (!locationDetail) {
-      this.data.locationDetail = await LocationDetail.getByLocationId(authToken, id)
+      this.data.locationDetail = await LocationDetail.getByLocationId(this.data, id)
     }
     return this.data.locationDetail || {}
   }
 
   async getLocationAddress () {
-    const {authToken, locationAddress} = this.data
+    const {locationAddress} = this.data
     const {addressId} = await this.getLocationDetail()
     if (!locationAddress) {
-      this.data.locationAddress = await Address.getById(authToken, addressId)
+      this.data.locationAddress = await Address.getById(this.data, addressId)
     }
     return this.data.locationAddress || {}
   }
 
   async getInvoiceAddress () {
-    const {authToken, invoiceAddress} = this.data
+    const {invoiceAddress} = this.data
     const {addressId} = await this.getBillingInvoicingDetails()
     if (!invoiceAddress) {
-      this.data.invoiceAddress = await Address.getById(authToken, addressId)
+      this.data.invoiceAddress = await Address.getById(this.data, addressId)
     }
     return this.data.invoiceAddress || {}
   }
 
   async getTechnicalCompetenceEvidence () {
-    const {authToken, applicationId, technicalCompetenceEvidence} = this.data
+    const {applicationId, technicalCompetenceEvidence} = this.data
     if (!technicalCompetenceEvidence) {
-      this.data.technicalCompetenceEvidence = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, TECHNICAL_QUALIFICATION)
+      this.data.technicalCompetenceEvidence = await Annotation.listByApplicationIdAndSubject(this.data, applicationId, TECHNICAL_QUALIFICATION)
     }
     return this.data.technicalCompetenceEvidence || {}
   }
 
   async getSitePlan () {
-    const {authToken, applicationId, sitePlan} = this.data
+    const {applicationId, sitePlan} = this.data
     if (!sitePlan) {
-      this.data.sitePlan = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, SITE_PLAN)
+      this.data.sitePlan = await Annotation.listByApplicationIdAndSubject(this.data, applicationId, SITE_PLAN)
     }
     return this.data.sitePlan || {}
   }
 
   async getFirePreventionPlan () {
-    const {authToken, applicationId, firePreventionPlan} = this.data
+    const {applicationId, firePreventionPlan} = this.data
     if (!firePreventionPlan) {
-      this.data.firePreventionPlan = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, FIRE_PREVENTION_PLAN)
+      this.data.firePreventionPlan = await Annotation.listByApplicationIdAndSubject(this.data, applicationId, FIRE_PREVENTION_PLAN)
     }
     return this.data.firePreventionPlan || {}
   }

--- a/src/models/configuration.model.js
+++ b/src/models/configuration.model.js
@@ -20,8 +20,8 @@ class Configuration extends BaseModel {
     ]
   }
 
-  static async list (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async list (context) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const query = encodeURI(`defra_configurations?$select=${Configuration.selectedDynamicsFields()}`)
     try {
       const response = await dynamicsDal.search(query)

--- a/src/models/contact.model.js
+++ b/src/models/contact.model.js
@@ -23,12 +23,12 @@ class Contact extends BaseModel {
     ]
   }
 
-  static async getById (authToken, id) {
-    return super.getById(authToken, id, ({dynamics}) => dynamics !== 'defra_dateofbirthdaycompanieshouse')
+  static async getById (context, id) {
+    return super.getById(context, id, ({dynamics}) => dynamics !== 'defra_dateofbirthdaycompanieshouse')
   }
 
-  static async list (authToken, accountId = undefined, contactType = Constants.Dynamics.COMPANY_DIRECTOR) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async list (context, accountId = undefined, contactType = Constants.Dynamics.COMPANY_DIRECTOR) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     let filter = `accountrolecode eq ${contactType} and defra_resignedoncompanieshouse eq null`
     if (accountId) {
@@ -48,9 +48,9 @@ class Contact extends BaseModel {
     }
   }
 
-  static async getIndividualPermitHolderByApplicationId (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const application = await Application.getById(authToken, applicationId)
+  static async getIndividualPermitHolderByApplicationId (context, applicationId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
+    const application = await Application.getById(context, applicationId)
     if (application.individualPermitHolderId()) {
       try {
         const query = encodeURI(`contacts(${application.individualPermitHolderId()})?$select=${Contact.selectedDynamicsFields()}`)
@@ -65,9 +65,9 @@ class Contact extends BaseModel {
     }
   }
 
-  static async getByApplicationId (authToken, applicationId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
-    const application = await Application.getById(authToken, applicationId)
+  static async getByApplicationId (context, applicationId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
+    const application = await Application.getById(context, applicationId)
     if (application.contactId) {
       try {
         const query = encodeURI(`contacts(${application.contactId})?$select=${Contact.selectedDynamicsFields()}`)
@@ -82,8 +82,8 @@ class Contact extends BaseModel {
     }
   }
 
-  static async getByFirstnameLastnameEmail (authToken, firstName, lastName, email) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByFirstnameLastnameEmail (context, firstName, lastName, email) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `firstname eq '${firstName}' and lastname eq '${lastName}' and emailaddress1 eq '${encodeURIComponent(email)}'`
     const query = `contacts?$select=${this.selectedDynamicsFields()}&$filter=${filter}`
     try {
@@ -98,9 +98,9 @@ class Contact extends BaseModel {
     }
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics()
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/dynamicsSolution.model.js
+++ b/src/models/dynamicsSolution.model.js
@@ -9,8 +9,8 @@ class DynamicsSolution extends BaseModel {
     return 'solutions'
   }
 
-  static async get (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async get (context) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     // The three solutions we are interested in are:
     // - Core

--- a/src/models/location.model.js
+++ b/src/models/location.model.js
@@ -25,9 +25,9 @@ class Location extends BaseModel {
     }
   }
 
-  static async getByApplicationId (authToken, applicationId, applicationLineId) {
+  static async getByApplicationId (context, applicationId, applicationLineId) {
     if (applicationId) {
-      const dynamicsDal = new DynamicsDalService(authToken)
+      const dynamicsDal = new DynamicsDalService(context.authToken)
       const filter = `_defra_applicationid_value eq ${applicationId}`
       const query = encodeURI(`defra_locations?$select=${Location.selectedDynamicsFields()}&$filter=${filter}`)
       try {
@@ -45,9 +45,9 @@ class Location extends BaseModel {
     }
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics(({field}) => field !== 'id')
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/locationDetail.model.js
+++ b/src/models/locationDetail.model.js
@@ -19,9 +19,9 @@ class LocationDetail extends BaseModel {
     ]
   }
 
-  static async getByLocationId (authToken, locationId) {
+  static async getByLocationId (context, locationId) {
     if (locationId) {
-      const dynamicsDal = new DynamicsDalService(authToken)
+      const dynamicsDal = new DynamicsDalService(context.authToken)
       const filter = `_defra_locationid_value eq ${locationId}`
       const query = encodeURI(`defra_locationdetailses?$select=${LocationDetail.selectedDynamicsFields()}&$filter=${filter}`)
       try {
@@ -42,9 +42,9 @@ class LocationDetail extends BaseModel {
     this.addressId = addressId
   }
 
-  async save (authToken) {
+  async save (context) {
     const dataObject = this.modelToDynamics(({field}) => field !== 'id')
-    await super.save(authToken, dataObject)
+    await super.save(context, dataObject)
   }
 }
 

--- a/src/models/payment.model.js
+++ b/src/models/payment.model.js
@@ -31,18 +31,18 @@ class Payment extends BaseModel {
     return Boolean(this.statusCode === Constants.Dynamics.PaymentStatusCodes.ISSUED)
   }
 
-  static async getBacsPayment (authToken, applicationLineId) {
-    return this.getByApplicationLineIdAndType(authToken, applicationLineId, Constants.Dynamics.PaymentTypes.BACS_PAYMENT)
+  static async getBacsPayment (context, applicationLineId) {
+    return this.getByApplicationLineIdAndType(context, applicationLineId, Constants.Dynamics.PaymentTypes.BACS_PAYMENT)
   }
 
-  static async getCardPayment (authToken, applicationLineId) {
-    return this.getByApplicationLineIdAndType(authToken, applicationLineId, Constants.Dynamics.PaymentTypes.CARD_PAYMENT)
+  static async getCardPayment (context, applicationLineId) {
+    return this.getByApplicationLineIdAndType(context, applicationLineId, Constants.Dynamics.PaymentTypes.CARD_PAYMENT)
   }
 
-  static async getByApplicationLineIdAndType (authToken, applicationLineId, type) {
+  static async getByApplicationLineIdAndType (context, applicationLineId, type) {
     let payment
     if (applicationLineId) {
-      const dynamicsDal = new DynamicsDalService(authToken)
+      const dynamicsDal = new DynamicsDalService(context.authToken)
       const filter = `_defra_applicationlineid_value eq ${applicationLineId} and defra_type eq ${type}`
       const query = `defra_payments?$select=${Payment.selectedDynamicsFields()}&$filter=${filter}`
       try {
@@ -59,16 +59,16 @@ class Payment extends BaseModel {
     return payment
   }
 
-  static async getBacsPaymentDetails (authToken, applicationLineId) {
-    return (await Payment.getByApplicationLineIdAndType(authToken, applicationLineId, BACS_PAYMENT)) || new Payment({applicationLineId, type: BACS_PAYMENT})
+  static async getBacsPaymentDetails (context, applicationLineId) {
+    return (await Payment.getByApplicationLineIdAndType(context, applicationLineId, BACS_PAYMENT)) || new Payment({applicationLineId, type: BACS_PAYMENT})
   }
 
-  static async getCardPaymentDetails (authToken, applicationLineId) {
-    return (await Payment.getByApplicationLineIdAndType(authToken, applicationLineId, CARD_PAYMENT)) || new Payment({applicationLineId, type: CARD_PAYMENT})
+  static async getCardPaymentDetails (context, applicationLineId) {
+    return (await Payment.getByApplicationLineIdAndType(context, applicationLineId, CARD_PAYMENT)) || new Payment({applicationLineId, type: CARD_PAYMENT})
   }
 
-  async makeCardPayment (authToken, description, returnUrl) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  async makeCardPayment (context, description, returnUrl) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const actionDataObject = {
       Amount: this.value,
       ReturnUrl: returnUrl,
@@ -89,8 +89,8 @@ class Payment extends BaseModel {
     }
   }
 
-  async getCardPaymentResult (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  async getCardPaymentResult (context) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const actionDataObject = {
       LookupByPaymentReference: this.referenceNumber
     }

--- a/src/models/standardRule.model.js
+++ b/src/models/standardRule.model.js
@@ -34,8 +34,8 @@ class StandardRule extends BaseModel {
     this.codeForId = StandardRule.transformPermitCode(standardRule.code)
   }
 
-  static async getByCode (authToken, code) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByCode (context, code) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const filter = `defra_code eq '${code}'`
     const query = encodeURI(`defra_standardrules?$select=${StandardRule.selectedDynamicsFields()}&$filter=${filter}`)
     try {
@@ -48,11 +48,11 @@ class StandardRule extends BaseModel {
     }
   }
 
-  static async getByApplicationLineId (authToken, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByApplicationLineId (context, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const {standardRuleId} = await ApplicationLine.getById(authToken, applicationLineId)
+      const {standardRuleId} = await ApplicationLine.getById(context, applicationLineId)
       const query = encodeURI(`defra_standardrules(${standardRuleId})?$select=${StandardRule.selectedDynamicsFields()}`)
       const result = await dynamicsDal.search(query)
       return StandardRule.dynamicsToModel(result)
@@ -62,8 +62,8 @@ class StandardRule extends BaseModel {
     }
   }
 
-  static async list (authToken, standardRuleTypeId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async list (context, standardRuleTypeId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     let filter =
       // Must be open for applications

--- a/src/models/standardRuleType.model.js
+++ b/src/models/standardRuleType.model.js
@@ -23,8 +23,8 @@ class StandardRuleType extends BaseModel {
     ]
   }
 
-  static async list (authToken) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async list (context) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     const orderBy = 'defra_category asc'
 
     const query = encodeURI(`defra_standardruletypes?$select=${StandardRuleType.selectedDynamicsFields()}&$orderby=${orderBy}`)
@@ -39,14 +39,14 @@ class StandardRuleType extends BaseModel {
     }
   }
 
-  static async getCategories (authToken) {
+  static async getCategories (context) {
     const categories = Object.keys(OFFLINE_CATEGORIES)
       .map((key) => {
         const {id, category, name: categoryName, hint = ''} = OFFLINE_CATEGORIES[key]
         return {id, categoryName, category, hint}
       })
 
-    const standardRuleTypes = await StandardRuleType.list(authToken)
+    const standardRuleTypes = await StandardRuleType.list(context)
     standardRuleTypes.forEach(({id = '', categoryName = '', category = '', hint = ''}) => {
       categories.push({id, categoryName: categoryName.toLowerCase(), category, hint})
     })

--- a/src/models/taskList/confidentiality.model.js
+++ b/src/models/taskList/confidentiality.model.js
@@ -13,12 +13,12 @@ module.exports = class Confidentiality extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await Confidentiality.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await Confidentiality.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.CONFIRM_CONFIDENTIALLY]: isComplete
@@ -31,11 +31,11 @@ module.exports = class Confidentiality extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Application for this application
-      const application = await Application.getById(authToken, applicationId)
+      const application = await Application.getById(context, applicationId)
 
       isComplete = application.confidentiality !== undefined
     } catch (error) {

--- a/src/models/taskList/confirmRules.model.js
+++ b/src/models/taskList/confirmRules.model.js
@@ -12,11 +12,11 @@ module.exports = class ConfirmRules extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
 
       const query = `defra_wasteparamses(${applicationLine.parametersId})`
       await dynamicsDal.update(query, {[CONFIRM_RULES]: true})
@@ -26,11 +26,11 @@ module.exports = class ConfirmRules extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the completed flag for confirm rules
-      const completed = await ApplicationLine.getCompleted(authToken, applicationLineId, CONFIRM_RULES)
+      const completed = await ApplicationLine.getCompleted(context, applicationLineId, CONFIRM_RULES)
 
       isComplete = Boolean(completed)
     } catch (error) {

--- a/src/models/taskList/contactDetails.model.js
+++ b/src/models/taskList/contactDetails.model.js
@@ -13,12 +13,12 @@ module.exports = class ContactDetails extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await ContactDetails.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await ContactDetails.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.CONTACT_DETAILS]: isComplete
@@ -31,11 +31,11 @@ module.exports = class ContactDetails extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Contact for this application
-      const contact = await Contact.getByApplicationId(authToken, applicationId)
+      const contact = await Contact.getByApplicationId(context, applicationId)
 
       isComplete = Boolean(contact && contact.firstName)
     } catch (error) {

--- a/src/models/taskList/costTime.model.js
+++ b/src/models/taskList/costTime.model.js
@@ -12,11 +12,11 @@ module.exports = class CostTime extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
 
       const query = `defra_wasteparamses(${applicationLine.parametersId})`
       await dynamicsDal.update(query, {[SHOW_COST_AND_TIME]: true})
@@ -26,11 +26,11 @@ module.exports = class CostTime extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the completed flag for cost time
-      const completed = await ApplicationLine.getCompleted(authToken, applicationLineId, SHOW_COST_AND_TIME)
+      const completed = await ApplicationLine.getCompleted(context, applicationLineId, SHOW_COST_AND_TIME)
 
       isComplete = Boolean(completed)
     } catch (error) {

--- a/src/models/taskList/drainageTypeDrain.model.js
+++ b/src/models/taskList/drainageTypeDrain.model.js
@@ -6,11 +6,11 @@ const BaseModel = require('../base.model')
 const LoggingService = require('../../services/logging.service')
 const ApplicationLine = require('../applicationLine.model')
 
-const updateCompleteness = async (authToken, applicationId, applicationLineId, value) => {
-  const dynamicsDal = new DynamicsDalService(authToken)
+const updateCompleteness = async (context, applicationId, applicationLineId, value) => {
+  const dynamicsDal = new DynamicsDalService(context.authToken)
 
   try {
-    const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
+    const applicationLine = await ApplicationLine.getById(context, applicationLineId)
 
     const query = `defra_wasteparamses(${applicationLine.parametersId})`
     await dynamicsDal.update(query, {[SURFACE_DRAINAGE]: value})
@@ -34,11 +34,11 @@ module.exports = class DrainageTypeDrain extends BaseModel {
     await updateCompleteness(...args, false)
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the completed flag for surface drainage
-      const completed = await ApplicationLine.getCompleted(authToken, applicationLineId, SURFACE_DRAINAGE)
+      const completed = await ApplicationLine.getCompleted(context, applicationLineId, SURFACE_DRAINAGE)
 
       isComplete = Boolean(completed)
     } catch (error) {

--- a/src/models/taskList/firePreventionPlan.model.js
+++ b/src/models/taskList/firePreventionPlan.model.js
@@ -8,12 +8,12 @@ const Annotation = require('../annotation.model')
 const ApplicationLine = require('../applicationLine.model')
 
 module.exports = class FirePreventionPlan extends BaseModel {
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await FirePreventionPlan.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await FirePreventionPlan.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.FIRE_PREVENTION_PLAN]: isComplete
@@ -26,11 +26,11 @@ module.exports = class FirePreventionPlan extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Evidence for a fire prevention plan
-      const evidence = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, Constants.UploadSubject.FIRE_PREVENTION_PLAN)
+      const evidence = await Annotation.listByApplicationIdAndSubject(context, applicationId, Constants.UploadSubject.FIRE_PREVENTION_PLAN)
       isComplete = Boolean(evidence.length)
     } catch (error) {
       LoggingService.logError(`Unable to calculate ${this.name} completeness: ${error}`)

--- a/src/models/taskList/invoiceAddress.model.js
+++ b/src/models/taskList/invoiceAddress.model.js
@@ -10,15 +10,16 @@ const AddressDetail = require('../addressDetail.model')
 const LoggingService = require('../../services/logging.service')
 
 module.exports = class InvoiceAddress extends BaseModel {
-  static async getAddress (request, authToken, applicationId, applicationLineId) {
+  static async getAddress (request, applicationId) {
     let address
     try {
+      const context = request.app.data
       // Get the AddressDetail for this application
-      const addressDetail = await AddressDetail.getBillingInvoicingDetails(authToken, applicationId)
+      const addressDetail = await AddressDetail.getBillingInvoicingDetails(context, applicationId)
 
       if (addressDetail && addressDetail.addressId !== undefined) {
         // Get the Address for this AddressDetail
-        address = await Address.getById(authToken, addressDetail.addressId)
+        address = await Address.getById(context, addressDetail.addressId)
       }
     } catch (error) {
       LoggingService.logError(error, request)
@@ -27,7 +28,8 @@ module.exports = class InvoiceAddress extends BaseModel {
     return address
   }
 
-  static async saveSelectedAddress (request, authToken, applicationId, applicationLineId, addressDto) {
+  static async saveSelectedAddress (request, applicationId, applicationLineId, addressDto) {
+    const context = request.app.data
     if (!addressDto.uprn) {
       const errorMessage = `Unable to save invoice address as it does not have a UPRN`
       LoggingService.logError(errorMessage, request)
@@ -38,66 +40,67 @@ module.exports = class InvoiceAddress extends BaseModel {
       addressDto.postcode = addressDto.postcode.toUpperCase()
     }
 
-    let addressDetail = await AddressDetail.getBillingInvoicingDetails(authToken, applicationId)
+    let addressDetail = await AddressDetail.getBillingInvoicingDetails(context, applicationId)
     if (!addressDetail.addressId) {
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
-    let address = await Address.getByUprn(authToken, addressDto.uprn)
+    let address = await Address.getByUprn(context, addressDto.uprn)
     if (!address) {
       // The address is not already in Dynamics so look it up in AddressBase and save it in Dynamics
-      let addresses = await Address.listByPostcode(authToken, addressDto.postcode)
+      let addresses = await Address.listByPostcode(context, addressDto.postcode)
       addresses = addresses.filter((element) => element.uprn === addressDto.uprn)
       address = addresses.pop()
       if (address) {
-        await address.save(authToken)
+        await address.save(context)
       }
     }
 
     // Save the AddressDetail to associate the Address with the Application
     if (address && addressDetail) {
       addressDetail.addressId = address.id
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
-    await InvoiceAddress.updateCompleteness(authToken, applicationId, applicationLineId)
+    await InvoiceAddress.updateCompleteness(context, applicationId, applicationLineId)
   }
 
-  static async saveManualAddress (request, authToken, applicationId, applicationLineId, addressDto) {
+  static async saveManualAddress (request, applicationId, applicationLineId, addressDto) {
+    const context = request.app.data
     if (addressDto.postcode) {
       addressDto.postcode = addressDto.postcode.toUpperCase()
     }
 
     // Get the AddressDetail for this Application (if there is one)
-    let addressDetail = await AddressDetail.getBillingInvoicingDetails(authToken, applicationId)
+    let addressDetail = await AddressDetail.getBillingInvoicingDetails(context, applicationId)
     if (!addressDetail.addressId) {
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
     // Get the Address for this AddressDetail (if there is one)
-    let address = await Address.getById(authToken, addressDetail.addressId)
+    let address = await Address.getById(context, addressDetail.addressId)
     if (!address) {
       address = new Address(addressDto)
     } else {
       Object.assign(address, addressDto)
     }
     address.fromAddressLookup = false
-    await address.save(authToken)
+    await address.save(context)
 
     // Save the AddressDetail to associate the Address with the Application
     if (address && addressDetail) {
       addressDetail.addressId = address.id
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
-    await InvoiceAddress.updateCompleteness(authToken, applicationId, applicationLineId)
+    await InvoiceAddress.updateCompleteness(context, applicationId, applicationLineId)
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await InvoiceAddress.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await InvoiceAddress.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.INVOICING_DETAILS]: isComplete
@@ -110,10 +113,10 @@ module.exports = class InvoiceAddress extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId) {
+  static async isComplete (context, applicationId) {
     let isComplete = false
     try {
-      const addressDetail = await AddressDetail.getBillingInvoicingDetails(authToken, applicationId)
+      const addressDetail = await AddressDetail.getBillingInvoicingDetails(context, applicationId)
       if (addressDetail && addressDetail.addressId) {
         isComplete = Address.getById(addressDetail.addressId) !== undefined
       }

--- a/src/models/taskList/permitHolderDetails.model.js
+++ b/src/models/taskList/permitHolderDetails.model.js
@@ -17,15 +17,16 @@ module.exports = class PermitHolderDetails extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async getAddress (request, authToken, applicationId, applicationLineId) {
+  static async getAddress (request, applicationId) {
     let address
     try {
+      const context = request.app.data
       // Get the AddressDetail for this application
-      const addressDetail = await AddressDetail.getIndividualPermitHolderDetails(authToken, applicationId)
+      const addressDetail = await AddressDetail.getIndividualPermitHolderDetails(context, applicationId)
 
       if (addressDetail && addressDetail.addressId !== undefined) {
         // Get the Address for this AddressDetail
-        address = await Address.getById(authToken, addressDetail.addressId)
+        address = await Address.getById(context, addressDetail.addressId)
       }
     } catch (error) {
       LoggingService.logError(error, request)
@@ -34,7 +35,8 @@ module.exports = class PermitHolderDetails extends BaseModel {
     return address
   }
 
-  static async saveSelectedAddress (request, authToken, applicationId, applicationLineId, addressDto) {
+  static async saveSelectedAddress (request, applicationId, applicationLineId, addressDto) {
+    const context = request.app.data
     if (!addressDto.uprn) {
       const errorMessage = `Unable to save individual permit holder address as it does not have a UPRN`
       LoggingService.logError(errorMessage, request)
@@ -45,63 +47,64 @@ module.exports = class PermitHolderDetails extends BaseModel {
       addressDto.postcode = addressDto.postcode.toUpperCase()
     }
 
-    let addressDetail = await AddressDetail.getIndividualPermitHolderDetails(authToken, applicationId)
+    let addressDetail = await AddressDetail.getIndividualPermitHolderDetails(context, applicationId)
     if (!addressDetail.addressId) {
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
-    let address = await Address.getByUprn(authToken, addressDto.uprn)
+    let address = await Address.getByUprn(context, addressDto.uprn)
     if (!address) {
       // The address is not already in Dynamics so look it up in AddressBase and save it in Dynamics
-      let addresses = await Address.listByPostcode(authToken, addressDto.postcode)
+      let addresses = await Address.listByPostcode(context, addressDto.postcode)
       addresses = addresses.filter((element) => element.uprn === addressDto.uprn)
       address = addresses.pop()
       if (address) {
-        await address.save(authToken)
+        await address.save(context)
       }
     }
 
     // Save the AddressDetail to associate the Address with the Application
     if (address && addressDetail) {
       addressDetail.addressId = address.id
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
   }
 
-  static async saveManualAddress (request, authToken, applicationId, applicationLineId, addressDto) {
+  static async saveManualAddress (request, applicationId, applicationLineId, addressDto) {
+    const context = request.app.data
     if (addressDto.postcode) {
       addressDto.postcode = addressDto.postcode.toUpperCase()
     }
 
     // Get the AddressDetail for this Application (if there is one)
-    let addressDetail = await AddressDetail.getIndividualPermitHolderDetails(authToken, applicationId)
+    let addressDetail = await AddressDetail.getIndividualPermitHolderDetails(context, applicationId)
     if (!addressDetail.addressId) {
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
 
     // Get the Address for this AddressDetail (if there is one)
-    let address = await Address.getById(authToken, addressDetail.addressId)
+    let address = await Address.getById(context, addressDetail.addressId)
     if (!address) {
       address = new Address(addressDto)
     } else {
       Object.assign(address, addressDto)
     }
     address.fromAddressLookup = false
-    await address.save(authToken)
+    await address.save(context)
 
     // Save the AddressDetail to associate the Address with the Application
     if (address && addressDetail) {
       addressDetail.addressId = address.id
-      await addressDetail.save(authToken)
+      await addressDetail.save(context)
     }
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await PermitHolderDetails.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await PermitHolderDetails.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.PERMIT_HOLDER_DETAILS]: isComplete
@@ -114,16 +117,16 @@ module.exports = class PermitHolderDetails extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId) {
+  static async isComplete (context, applicationId) {
     let isComplete = false
     try {
-      const {isIndividual, accountId, permitHolderIndividualId} = await Application.getById(authToken, applicationId)
+      const {isIndividual, accountId, permitHolderIndividualId} = await Application.getById(context, applicationId)
 
       if (isIndividual) {
         // Get the Contact for this application
-        const contact = await Contact.getById(authToken, permitHolderIndividualId)
-        const addressDetail = await AddressDetail.getIndividualPermitHolderDetails(authToken, applicationId)
-        const address = await Address.getById(authToken, addressDetail.addressId)
+        const contact = await Contact.getById(context, permitHolderIndividualId)
+        const addressDetail = await AddressDetail.getIndividualPermitHolderDetails(context, applicationId)
+        const address = await Address.getById(context, addressDetail.addressId)
 
         let isContactComplete = contact && contact.firstName && contact.lastName
         let isContactDetailComplete = addressDetail.dateOfBirth && addressDetail.telephone
@@ -131,7 +134,7 @@ module.exports = class PermitHolderDetails extends BaseModel {
         isComplete = Boolean(isContactComplete && isContactDetailComplete && address)
       } else {
         // Get the Account for this application
-        const account = await Account.getById(authToken, accountId)
+        const account = await Account.getById(context, accountId)
         isComplete = Boolean(account && account.accountName)
       }
     } catch (error) {

--- a/src/models/taskList/saveAndReturn.model.js
+++ b/src/models/taskList/saveAndReturn.model.js
@@ -8,11 +8,11 @@ const Application = require('../application.model')
 const ApplicationLine = require('../applicationLine.model')
 
 module.exports = class SaveAndReturn extends BaseModel {
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
 
       const query = `defra_wasteparamses(${applicationLine.parametersId})`
       await dynamicsDal.update(query, {[SAVE_AND_RETURN_EMAIL]: true})
@@ -22,14 +22,14 @@ module.exports = class SaveAndReturn extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Application for this application
-      const application = await Application.getById(authToken, applicationId)
+      const application = await Application.getById(context, applicationId)
 
       // Get the completed flag for save and return
-      const completed = await ApplicationLine.getCompleted(authToken, applicationLineId, SAVE_AND_RETURN_EMAIL)
+      const completed = await ApplicationLine.getCompleted(context, applicationLineId, SAVE_AND_RETURN_EMAIL)
 
       isComplete = Boolean(completed && application.saveAndReturnEmail)
     } catch (error) {

--- a/src/models/taskList/sitePlan.model.js
+++ b/src/models/taskList/sitePlan.model.js
@@ -8,12 +8,12 @@ const Annotation = require('../annotation.model')
 const ApplicationLine = require('../applicationLine.model')
 
 module.exports = class SitePlan extends BaseModel {
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await SitePlan.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await SitePlan.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.SITE_PLAN]: isComplete
@@ -26,11 +26,11 @@ module.exports = class SitePlan extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Evidence for a site plan
-      const evidence = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, Constants.UploadSubject.SITE_PLAN)
+      const evidence = await Annotation.listByApplicationIdAndSubject(context, applicationId, Constants.UploadSubject.SITE_PLAN)
       isComplete = Boolean(evidence.length)
     } catch (error) {
       LoggingService.logError(`Unable to calculate SitePlan completeness: ${error}`)

--- a/src/models/taskList/taskList.model.js
+++ b/src/models/taskList/taskList.model.js
@@ -26,8 +26,8 @@ class TaskList extends BaseModel {
     })
   }
 
-  static async getByApplicationLineId (authToken, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async getByApplicationLineId (context, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     const taskList = new TaskList()
     taskList._defineTaskListSections()
@@ -265,7 +265,7 @@ class TaskList extends BaseModel {
 
   // Iterates through all of the task list items and calls the isComplete() function of each one,
   // combining the results into a single boolean value if all task list items are complete
-  isComplete (authToken, applicationId, applicationLineId) {
+  isComplete (context, applicationId, applicationLineId) {
     return Promise.all(
       // Exclude models that are not applicable to the current task list
       this.taskListModels
@@ -273,7 +273,7 @@ class TaskList extends BaseModel {
           return (this.taskListModelNames.includes(item.name))
         })
         .map((item) => {
-          return item.isComplete(authToken, applicationId, applicationLineId)
+          return item.isComplete(context, applicationId, applicationLineId)
         })
     ).then((values) => {
       // Reduce all of the individual flags into a single flag (which can be overridden by the bypassCompletenessCheck flag, e.g. during development)

--- a/src/models/taskList/technicalQualification.model.js
+++ b/src/models/taskList/technicalQualification.model.js
@@ -13,12 +13,12 @@ module.exports = class TechnicalQualification extends BaseModel {
     this.applicationLineId = data.applicationLineId
   }
 
-  static async updateCompleteness (authToken, applicationId, applicationLineId) {
-    const dynamicsDal = new DynamicsDalService(authToken)
+  static async updateCompleteness (context, applicationId, applicationLineId) {
+    const dynamicsDal = new DynamicsDalService(context.authToken)
 
     try {
-      const applicationLine = await ApplicationLine.getById(authToken, applicationLineId)
-      const isComplete = await TechnicalQualification.isComplete(authToken, applicationId, applicationLineId)
+      const applicationLine = await ApplicationLine.getById(context, applicationLineId)
+      const isComplete = await TechnicalQualification.isComplete(context, applicationId, applicationLineId)
 
       const entity = {
         [Constants.Dynamics.CompletedParamters.TECHNICAL_QUALIFICATION]: isComplete
@@ -31,11 +31,11 @@ module.exports = class TechnicalQualification extends BaseModel {
     }
   }
 
-  static async isComplete (authToken, applicationId, applicationLineId) {
+  static async isComplete (context, applicationId, applicationLineId) {
     let isComplete = false
     try {
       // Get the Evidence for a technical qualification
-      const evidence = await Annotation.listByApplicationIdAndSubject(authToken, applicationId, Constants.UploadSubject.TECHNICAL_QUALIFICATION)
+      const evidence = await Annotation.listByApplicationIdAndSubject(context, applicationId, Constants.UploadSubject.TECHNICAL_QUALIFICATION)
       isComplete = Boolean(evidence && evidence.length)
     } catch (error) {
       LoggingService.logError(`Unable to calculate TechnicalQualification completeness: ${error}`)

--- a/src/services/recovery.service.js
+++ b/src/services/recovery.service.js
@@ -12,48 +12,54 @@ const StandardRule = require('../models/standardRule.model')
 const {AUTH_TOKEN, APPLICATION_ID, APPLICATION_LINE_ID, STANDARD_RULE_ID, STANDARD_RULE_TYPE_ID, PERMIT_HOLDER_TYPE} = Constants.COOKIE_KEY
 
 module.exports = class RecoveryService {
-  static async recoverOptionalData (authToken, applicationId, applicationLineId, options) {
+  static async recoverOptionalData (context, applicationId, applicationLineId, options) {
     // Query in parallel for optional entities
     const [application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule] = await Promise.all([
-      options.application ? Application.getById(authToken, applicationId) : Promise.resolve(undefined),
-      options.applicationLine ? ApplicationLine.getById(authToken, applicationLineId) : Promise.resolve(undefined),
-      options.applicationReturn ? ApplicationReturn.getByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
-      options.account ? Account.getByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
-      options.contact ? Contact.getByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
-      options.individualPermitHolder ? Contact.getIndividualPermitHolderByApplicationId(authToken, applicationId) : Promise.resolve(undefined),
-      options.payment ? Payment.getBacsPaymentDetails(authToken, applicationLineId) : Promise.resolve(undefined),
-      options.cardPayment ? Payment.getCardPaymentDetails(authToken, applicationLineId) : Promise.resolve(undefined),
-      options.standardRule ? StandardRule.getByApplicationLineId(authToken, applicationLineId) : Promise.resolve(undefined)
+      options.application ? Application.getById(context, applicationId) : Promise.resolve(undefined),
+      options.applicationLine ? ApplicationLine.getById(context, applicationLineId) : Promise.resolve(undefined),
+      options.applicationReturn ? ApplicationReturn.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
+      options.account ? Account.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
+      options.contact ? Contact.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
+      options.individualPermitHolder ? Contact.getIndividualPermitHolderByApplicationId(context, applicationId) : Promise.resolve(undefined),
+      options.payment ? Payment.getBacsPaymentDetails(context, applicationLineId) : Promise.resolve(undefined),
+      options.cardPayment ? Payment.getCardPaymentDetails(context, applicationLineId) : Promise.resolve(undefined),
+      options.standardRule ? StandardRule.getByApplicationLineId(context, applicationLineId) : Promise.resolve(undefined)
     ])
 
     return {application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule}
   }
 
   static async recoverFromCookies (slug, request, options) {
-    const authToken = CookieService.get(request, AUTH_TOKEN)
+    const context = request.app.data
+
+    context.authToken = CookieService.get(request, AUTH_TOKEN)
     const applicationId = CookieService.get(request, APPLICATION_ID)
+    const application = await Application.getById(context, applicationId)
     const applicationLineId = CookieService.get(request, APPLICATION_LINE_ID)
     const standardRuleId = CookieService.get(request, STANDARD_RULE_ID)
     const standardRuleTypeId = CookieService.get(request, STANDARD_RULE_TYPE_ID)
     const permitHolderType = CookieService.get(request, PERMIT_HOLDER_TYPE)
 
     // Query in parallel for optional entities
-    const {application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule} = await RecoveryService.recoverOptionalData(authToken, applicationId, applicationLineId, options)
+    const {applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule} = await RecoveryService.recoverOptionalData(context, applicationId, applicationLineId, options)
 
-    return {slug, authToken, applicationId, applicationLineId, application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType}
+    Object.assign(context, {slug, applicationId, applicationLineId, application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType})
+
+    return context
   }
 
   static async recoverFromSlug (slug, h, options) {
-    let recoveredApplication
+    const context = h.request.app.data
     const cookie = await CookieService.generateCookie(h)
-    let authToken = cookie.authToken
-    const applicationReturn = await ApplicationReturn.getBySlug(authToken, slug)
+    context.authToken = cookie.authToken
+
+    const applicationReturn = await ApplicationReturn.getBySlug(context, slug)
     if (applicationReturn) {
       const applicationId = applicationReturn.applicationId
 
-      const application = await Application.getById(authToken, applicationId)
+      const application = await Application.getById(context, applicationId)
 
-      const applicationLine = await ApplicationLine.getByApplicationId(authToken, applicationId)
+      const applicationLine = await ApplicationLine.getByApplicationId(context, applicationId)
       const applicationLineId = applicationLine.id
 
       // Don't attempt to get the application, applicationLine and applicationReturn again
@@ -64,15 +70,15 @@ module.exports = class RecoveryService {
       // Always load the standard rule when restoring
       options.standardRule = true
 
-      const {account, contact, individualPermitHolder, payment, cardPayment, standardRule} = await RecoveryService.recoverOptionalData(authToken, applicationId, applicationLineId, options)
+      const {account, contact, individualPermitHolder, payment, cardPayment, standardRule} = await RecoveryService.recoverOptionalData(context, applicationId, applicationLineId, options)
       const {id: standardRuleId, standardRuleTypeId} = standardRule || {}
 
       const permitHolderType = Constants.PERMIT_HOLDER_TYPES.LIMITED_COMPANY.id
 
-      recoveredApplication = {slug, cookie, authToken, applicationId, applicationLineId, application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType}
+      Object.assign(context, {slug, cookie, applicationId, applicationLineId, application, applicationLine, applicationReturn, account, contact, individualPermitHolder, payment, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType})
 
       // Setup all the cookies as if the user hadn't left
-      cookie[AUTH_TOKEN] = authToken
+      cookie[AUTH_TOKEN] = context.authToken
       cookie[APPLICATION_ID] = applicationId
       cookie[APPLICATION_LINE_ID] = applicationLineId
       if (standardRuleTypeId) {
@@ -84,23 +90,22 @@ module.exports = class RecoveryService {
       cookie[PERMIT_HOLDER_TYPE] = permitHolderType
     }
 
-    return recoveredApplication
+    return context
   }
 
   static async createApplicationContext (h, options = {}) {
     let {request} = h
     let {slug = ''} = request.params
-    let data = {}
 
-    if (slug) {
-      data = await RecoveryService.recoverFromSlug(slug, h, options)
-    } else {
-      data = await RecoveryService.recoverFromCookies(slug, request, options)
+    if (!request.app.data) {
+      request.app.data = {}
     }
 
-    request.app.data = request.app.data || {}
-
-    Object.assign(request.app.data, data)
+    if (slug) {
+      await RecoveryService.recoverFromSlug(slug, h, options)
+    } else {
+      await RecoveryService.recoverFromCookies(slug, request, options)
+    }
 
     return request.app.data
   }

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -98,4 +98,8 @@ module.exports = class Utilities {
     }
     return returnValue
   }
+
+  static toCamelCase (str) {
+    return str[0].toLowerCase() + str.substr(1)
+  }
 }

--- a/src/views/saveAndReturn/checkYourEmail.html
+++ b/src/views/saveAndReturn/checkYourEmail.html
@@ -23,24 +23,6 @@
 
         <input id="got-email" type="hidden" name="got-email" value="false">
 
-        <details class="closeOnOpen">
-          <summary><span class="summary">Still have not received an email?</span></summary>
-          <div>
-            <p>
-              Please contact us for help.
-            </p>
-            <p>Email: <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
-
-            <p>Telephone: 03708 506 506</p>
-
-            <p>Telephone from outside the UK: +44 (0) 114 282 5312</p>
-
-            <p>Minicom (for the hard of hearing): 03702 422 549</p>
-
-            <p>Lines are open Monday to Friday, 8am to 6pm (GMT).</p>
-          </div>
-        </details>
-
         <details role="group" class="form-hint-details" {{#if errors.save-and-return-email}}open="open"{{/if}}>
           <summary id="email-summary" role="button" aria-controls="details-content-0" aria-expanded="false">I can’t find the email</summary>
           <div class="panel panel-border-narrow" id="details-content-0" aria-hidden="true">

--- a/src/views/saveAndReturn/checkYourEmail.html
+++ b/src/views/saveAndReturn/checkYourEmail.html
@@ -23,6 +23,24 @@
 
         <input id="got-email" type="hidden" name="got-email" value="false">
 
+        <details class="closeOnOpen">
+          <summary><span class="summary">Still have not received an email?</span></summary>
+          <div>
+            <p>
+              Please contact us for help.
+            </p>
+            <p>Email: <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+
+            <p>Telephone: 03708 506 506</p>
+
+            <p>Telephone from outside the UK: +44 (0) 114 282 5312</p>
+
+            <p>Minicom (for the hard of hearing): 03702 422 549</p>
+
+            <p>Lines are open Monday to Friday, 8am to 6pm (GMT).</p>
+          </div>
+        </details>
+
         <details role="group" class="form-hint-details" {{#if errors.save-and-return-email}}open="open"{{/if}}>
           <summary id="email-summary" role="button" aria-controls="details-content-0" aria-expanded="false">I can’t find the email</summary>
           <div class="panel panel-border-narrow" id="details-content-0" aria-hidden="true">

--- a/test/controllers/base.controller.test.js
+++ b/test/controllers/base.controller.test.js
@@ -5,15 +5,6 @@ const lab = exports.lab = Lab.script()
 const Code = require('code')
 
 const BaseController = require('../../src/controllers/base.controller')
-let controller
-
-lab.beforeEach(() => {
-
-})
-
-lab.afterEach(() => {
-
-})
 
 lab.experiment('Base Controller tests:', () => {
   lab.test('createPageContext() method builds page context object correctly', () => {
@@ -23,7 +14,7 @@ lab.experiment('Base Controller tests:', () => {
       path: 'THE_ROUTE_PATH'
     }
 
-    controller = new BaseController({route})
+    const controller = new BaseController({route})
 
     const pageContext = controller.createPageContext(route)
 

--- a/test/models/annotation.model.test.js
+++ b/test/models/annotation.model.test.js
@@ -9,6 +9,7 @@ const Annotation = require('../../src/models/annotation.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
 let sandbox
+const request = {app: {}}
 
 let testAnnotation
 const testAnnotationId = 'ANNOTATION_ID'
@@ -77,7 +78,7 @@ lab.experiment('Annotation Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const annotationList = await Annotation.listByApplicationIdAndSubject(undefined, fakeApplication.id)
+    const annotationList = await Annotation.listByApplicationIdAndSubject(request, fakeApplication.id)
     Code.expect(Array.isArray(annotationList)).to.be.true()
     Code.expect(annotationList.length).to.equal(3)
     annotationList.forEach((annotation, index) => {

--- a/test/models/applicationReturn.model.test.js
+++ b/test/models/applicationReturn.model.test.js
@@ -9,6 +9,7 @@ const ApplicationLine = require('../../src/models/applicationLine.model')
 const ApplicationReturn = require('../../src/models/applicationReturn.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
+const request = {app: {}}
 let fakeApplicationLine
 let fakeApplicationReturn
 
@@ -53,7 +54,7 @@ lab.experiment('ApplicationReturn Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const applicationReturn = await ApplicationReturn.getBySlug()
+    const applicationReturn = await ApplicationReturn.getBySlug(request)
     Code.expect(applicationReturn).to.equal(fakeApplicationReturn)
     Code.expect(spy.callCount).to.equal(1)
   })
@@ -66,7 +67,7 @@ lab.experiment('ApplicationReturn Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const applicationReturn = await ApplicationReturn.getByApplicationId()
+    const applicationReturn = await ApplicationReturn.getByApplicationId(request)
     Code.expect(applicationReturn).to.equal(fakeApplicationReturn)
     Code.expect(spy.callCount).to.equal(1)
   })

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -10,6 +10,7 @@ const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
 let testContact
 let sandbox
+const request = {app: {}}
 const authToken = 'THE_AUTH_TOKEN'
 
 lab.beforeEach(() => {
@@ -113,7 +114,7 @@ lab.experiment('Contact Model tests:', () => {
 
   lab.test('list() method returns a list of Contact objects', async () => {
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const contactList = await Contact.list()
+    const contactList = await Contact.list(request)
     Code.expect(Array.isArray(contactList)).to.be.true()
     Code.expect(contactList.length).to.equal(3)
     Code.expect(spy.callCount).to.equal(1)

--- a/test/models/dynamicsSolution.model.test.js
+++ b/test/models/dynamicsSolution.model.test.js
@@ -8,6 +8,8 @@ const sinon = require('sinon')
 const DynamicsSolution = require('../../src/models/dynamicsSolution.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
+const request = {app: {}}
+
 let dynamicsSearchStub
 
 lab.beforeEach(() => {
@@ -47,7 +49,7 @@ lab.afterEach(() => {
 lab.experiment('DynamicsSolution Model tests:', () => {
   lab.test('get() method returns the correct DynamicsSolution objects', async () => {
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const dynamicsVersionInfo = await DynamicsSolution.get()
+    const dynamicsVersionInfo = await DynamicsSolution.get(request)
     Code.expect(spy.callCount).to.equal(1)
 
     Code.expect(dynamicsVersionInfo.length).to.equal(3)

--- a/test/models/standardRule.model.test.js
+++ b/test/models/standardRule.model.test.js
@@ -10,6 +10,7 @@ const ApplicationLine = require('../../src/models/applicationLine.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
 let sandbox
+const request = {app: {}}
 
 const fakeStandardRule = {
   id: 'STANDARD_RULE_ID',
@@ -66,7 +67,7 @@ lab.experiment('StandardRule Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const standardRuleList = await StandardRule.list()
+    const standardRuleList = await StandardRule.list(request)
     Code.expect(Array.isArray(standardRuleList)).to.be.true()
     Code.expect(standardRuleList.length).to.equal(3)
     standardRuleList.forEach((standardRule, index) => {
@@ -83,7 +84,7 @@ lab.experiment('StandardRule Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const standardRule = await StandardRule.getByCode()
+    const standardRule = await StandardRule.getByCode(request)
     Code.expect(standardRule).to.equal(fakeStandardRule)
     Code.expect(spy.callCount).to.equal(1)
   })
@@ -92,7 +93,7 @@ lab.experiment('StandardRule Model tests:', () => {
     DynamicsDalService.prototype.search = () => fakeDynamicsRecord()
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const standardRule = await StandardRule.getByApplicationLineId()
+    const standardRule = await StandardRule.getByApplicationLineId(request)
     Code.expect(standardRule).to.equal(fakeStandardRule)
     Code.expect(spy.callCount).to.equal(1)
   })

--- a/test/models/standardRuleType.model.test.js
+++ b/test/models/standardRuleType.model.test.js
@@ -9,6 +9,7 @@ const StandardRuleType = require('../../src/models/standardRuleType.model')
 const DynamicsDalService = require('../../src/services/dynamicsDal.service')
 
 let sandbox
+const request = {app: {}}
 
 const fakeStandardRuleType = {
   id: 'STANDARD_RULE_TYPE_ID',
@@ -50,7 +51,7 @@ lab.experiment('StandardRuleType Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const standardRuleList = await StandardRuleType.list()
+    const standardRuleList = await StandardRuleType.list(request)
     Code.expect(Array.isArray(standardRuleList)).to.be.true()
     Code.expect(standardRuleList.length).to.equal(categories.length)
     standardRuleList.forEach((standardRuleType, index) => {
@@ -75,7 +76,7 @@ lab.experiment('StandardRuleType Model tests:', () => {
     }
 
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const standardRuleList = await StandardRuleType.getCategories()
+    const standardRuleList = await StandardRuleType.getCategories(request)
     Code.expect(Array.isArray(standardRuleList)).to.be.true()
     Code.expect(standardRuleList.length).to.equal(categories.length + offlineCategories.length)
     let onlineIndex = 0

--- a/test/models/taskList/invoiceAddress.model.test.js
+++ b/test/models/taskList/invoiceAddress.model.test.js
@@ -13,7 +13,7 @@ const InvoiceAddress = require('../../../src/models/taskList/invoiceAddress.mode
 
 let sandbox
 
-const request = undefined
+const request = {app: {data: {}}}
 const authToken = 'THE_AUTH_TOKEN'
 const applicationId = 'APPLICATION_ID'
 const applicationLineId = 'APPLICATION_LINE_ID'
@@ -60,6 +60,7 @@ lab.beforeEach(() => {
   sandbox.stub(DynamicsDalService.prototype, 'update').value(() => fakeAddress1.id)
   sandbox.stub(ApplicationLine, 'getById').value(() => new ApplicationLine({ id: applicationLineId }))
   sandbox.stub(AddressDetail, 'getByApplicationIdAndType').value(() => new AddressDetail({ addressId: 'ADDRESS_ID' }))
+  sandbox.stub(Address.prototype, 'save').value(() => undefined)
   sandbox.stub(Address, 'getById').value(() => new Address(fakeAddress1))
   sandbox.stub(Address, 'getByUprn').value(() => new Address(fakeAddress1))
   sandbox.stub(Address, 'listByPostcode').value(() => [
@@ -86,8 +87,8 @@ lab.experiment('Task List: Invoice Address Model tests:', () => {
         uprn: fakeAddress1.uprn,
         postcode: fakeAddress1.postcode
       }
-      const spy = sinon.spy(DynamicsDalService.prototype, 'create')
-      await InvoiceAddress.saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
+      const spy = sinon.spy(DynamicsDalService.prototype, 'update')
+      await InvoiceAddress.saveSelectedAddress(request, applicationId, applicationLineId, addressDto)
       Code.expect(spy.callCount).to.equal(1)
     })
 
@@ -98,7 +99,7 @@ lab.experiment('Task List: Invoice Address Model tests:', () => {
         postcode: fakeAddress1.postcode
       }
       const spy = sinon.spy(DynamicsDalService.prototype, 'create')
-      await InvoiceAddress.saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
+      await InvoiceAddress.saveSelectedAddress(request, applicationId, applicationLineId, addressDto)
       Code.expect(spy.callCount).to.equal(1)
     })
   })

--- a/test/models/taskList/permitHolderDetails.model.test.js
+++ b/test/models/taskList/permitHolderDetails.model.test.js
@@ -24,7 +24,8 @@ let fakeAddress1
 let fakeAddress2
 let fakeAddress3
 
-const request = undefined
+const request = {app: {data: {}}}
+
 const authToken = 'THE_AUTH_TOKEN'
 const applicationId = 'APPLICATION_ID'
 const applicationLineId = 'APPLICATION_LINE_ID'
@@ -71,7 +72,7 @@ lab.beforeEach(() => {
     uprn: 'UPRN1',
     fromAddressLookup: true
   }
-  
+
   fakeAddress2 = {
     id: 'ADDRESS_ID_2',
     buildingNameOrNumber: '102',
@@ -82,7 +83,7 @@ lab.beforeEach(() => {
     uprn: 'UPRN2',
     fromAddressLookup: true
   }
-  
+
   fakeAddress3 = {
     id: 'ADDRESS_ID_3',
     buildingNameOrNumber: '103',
@@ -138,7 +139,7 @@ lab.experiment('Model persistence methods:', () => {
       postcode: fakeAddress1.postcode
     }
     const spy = sinon.spy(DynamicsDalService.prototype, 'create')
-    await PermitHolderDetails.saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
+    await PermitHolderDetails.saveSelectedAddress(request, applicationId, applicationLineId, addressDto)
     Code.expect(spy.callCount).to.equal(1)
   })
 
@@ -149,7 +150,7 @@ lab.experiment('Model persistence methods:', () => {
       postcode: fakeAddress1.postcode
     }
     const spy = sinon.spy(DynamicsDalService.prototype, 'create')
-    await PermitHolderDetails.saveSelectedAddress(request, authToken, applicationId, applicationLineId, addressDto)
+    await PermitHolderDetails.saveSelectedAddress(request, applicationId, applicationLineId, addressDto)
     Code.expect(spy.callCount).to.equal(1)
   })
 })

--- a/test/models/taskList/siteNameAndLocation.model.test.js
+++ b/test/models/taskList/siteNameAndLocation.model.test.js
@@ -40,7 +40,7 @@ const fakeLocationDetail = {
   addressId: fakeAddress.id
 }
 
-const request = undefined
+const request = {app: {data: {}}}
 const authToken = 'THE_AUTH_TOKEN'
 const applicationId = fakeApplicationLine.applicationId
 const applicationLineId = fakeApplicationLine.id
@@ -98,7 +98,7 @@ lab.experiment('Task List: Site Name and Location Model tests:', () => {
     Location.getByApplicationId = () => {
       return undefined
     }
-    LocationDetail.getByLocationId = (authToken, locationId) => {
+    LocationDetail.getByLocationId = () => {
       return undefined
     }
     const appContext = {}

--- a/test/models/taskList/taskList.model.test.js
+++ b/test/models/taskList/taskList.model.test.js
@@ -9,6 +9,7 @@ const TaskList = require('../../../src/models/taskList/taskList.model')
 const DynamicsDalService = require('../../../src/services/dynamicsDal.service')
 
 let sandbox
+const request = {app: {data: {}}}
 
 lab.beforeEach(() => {
   // Create a sinon sandbox to stub methods
@@ -60,14 +61,14 @@ lab.experiment('Task List Model tests:', () => {
 
   lab.test('getByApplicationLineId() method returns a TaskList object', async () => {
     const spy = sinon.spy(DynamicsDalService.prototype, 'search')
-    const taskList = await TaskList.getByApplicationLineId()
+    const taskList = await TaskList.getByApplicationLineId(request)
     Code.expect(taskList).to.not.be.null()
     Code.expect(spy.callCount).to.equal(1)
   })
 
   lab.test('Task List returned by getByApplicationLineId() method has the correct number of sections', async () => {
     // Get the Task List
-    const taskList = await TaskList.getByApplicationLineId()
+    const taskList = await TaskList.getByApplicationLineId(request)
 
     // Check we have the correct sections
     Code.expect(Array.isArray(taskList.sections)).to.be.true()
@@ -78,7 +79,7 @@ lab.experiment('Task List Model tests:', () => {
     lab.test(`Task List returned by getByApplicationLineId() contains the ${sectionId} section`, async () => {
       const expectedSectionItemIds = expectedSections[sectionId]
       // Get the Task List
-      const taskList = await TaskList.getByApplicationLineId()
+      const taskList = await TaskList.getByApplicationLineId(request)
       const section = taskList.sections[index]
 
       // Check we have the correct section IDs in the section

--- a/test/routes/address/permitHolder/postcodePermitHolder.route.test.js
+++ b/test/routes/address/permitHolder/postcodePermitHolder.route.test.js
@@ -11,7 +11,6 @@ const CookieService = require('../../../../src/services/cookie.service')
 const Address = require('../../../../src/models/address.model')
 const Application = require('../../../../src/models/application.model')
 const Payment = require('../../../../src/models/payment.model')
-const Contact = require('../../../../src/models/contact.model')
 const PermitHolderDetails = require('../../../../src/models/taskList/permitHolderDetails.model')
 const {COOKIE_RESULT} = require('../../../../src/constants')
 

--- a/test/routes/address/permitHolder/selectPermitHolder.route.test.js
+++ b/test/routes/address/permitHolder/selectPermitHolder.route.test.js
@@ -11,7 +11,6 @@ const CookieService = require('../../../../src/services/cookie.service')
 const Address = require('../../../../src/models/address.model')
 const Application = require('../../../../src/models/application.model')
 const Payment = require('../../../../src/models/payment.model')
-const Contact = require('../../../../src/models/contact.model')
 const PermitHolderDetails = require('../../../../src/models/taskList/permitHolderDetails.model')
 const {COOKIE_RESULT} = require('../../../../src/constants')
 
@@ -96,10 +95,9 @@ lab.beforeEach(() => {
   ])
   sandbox.stub(PermitHolderDetails, 'getAddress').value(() => new Address(fakeAddress1))
   sandbox.stub(PermitHolderDetails, 'saveSelectedAddress').value(() => undefined)
-  
+
   sandbox.stub(Payment, 'getBacsPayment').value(() => {})
   sandbox.stub(Payment.prototype, 'isPaid').value(() => false)
-  
 })
 
 lab.afterEach(() => {

--- a/test/routes/applicationReceived.route.test.js
+++ b/test/routes/applicationReceived.route.test.js
@@ -75,7 +75,9 @@ lab.beforeEach(() => {
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(RecoveryService, 'recoverFromSlug').value(() => fakeRecovery())
+  sandbox.stub(RecoveryService, 'recoverFromSlug').value((slug, {request}) => {
+    Object.assign(request.app.data, fakeRecovery())
+  })
   sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => true)
   sandbox.stub(Contact, 'getByApplicationId').value(() => new Contact(fakeContact))


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-1184

This pull request refactors passing the context (containing the cached request data) within each model function instead of just the authtoken.

The generic model.getById now references the cached data prior to reading dynamics.

To reduce the code changes in the refactor, cleaning up all calls to the CRM have not yet been addressed.