### PR TITLE
MCP - Cost and time

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -56,8 +56,9 @@ Constants.OFFLINE_CATEGORIES = {
 }
 
 Constants.PROCESSING_TIME = {
-  MCP_CATEGORIES_PROCESSING_TIME: '9 weeks',
-  DEFAULT_CATEGORIES_PROCESSING_TIME: '13 weeks'
+  'mpcd-sg': '9 weeks',
+  'mcpd-mcp': '9 weeks',
+  default: '13 weeks'
 }
 
 Constants.PAYMENT_CONFIGURATION_PREFIX = 'WastePermits.ECOM.'

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,6 +55,11 @@ Constants.OFFLINE_CATEGORIES = {
   }
 }
 
+Constants.PROCESSING_TIME = {
+  MCP_CATEGORIES_PROCESSING_TIME: '9 weeks',
+  DEFAULT_CATEGORIES_PROCESSING_TIME: '13 weeks'
+}
+
 Constants.PAYMENT_CONFIGURATION_PREFIX = 'WastePermits.ECOM.'
 
 Constants.DEFRA_COOKIE_KEY = 'DefraSession'

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -1,21 +1,26 @@
 'use strict'
 
-const { WASTE_IN_DEPOSIT_FOR_RECOVERY } = require('../constants').PermitTypes.STANDARD_RULES
+const Constants = require('../constants')
+const { WASTE_IN_DEPOSIT_FOR_RECOVERY } = Constants.PermitTypes.STANDARD_RULES
+const { MCP_CATEGORIES_PROCESSING_TIME, DEFAULT_CATEGORIES_PROCESSING_TIME } = Constants.PROCESSING_TIME
 const Routes = require('../routes')
 const BaseController = require('./base.controller')
 const CostTime = require('../models/taskList/costTime.task')
 const RecoveryService = require('../services/recovery.service')
