### PR TITLE
Consultee and management system fixes

### DIFF
--- a/src/validators/base.validator.js
+++ b/src/validators/base.validator.js
@@ -70,8 +70,13 @@ module.exports = class BaseValidator {
       let fieldName
       let propertyWithError
       if (error.path.length) {
-        fieldName = error.path[0] // field that the error is to be associated with.
-        propertyWithError = error.path.pop() // the descendant in the path where the error can be found.
+        if (error.context && (error.context.key !== error.context.label)) {
+          // If a label has been explicitly set on the error then use that
+          fieldName = propertyWithError = error.context.label
+        } else {
+          fieldName = error.path[0] // field that the error is to be associated with.
+          propertyWithError = error.path.pop() // the descendant in the path where the error can be found.
+        }
       } else {
         // Validation errors on the root of the request payload need to be labelled with the name of the field that the error should be attached to.
         fieldName = propertyWithError = error.context.label

--- a/src/validators/needToConsult.validator.js
+++ b/src/validators/needToConsult.validator.js
@@ -7,7 +7,7 @@ const MAX_NAME_LENGTH = 150
 module.exports = class NeedToConsultValidator extends BaseValidator {
   get errorMessages () {
     return {
-      'consult-none-required': {
+      'consult-select': {
         'object.without': `You cannot select a release and 'None of these'. Please deselect one of them.`,
         'object.missing': `Select at least one option. If there are no releases select 'None of these'.`
       },
@@ -27,31 +27,33 @@ module.exports = class NeedToConsultValidator extends BaseValidator {
   }
 
   get formValidators () {
-    return Joi.object().keys({
-      'consult-sewerage-undertaker': Joi
-        .string()
-        .max(MAX_NAME_LENGTH)
-        .when('consult-sewer-required', {
-          is: 'yes',
-          then: Joi.required(),
-          otherwise: Joi.optional() }),
-      'consult-harbour-authority': Joi
-        .string()
-        .max(MAX_NAME_LENGTH)
-        .when('consult-harbour-required', {
-          is: 'yes',
-          then: Joi.required(),
-          otherwise: Joi.optional() }),
-      'consult-fisheries-committee': Joi
-        .string()
-        .max(MAX_NAME_LENGTH)
-        .when('consult-fisheries-required', {
-          is: 'yes',
-          then: Joi.required(),
-          otherwise: Joi.optional() })
-    })
+    return Joi.object()
+      .keys({
+        'consult-none-required': Joi.string().optional().label('consult-select'),
+        'consult-sewerage-undertaker': Joi
+          .string()
+          .max(MAX_NAME_LENGTH)
+          .when('consult-sewer-required', {
+            is: 'yes',
+            then: Joi.required(),
+            otherwise: Joi.optional() }),
+        'consult-harbour-authority': Joi
+          .string()
+          .max(MAX_NAME_LENGTH)
+          .when('consult-harbour-required', {
+            is: 'yes',
+            then: Joi.required(),
+            otherwise: Joi.optional() }),
+        'consult-fisheries-committee': Joi
+          .string()
+          .max(MAX_NAME_LENGTH)
+          .when('consult-fisheries-required', {
+            is: 'yes',
+            then: Joi.required(),
+            otherwise: Joi.optional() })
+      })
       .without('consult-none-required', ['consult-sewer-required', 'consult-harbour-required', 'consult-fisheries-required'])
       .or('consult-none-required', 'consult-sewer-required', 'consult-harbour-required', 'consult-fisheries-required')
-      .label('consult-none-required') // Label with the name of the field that the error should be attached to on the form
+      .label('consult-select') // Label with the name of the field that the error should be attached to on the form
   }
 }

--- a/src/views/managementSystemSelect.html
+++ b/src/views/managementSystemSelect.html
@@ -25,7 +25,7 @@
       <form method="POST" action="{{formAction}}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
-        <div class="form-group {{#getFormErrorGroupClass errors.environmental-management-system}}{{/getFormErrorGroupClass}}">
+        <div id="environmental-management-system" class="form-group {{#getFormErrorGroupClass errors.environmental-management-system}}{{/getFormErrorGroupClass}}">
           <fieldset>
 
             <legend id="environmental-management-system-legend" class="visuallyhidden">{{pageHeading}}</legend>

--- a/src/views/needToConsult.html
+++ b/src/views/needToConsult.html
@@ -11,75 +11,67 @@
 
       {{> common/pageHeading pageHeading }}
 
+      <p>If it does, we will ask the organisation involved for their views on your permit application.</p>
+
       <form id="form" method="POST" action="{{formAction}}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}
 
-        <div class="form-group {{#getFormErrorGroupClass errors.consult-none-required}}{{/getFormErrorGroupClass}}">
+        <div class="form-group {{#getFormErrorGroupClass errors.consult-select}}{{/getFormErrorGroupClass}}">
         <fieldset>
           <legend id="legend" class="visuallyhidden">{{pageHeading}}</legend>
 
-          <p>If it does, we will ask the relevant organisation for their views on your permit application.</p>
+          <h2 id="consult-select" class="heading-small">Select all that you will release into</h2>
+          {{> common/fieldError fieldId='consult-select-error' message=errors.consult-select }}
 
-          <h2 class="heading-small">Select all that you will release into</h2>
-
-          <div class="form-group">
-            <div class="multiple-choice" data-target="consult-sewer-yes">
-              <input id="consult-sewer-required" name="consult-sewer-required" type="checkbox" value="yes" {{#if formValues.consult-sewer-required}}checked{{/if}}>
-              <label id="consult-sewer-required-label" for="consult-sewer-required">
-                A sewer managed by a water or sewerage company
-                <span class="form-hint">This does not apply if the only release is sewage or foul water from staff facilities</span>
-              </label>
-            </div>
-            <div id="consult-sewer-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-sewerage-undertaker}}{{/getFormErrorGroupClass}}">
-              <label id="consult-sewerage-undertaker-label" class="form-label" for="consult-sewerage-undertaker">
-                Water or sewerage company name
-              </label>
-              {{> common/fieldError fieldId='consult-sewerage-undertaker-error' message=errors.consult-sewerage-undertaker }}
-              <input class="form-control form-control-char-60 {{#if errors.consult-sewerage-undertaker}}form-control-error{{/if}}" id="consult-sewerage-undertaker" name="consult-sewerage-undertaker" type="text" value="{{formValues.consult-sewerage-undertaker}}">
-            </div>
+          <div class="multiple-choice" data-target="consult-sewer-yes">
+            <input id="consult-sewer-required" name="consult-sewer-required" type="checkbox" value="yes" {{#if formValues.consult-sewer-required}}checked{{/if}}>
+            <label id="consult-sewer-required-label" for="consult-sewer-required">
+              A sewer managed by a water or sewerage company
+              <span class="form-hint">This does not apply if the only release is sewage or foul water from staff facilities</span>
+            </label>
+          </div>
+          <div id="consult-sewer-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-sewerage-undertaker}}{{/getFormErrorGroupClass}}">
+            <label id="consult-sewerage-undertaker-label" class="form-label" for="consult-sewerage-undertaker">
+              Water or sewerage company name
+            </label>
+            {{> common/fieldError fieldId='consult-sewerage-undertaker-error' message=errors.consult-sewerage-undertaker }}
+            <input class="form-control form-control-char-60 {{#if errors.consult-sewerage-undertaker}}form-control-error{{/if}}" id="consult-sewerage-undertaker" name="consult-sewerage-undertaker" type="text" value="{{formValues.consult-sewerage-undertaker}}">
           </div>
 
-          <div class="form-group">
-            <div class="multiple-choice" data-target="consult-harbour-yes">
-              <input id="consult-harbour-required" name="consult-harbour-required" type="checkbox" value="yes" {{#if formValues.consult-harbour-required}}checked{{/if}}>
-              <label id="consult-harbour-required-label" for="consult-harbour-required">
-                A harbour managed by a harbour authority
-              </label>
-            </div>
-            <div id="consult-harbour-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-harbour-authority}}{{/getFormErrorGroupClass}}">
-              <label id="consult-harbour-authority-label" class="form-label" for="consult-harbour-authority">
-                Harbour authority name
-              </label>
-              {{> common/fieldError fieldId='consult-harbour-authority-error' message=errors.consult-harbour-authority }}
-              <input class="form-control form-control-char-60 {{#if errors.consult-harbour-authority}}form-control-error{{/if}}" id="consult-harbour-authority" name="consult-harbour-authority" type="text" value="{{formValues.consult-harbour-authority}}">
-            </div>
+          <div class="multiple-choice" data-target="consult-harbour-yes">
+            <input id="consult-harbour-required" name="consult-harbour-required" type="checkbox" value="yes" {{#if formValues.consult-harbour-required}}checked{{/if}}>
+            <label id="consult-harbour-required-label" for="consult-harbour-required">
+              A harbour managed by a harbour authority
+            </label>
+          </div>
+          <div id="consult-harbour-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-harbour-authority}}{{/getFormErrorGroupClass}}">
+            <label id="consult-harbour-authority-label" class="form-label" for="consult-harbour-authority">
+              Harbour authority name
+            </label>
+            {{> common/fieldError fieldId='consult-harbour-authority-error' message=errors.consult-harbour-authority }}
+            <input class="form-control form-control-char-60 {{#if errors.consult-harbour-authority}}form-control-error{{/if}}" id="consult-harbour-authority" name="consult-harbour-authority" type="text" value="{{formValues.consult-harbour-authority}}">
           </div>
 
 
-          <div class="form-group">
-            <div class="multiple-choice" data-target="consult-fisheries-yes">
-              <input id="consult-fisheries-required" name="consult-fisheries-required" type="checkbox" value="yes" {{#if formValues.consult-fisheries-required}}checked{{/if}}>
-              <label id="consult-fisheries-required-label" for="consult-fisheries-required">
-                Directly into relevant territorial waters or coastal waters within the sea fisheries district of a local fisheries committee
-              </label>
-            </div>
-            <div id="consult-fisheries-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-fisheries-committee}}{{/getFormErrorGroupClass}}">
-              <label id="consult-fisheries-committee-label" class="form-label" for="consult-fisheries-committee">
-                Fisheries committee name
-              </label>
-              {{> common/fieldError fieldId='consult-fisheries-committee-error' message=errors.consult-fisheries-committee }}
-              <input class="form-control form-control-char-60 {{#if errors.consult-fisheries-committee}}form-control-error{{/if}}" id="consult-fisheries-committee" name="consult-fisheries-committee" type="text" value="{{formValues.consult-fisheries-committee}}">
-            </div>
+          <div class="multiple-choice" data-target="consult-fisheries-yes">
+            <input id="consult-fisheries-required" name="consult-fisheries-required" type="checkbox" value="yes" {{#if formValues.consult-fisheries-required}}checked{{/if}}>
+            <label id="consult-fisheries-required-label" for="consult-fisheries-required">
+              Directly into relevant territorial waters or coastal waters within the sea fisheries district of a local fisheries committee
+            </label>
+          </div>
+          <div id="consult-fisheries-yes" class="panel panel-border-narrow js-hidden {{#getFormErrorGroupClass errors.consult-fisheries-committee}}{{/getFormErrorGroupClass}}">
+            <label id="consult-fisheries-committee-label" class="form-label" for="consult-fisheries-committee">
+              Fisheries committee name
+            </label>
+            {{> common/fieldError fieldId='consult-fisheries-committee-error' message=errors.consult-fisheries-committee }}
+            <input class="form-control form-control-char-60 {{#if errors.consult-fisheries-committee}}form-control-error{{/if}}" id="consult-fisheries-committee" name="consult-fisheries-committee" type="text" value="{{formValues.consult-fisheries-committee}}">
           </div>
 
-          <div class="form-group">
-            <div class="multiple-choice">
-              <input id="consult-none-required" name="consult-none-required" type="checkbox" value="yes" {{#if formValues.consult-none-required}}checked{{/if}}>
-              <label id="consult-none-required-label" for="consult-none-required">
-                None of these
-                {{> common/fieldError fieldId='consult-none-required-error' message=errors.consult-none-required }}
-              </label>
-            </div>
+          <div class="multiple-choice">
+            <input id="consult-none-required" name="consult-none-required" type="checkbox" value="yes" {{#if formValues.consult-none-required}}checked{{/if}}>
+            <label id="consult-none-required-label" for="consult-none-required">
+              None of these
+            </label>
           </div>
 
         </fieldset>

--- a/src/views/upload/managementSystem/managementSystemSummary.html
+++ b/src/views/upload/managementSystem/managementSystemSummary.html
@@ -20,14 +20,12 @@
         <div id="has-no-annotations" class="form-group">
           <div id="management-system-summary-description">
             <p>
-              <span>Write a summary to explain how your management system complies with each section of the</span>
+              Write a summary to explain how your management system complies with each section of the
               <a id="environmental-management-system-guidance-link"
                  href="https://www.gov.uk/guidance/develop-a-management-system-environmental-permits"
                  target="_blank"
-                 rel="noopener noreferrer">
-                <span>guidance about management systems on GOV.UK (opens new tab)</span>
-              </a>
-              <span>You should also summarise any extra items that your system includes.</span>
+                 rel="noopener noreferrer">guidance about management systems on GOV.UK (opens new tab)</a>.
+              You should also summarise any extra items that your system includes.
             </p>
             <p>
               If you are using a recognised scheme or standard you must still produce a summary.

--- a/test/routes/needToConsult.route.test.js
+++ b/test/routes/needToConsult.route.test.js
@@ -173,13 +173,13 @@ lab.experiment('Consultees page tests:', () => {
         postRequest.payload = {}
         const doc = await GeneralTestHelper.getDoc(postRequest)
         await checkCommonElements(doc)
-        await GeneralTestHelper.checkValidationMessage(doc, 'consult-none-required', `Select at least one option. If there are no releases select 'None of these'.`)
+        await GeneralTestHelper.checkValidationMessage(doc, 'consult-select', `Select at least one option. If there are no releases select 'None of these'.`)
       })
       lab.test(`when both releases and 'None' are selected`, async () => {
         postRequest.payload['consult-none-required'] = 'yes'
         const doc = await GeneralTestHelper.getDoc(postRequest)
         await checkCommonElements(doc)
-        await GeneralTestHelper.checkValidationMessage(doc, 'consult-none-required', `You cannot select a release and 'None of these'. Please deselect one of them.`)
+        await GeneralTestHelper.checkValidationMessage(doc, 'consult-select', `You cannot select a release and 'None of these'. Please deselect one of them.`)
       })
       lab.test('when sewer is selected but no undertaker name is provided', async () => {
         delete postRequest.payload['consult-sewerage-undertaker']


### PR DESCRIPTION
Content changes and error handling following QA

https://eaflood.atlassian.net/browse/WE-1700
https://eaflood.atlassian.net/browse/WE-1694

Fixes most of the issues, except one optional one:
"1. Do not display both errors - checkbox and missing text - if it is relatively easy"

After spending too long looking at how to to do this, I've left it for now.
