### PR TITLE
Add another partner navigates to Convictions declaration page for first partner.

### DIFF
--- a/src/controllers/permitHolder/partnershipPartnerList.controller.js
+++ b/src/controllers/permitHolder/partnershipPartnerList.controller.js
@@ -60,10 +60,10 @@ module.exports = class PartnershipPartnerListController extends BaseController {
             return { partnerId, name, email, telephone, dob, changeLink, deleteLink, fullAddress }
           }
         }
-        // Remove any incomplete partners
-        await partner.delete(context)
-        return false
       }
+      // Remove any incomplete partners
+      await partner.delete(context)
+      return false
     }))
 
     // Filter out the incomplete partners

--- a/src/views/declaration/company/bankruptcy.html
+++ b/src/views/declaration/company/bankruptcy.html
@@ -29,8 +29,8 @@
 
         {{#if operatorTypeIsPartnership}}
         <ul id="operator-type-is-partnership" class="list list-bullet">
-          <li>the individual partners</li>
-          <li>business partners, where the offence was committed in the course of their business</li>
+          <li>the partners</li>
+          <li>any companies that became insolvent, where a partner was an officer of the company when it became insolvent</li>
         </ul>
         {{/if}}
 

--- a/src/views/declaration/company/offences.html
+++ b/src/views/declaration/company/offences.html
@@ -31,8 +31,8 @@
 
         {{#if operatorTypeIsPartnership}}
         <ul id="operator-type-is-partnership" class="list list-bullet">
-          <li>the individual partners</li>
-          <li>business partners, where the offence was committed in the course of their business</li>
+          <li>any of the partners</li>
+          <li>partner convictions related to another business as well as the partnership</li>
         </ul>
         {{/if}}
 


### PR DESCRIPTION
Also Convictions and Bankruptcy text mismatch with the wire-frame for partnerships.

https://eaflood.atlassian.net/browse/WE-1460
https://eaflood.atlassian.net/browse/WE-1461