+const StandardRuleType = require('../persistence/entities/standardRuleType.entity')
 
 module.exports = class CostTimeController extends BaseController {
   async doGet (request, h) {
     const pageContext = this.createPageContext(h)
     const context = await RecoveryService.createApplicationContext(h, { applicationLine: true, standardRule: true })
     const { applicationLine = {}, standardRule = {} } = context
+    const { categoryName } = await StandardRuleType.getById(context, standardRule.standardRuleTypeId)
 
     // Default to 0 when the balance hasn't been set
     const { value = 0 } = applicationLine
 
     pageContext.cost = value.toLocaleString()
+    pageContext.time = categoryName.includes('MCP') ? MCP_CATEGORIES_PROCESSING_TIME : DEFAULT_CATEGORIES_PROCESSING_TIME
     pageContext.includesWasteRecoveryPlan = standardRule.code === WASTE_IN_DEPOSIT_FOR_RECOVERY
 
     return this.showView({ h, pageContext })

--- a/src/controllers/costTime.controller.js
+++ b/src/controllers/costTime.controller.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const Constants = require('../constants')
-const { WASTE_IN_DEPOSIT_FOR_RECOVERY } = Constants.PermitTypes.STANDARD_RULES
-const { MCP_CATEGORIES_PROCESSING_TIME, DEFAULT_CATEGORIES_PROCESSING_TIME } = Constants.PROCESSING_TIME
+const { PROCESSING_TIME, PermitTypes } = require('../constants')
+const { WASTE_IN_DEPOSIT_FOR_RECOVERY } = PermitTypes.STANDARD_RULES
 const Routes = require('../routes')
 const BaseController = require('./base.controller')
 const CostTime = require('../models/taskList/costTime.task')
@@ -20,7 +19,7 @@ module.exports = class CostTimeController extends BaseController {
     const { value = 0 } = applicationLine
 
     pageContext.cost = value.toLocaleString()
-    pageContext.time = categoryName.includes('MCP') ? MCP_CATEGORIES_PROCESSING_TIME : DEFAULT_CATEGORIES_PROCESSING_TIME
+    pageContext.time = PROCESSING_TIME[categoryName.toLowerCase()] || PROCESSING_TIME.default
     pageContext.includesWasteRecoveryPlan = standardRule.code === WASTE_IN_DEPOSIT_FOR_RECOVERY
 
     return this.showView({ h, pageContext })

--- a/src/views/costTime.html
+++ b/src/views/costTime.html
@@ -24,7 +24,7 @@
             <h2 id="time-to-wait-text" class="bold">Time to wait after applying</h2>
             <span id="more-info-text">It may take longer if we need to ask you for more information.</span>
           </dt>
-          <dd id="length-of-time-text" class="bold-medium">up to 13 weeks</dd>
+          <dd id="length-of-time-text" class="bold-medium">up to {{time}}</dd>
         </div>
       </dl>
 

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -15,6 +15,7 @@ const Location = require('../../src/persistence/entities/location.entity')
 const LocationDetail = require('../../src/persistence/entities/locationDetail.entity')
 const Payment = require('../../src/persistence/entities/payment.entity')
 const StandardRule = require('../../src/persistence/entities/standardRule.entity')
+const StandardRuleType = require('../../src/persistence/entities/standardRuleType.entity')
 
 const ContactDetail = require('../../src/models/contactDetail.model')
 const CharityDetail = require('../../src/models/charityDetail.model')
@@ -236,6 +237,13 @@ class MockData {
     }
   }
 
+  get standardRuleType () {
+    return {
+      categoryName: 'CATEGORY_NAME',
+      standardRuleTypeId: 'STANDARD_RULE_TYPE_ID'
+    }
+  }
+
   get totalCostItemModel () {
     return {
       description: 'TOTAL_COST_ITEM_DESCRIPTION',
@@ -384,7 +392,8 @@ class Mocks {
         authToken: 'AUTH_TOKEN',
         applicationId: this.application.id,
         applicationLineId: this.applicationLine.id,
-        application: this.application
+        application: this.application,
+        standardRule: this.standardRule
       })
     }
     return this._recovery
@@ -401,6 +410,11 @@ class Mocks {
   get standardRule () {
     const { standardRule } = this.mockData
     return this._standardRule || (this._standardRule = new StandardRule(standardRule))
+  }
+
+  get standardRuleType () {
+    const { standardRuleType } = this.mockData
+    return this._standardRuleType || (this._standardRuleType = new StandardRuleType(standardRuleType))
   }
 }
 

--- a/test/routes/costTime.route.test.js
+++ b/test/routes/costTime.route.test.js
@@ -4,14 +4,15 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../helpers/mocks')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 
 const Application = require('../../src/persistence/entities/application.entity')
 const CostTime = require('../../src/models/taskList/costTime.task')
-const StandardRule = require('../../src/persistence/entities/standardRule.entity')
-const CharityDetail = require('../../src/models/charityDetail.model')
+const RecoveryService = require('../../src/services/recovery.service')
+const StandardRuleType = require('../../src/persistence/entities/standardRuleType.entity')
 const CookieService = require('../../src/services/cookie.service')
 const LoggingService = require('../../src/services/logging.service')
 const { COOKIE_RESULT } = require('../../src/constants')
@@ -20,31 +21,23 @@ const routePath = '/costs-times'
 const nextRoutePath = '/task-list'
 const errorPath = '/errors/technical-problem'
 
-let fakeApplication
-let fakeStandardRule
+let mocks
 let sandbox
 
 lab.beforeEach(() => {
-  fakeApplication = {
-    id: 'APPLICATION_ID'
-  }
-
-  fakeStandardRule = {
-    code: 'STANDARD_RULE_CODE',
-    guidanceUrl: 'STANDARD_RULE_GUIDANCE_URL'
-  }
+  mocks = new Mocks()
 
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
+  sandbox.stub(Application, 'getById').value(() => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(CostTime, 'isComplete').value(() => false)
   sandbox.stub(CostTime, 'updateCompleteness').value(() => {})
-  sandbox.stub(StandardRule, 'getByApplicationLineId').value(() => new Application(fakeStandardRule))
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(StandardRuleType, 'getById').value(() => mocks.standardRuleType)
 })
 
 lab.afterEach(() => {
@@ -85,13 +78,23 @@ lab.experiment('Cost and time for this permit page tests:', () => {
         const doc = await GeneralTestHelper.getDoc(getRequest)
         checkCommonElements(doc)
         Code.expect(doc.getElementById('includes-waste-recovery-plan')).to.not.exist()
+        Code.expect(GeneralTestHelper.getText(doc.getElementById('length-of-time-text'))).to.equal('up to 13 weeks')
       })
 
       lab.test(`when standard rule is a recovery plan`, async () => {
-        fakeStandardRule.code = 'SR2015 No 39'
+        mocks.standardRule.code = 'SR2015 No 39'
         const doc = await GeneralTestHelper.getDoc(getRequest)
         checkCommonElements(doc)
         Code.expect(doc.getElementById('includes-waste-recovery-plan')).to.exist()
+        Code.expect(GeneralTestHelper.getText(doc.getElementById('length-of-time-text'))).to.equal('up to 13 weeks')
+      })
+
+      lab.test(`when standard rule is for an mcp`, async () => {
+        mocks.standardRuleType.categoryName = 'CATEGORY-NAME-MCP'
+        const doc = await GeneralTestHelper.getDoc(getRequest)
+        checkCommonElements(doc)
+        Code.expect(doc.getElementById('includes-waste-recovery-plan')).to.not.exist()
+        Code.expect(GeneralTestHelper.getText(doc.getElementById('length-of-time-text'))).to.equal('up to 9 weeks')
       })
     })
   })
@@ -115,7 +118,7 @@ lab.experiment('Cost and time for this permit page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when updateCompletenesss fails', async () => {
+      lab.test('redirects to error screen when updateCompleteness fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         CostTime.updateCompleteness = () => {
           throw new Error('update failed')

--- a/test/routes/costTime.route.test.js
+++ b/test/routes/costTime.route.test.js
@@ -90,7 +90,7 @@ lab.experiment('Cost and time for this permit page tests:', () => {
       })
 
       lab.test(`when standard rule is for an mcp`, async () => {
-        mocks.standardRuleType.categoryName = 'CATEGORY-NAME-MCP'
+        mocks.standardRuleType.categoryName = 'MCPD-MCP'
         const doc = await GeneralTestHelper.getDoc(getRequest)
         checkCommonElements(doc)
         Code.expect(doc.getElementById('includes-waste-recovery-plan')).to.not.exist()


### PR DESCRIPTION
- Use configuration to control processing time message
- Use standard mocks within cost-time unit test

Implements: https://eaflood.atlassian.net/browse/WE-1953