### PR TITLE
Allow saving specified fields only correctly

### DIFF
--- a/src/controllers/confirmMiningWastePlan.controller.js
+++ b/src/controllers/confirmMiningWastePlan.controller.js
@@ -51,7 +51,7 @@ module.exports = class ConfirmMiningWastePlanController extends BaseController {
       }
 
       application.miningWastePlan = miningWastePlan.type
-      await application.save(context)
+      await application.save(context, ['miningWastePlan'])
 
       return this.redirect({ request, h, redirectPath: this.nextPath })
     }

--- a/src/controllers/miningWasteWeight.controller.js
+++ b/src/controllers/miningWasteWeight.controller.js
@@ -28,7 +28,7 @@ module.exports = class MiningWasteWeightController extends BaseController {
     const { application, applicationId, applicationLineId } = context
 
     application.miningWasteWeight = request.payload['mining-waste-weight']
-    await application.save(context)
+    await application.save(context, ['miningWasteWeight'])
 
     await MiningWasteDetails.updateCompleteness(context, applicationId, applicationLineId)
 

--- a/src/models/base.model.js
+++ b/src/models/base.model.js
@@ -344,7 +344,7 @@ module.exports = class BaseModel {
     }
   }
 
-  async _deleteBoundReferences (dynamicsDal) {
+  async _deleteBoundReferences (dynamicsDal, fields) {
     // This method deletes any bound references as specified in the mapping method if the new value of any key is undefined.
     //
     // For example, when the mapping for Account is:
@@ -367,6 +367,7 @@ module.exports = class BaseModel {
     const { entity, mapping } = this.constructor
     const boundMapping = mapping
       .filter(({ bind }) => bind && bind.relationship) // only those fields that have a relationship with another entity
+      .filter(({ field }) => !fields || fields.indexOf(field) !== -1) // only those in the fields array if it has been entered
       .filter(({ field }) => !this[field]) // only those where the value of the field has been cleared
     if (boundMapping.length) {
       // select all the cleared references of entities bound to this entity and get their original values
@@ -416,7 +417,7 @@ module.exports = class BaseModel {
         query = entity
         this.id = await dynamicsDal.create(query, dataObject)
       } else {
-        await this._deleteBoundReferences(dynamicsDal)
+        await this._deleteBoundReferences(dynamicsDal, fields)
         // Update Entity
         query = `${entity}(${this.id})`
         await dynamicsDal.update(query, dataObject)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-1508

When a bound reference is not included when fields are specified, then don't delete it.
