### PR TITLE
Only display main consultee error

### DIFF
--- a/src/validators/needToConsult.validator.js
+++ b/src/validators/needToConsult.validator.js
@@ -27,33 +27,25 @@ module.exports = class NeedToConsultValidator extends BaseValidator {
   }
 
   get formValidators () {
-    return Joi.object()
-      .keys({
-        'consult-none-required': Joi.string().optional().label('consult-select'),
-        'consult-sewerage-undertaker': Joi
-          .string()
-          .max(MAX_NAME_LENGTH)
-          .when('consult-sewer-required', {
-            is: 'yes',
-            then: Joi.required(),
-            otherwise: Joi.optional() }),
-        'consult-harbour-authority': Joi
-          .string()
-          .max(MAX_NAME_LENGTH)
-          .when('consult-harbour-required', {
-            is: 'yes',
-            then: Joi.required(),
-            otherwise: Joi.optional() }),
-        'consult-fisheries-committee': Joi
-          .string()
-          .max(MAX_NAME_LENGTH)
-          .when('consult-fisheries-required', {
-            is: 'yes',
-            then: Joi.required(),
-            otherwise: Joi.optional() })
-      })
-      .without('consult-none-required', ['consult-sewer-required', 'consult-harbour-required', 'consult-fisheries-required'])
+    return Joi.object({
+      'consult-none-required': Joi.string().label('consult-select')
+    })
       .or('consult-none-required', 'consult-sewer-required', 'consult-harbour-required', 'consult-fisheries-required')
-      .label('consult-select') // Label with the name of the field that the error should be attached to on the form
+      .label('consult-select') // The name of the field that object-level errors should be attached to on the page
+      .when(Joi.object({ 'consult-none-required': Joi.exist() }), {
+        then: Joi.object()
+          .without('consult-none-required', ['consult-sewer-required', 'consult-harbour-required', 'consult-fisheries-required']),
+        otherwise: Joi.object({
+          'consult-sewerage-undertaker': Joi.string()
+            .max(MAX_NAME_LENGTH)
+            .when('consult-sewer-required', { is: Joi.exist(), then: Joi.required() }),
+          'consult-harbour-authority': Joi.string()
+            .max(MAX_NAME_LENGTH)
+            .when('consult-harbour-required', { is: Joi.exist(), then: Joi.required() }),
+          'consult-fisheries-committee': Joi.string()
+            .max(MAX_NAME_LENGTH)
+            .when('consult-fisheries-required', { is: Joi.exist(), then: Joi.required() })
+        })
+      })
   }
 }

--- a/test/routes/generalTestHelper.test.js
+++ b/test/routes/generalTestHelper.test.js
@@ -41,6 +41,14 @@ module.exports = class GeneralTestHelper {
     Code.expect(doc.getElementById(`${fieldId}-error`).firstChild.firstChild.nodeValue).to.equal(expectedErrorMessage)
   }
 
+  static checkNoValidationMessage (doc, fieldId) {
+    Code.expect(doc.getElementById(`${fieldId}-error`)).to.not.exist()
+  }
+
+  static checkValidationMessageCount (doc, expectedCount) {
+    Code.expect(doc.getElementById('error-summary-list').getElementsByTagName('li').length).to.equal(expectedCount)
+  }
+
   static async getDoc (request, status = 200) {
     // TODO Possibly call this executeRequest
     // This executes a request and then returns the document view

--- a/test/routes/needToConsult.route.test.js
+++ b/test/routes/needToConsult.route.test.js
@@ -181,6 +181,15 @@ lab.experiment('Consultees page tests:', () => {
         await checkCommonElements(doc)
         await GeneralTestHelper.checkValidationMessage(doc, 'consult-select', `You cannot select a release and 'None of these'. Please deselect one of them.`)
       })
+      lab.test(`when both releases and 'None' are selected, only shows single error message`, async () => {
+        postRequest.payload['consult-none-required'] = 'yes'
+        delete postRequest.payload['consult-sewerage-undertaker']
+        const doc = await GeneralTestHelper.getDoc(postRequest)
+        await checkCommonElements(doc)
+        await GeneralTestHelper.checkValidationMessage(doc, 'consult-select', `You cannot select a release and 'None of these'. Please deselect one of them.`)
+        await GeneralTestHelper.checkValidationMessageCount(doc, 1)
+        await GeneralTestHelper.checkNoValidationMessage(doc, 'consult-sewerage-undertaker')
+      })
       lab.test('when sewer is selected but no undertaker name is provided', async () => {
         delete postRequest.payload['consult-sewerage-undertaker']
         const doc = await GeneralTestHelper.getDoc(postRequest)


### PR DESCRIPTION
Resolving final error display issue on the consultee page, from card:
https://eaflood.atlassian.net/browse/WE-1734

“Do not display both errors - checkbox and missing text - if it is relatively easy”

Each field now checks for the "None" value being selected, which results in multiple, duplicate errors, so I have added code to remove any duplicate error messages when they are added to the page.