### PR TITLE
Refactor to remove missed applicationId parameters

### DIFF
--- a/src/models/checkList/base.check.js
+++ b/src/models/checkList/base.check.js
@@ -10,7 +10,6 @@ const StandardRule = require('../../persistence/entities/standardRule.entity')
 const ContactDetail = require('../contactDetail.model')
 
 const {
-  DESIGNATED_MEMBER_CONTACT_DETAILS,
   BILLING_INVOICING,
   PUBLIC_BODY_MAIN_ADDRESS,
   COMPANY_REGISTERED_ADDRESS
@@ -97,14 +96,6 @@ module.exports = class BaseCheck {
       this.data.companies = await company.listLinked(this.data)
     }
     return this.data.companies || []
-  }
-
-  async getDesignatedMemberDetails () {
-    if (!this.data.designatedMemberDetails) {
-      const type = DESIGNATED_MEMBER_CONTACT_DETAILS.TYPE
-      this.data.designatedMemberDetails = await ContactDetail.list(this.data, { type })
-    }
-    return this.data.designatedMemberDetails || {}
   }
 
   async listContactDetails ({ TYPE: type }) {

--- a/src/persistence/entities/application.entity.js
+++ b/src/persistence/entities/application.entity.js
@@ -119,7 +119,7 @@ class Application extends BaseEntity {
       // Call Dynamics save and return email action
       let action = `${this.constructor.dynamicsEntity}(${this.id})/Microsoft.Dynamics.CRM.defra_saveandreturnemail`
       await dynamicsDal.callAction(action, actionDataObject)
-      const applicationReturn = await ApplicationReturn.getByApplicationId(context, this.id)
+      const applicationReturn = await ApplicationReturn.getByApplicationId(context)
       LoggingService.logDebug(`Save and Return Url for Application "${this.applicationNumber}": ${origin}${SAVE_AND_RETURN_RECOVER.path}/${applicationReturn.slug}`)
     } catch (error) {
       LoggingService.logError(`Unable to call Dynamics Save and Return Email action: ${error}`)

--- a/src/persistence/entities/applicationLine.entity.js
+++ b/src/persistence/entities/applicationLine.entity.js
@@ -19,7 +19,8 @@ class ApplicationLine extends BaseEntity {
     ]
   }
 
-  static async getByApplicationId (context, applicationId) {
+  static async getByApplicationId (context) {
+    const { applicationId } = context
     return super.getBy(context, { applicationId })
   }
 }

--- a/src/services/recovery.service.js
+++ b/src/services/recovery.service.js
@@ -20,9 +20,9 @@ module.exports = class RecoveryService {
     const [application, applicationLine, applicationReturn, account, contact, cardPayment, standardRule] = await Promise.all([
       options.application ? Application.getById(context, applicationId) : Promise.resolve(undefined),
       options.applicationLine ? ApplicationLine.getById(context, applicationLineId) : Promise.resolve(undefined),
-      options.applicationReturn ? ApplicationReturn.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
-      options.account ? Account.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
-      options.contact ? Contact.getByApplicationId(context, applicationId) : Promise.resolve(undefined),
+      options.applicationReturn ? ApplicationReturn.getByApplicationId(context) : Promise.resolve(undefined),
+      options.account ? Account.getByApplicationId(context) : Promise.resolve(undefined),
+      options.contact ? Contact.getByApplicationId(context) : Promise.resolve(undefined),
       options.cardPayment ? Payment.getCardPaymentDetails(context, applicationLineId) : Promise.resolve(undefined),
       options.standardRule ? StandardRule.getByApplicationLineId(context, applicationLineId) : Promise.resolve(undefined)
     ])
@@ -67,7 +67,9 @@ module.exports = class RecoveryService {
 
       const application = await Application.getById(context, applicationId)
 
-      const applicationLine = await ApplicationLine.getByApplicationId(context, applicationId)
+      context.applicationId = applicationId
+
+      const applicationLine = await ApplicationLine.getByApplicationId(context)
       const applicationLineId = applicationLine.id
 
       // Don't attempt to get the application, applicationLine and applicationReturn again
@@ -83,7 +85,7 @@ module.exports = class RecoveryService {
 
       const permitHolderType = RecoveryService.getPermitHolderType(application)
 
-      Object.assign(context, { slug, cookie, applicationId, applicationLineId, application, applicationLine, applicationReturn, account, contact, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType })
+      Object.assign(context, { slug, cookie, applicationLineId, application, applicationLine, applicationReturn, account, contact, cardPayment, standardRule, standardRuleId, standardRuleTypeId, permitHolderType })
 
       // Setup all the cookies as if the user hadn't left
       cookie[AUTH_TOKEN] = context.authToken


### PR DESCRIPTION
Remove unnecessary applicationId parameters as it is passed within the context.
Also remove the redundant "getDesignatedMemberDetails" function.