### PR TITLE
More route unit tests now use standard mocks

### DIFF
--- a/src/controllers/permitHolder/permitHolderDetails.controller.js
+++ b/src/controllers/permitHolder/permitHolderDetails.controller.js
@@ -12,26 +12,26 @@ module.exports = class PermitHolderDetailsController extends BaseController {
     const { charityPermitHolder } = charityDetail
 
     // If there is a charity detail, it must be a charity
-    switch (charityPermitHolder ? CHARITY_OR_TRUST : permitHolderType) {
+    switch (charityPermitHolder ? CHARITY_OR_TRUST.type : permitHolderType.type) {
       case undefined:
         throw new Error('Permit Holder Type is undefined')
-      case INDIVIDUAL:
-      case SOLE_TRADER:
+      case INDIVIDUAL.type:
+      case SOLE_TRADER.type:
         // Re-direct to individual details flow
         return this.redirect({ h, route: PERMIT_HOLDER_NAME_AND_DATE_OF_BIRTH })
-      case LIMITED_LIABILITY_PARTNERSHIP:
+      case LIMITED_LIABILITY_PARTNERSHIP.type:
         // Re-direct to limited liability partnership details flow
         return this.redirect({ h, route: LLP_COMPANY_NUMBER })
-      case PUBLIC_BODY:
+      case PUBLIC_BODY.type:
         // Re-direct to partnership details flow
         return this.redirect({ h, route: PUBLIC_BODY_NAME })
-      case PARTNERSHIP:
+      case PARTNERSHIP.type:
         // Re-direct to partnership details flow
         return this.redirect({ h, route: PARTNERSHIP_TRADING_NAME })
-      case CHARITY_OR_TRUST:
+      case CHARITY_OR_TRUST.type:
         // Re-direct to partnership details flow
         return this.redirect({ h, route: CHARITY_PERMIT_HOLDER })
-      case OTHER_ORGANISATION:
+      case OTHER_ORGANISATION.type:
         // Re-direct to partnership details flow
         return this.redirect({ h, route: PERMIT_GROUP_DECIDE })
       default:

--- a/src/controllers/permitHolder/permitHolderType.controller.js
+++ b/src/controllers/permitHolder/permitHolderType.controller.js
@@ -17,7 +17,8 @@ module.exports = class PermitHolderTypeController extends BaseController {
         selectedPermitHolderType = permitHolderTypes.find(({ id }) => id === PERMIT_HOLDER_TYPES.CHARITY_OR_TRUST.id)
       } else {
         const { applicantType, organisationType } = application
-        selectedPermitHolderType = permitHolderTypes.find(({ dynamicsApplicantTypeId, dynamicsOrganisationTypeId }) => dynamicsApplicantTypeId === applicantType && dynamicsOrganisationTypeId === organisationType)
+        selectedPermitHolderType = permitHolderTypes.find(({ dynamicsApplicantTypeId, dynamicsOrganisationTypeId }) =>
+          dynamicsApplicantTypeId === applicantType && dynamicsOrganisationTypeId === organisationType)
       }
     }
     if (selectedPermitHolderType) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -808,7 +808,9 @@ const Routes = {
     controller: 'bespokeOrStandardRules',
     validator: 'bespokeOrStandardRules',
     nextRoute: 'PERMIT_HOLDER_TYPE',
-    types: 'GET, POST'
+    types: 'GET, POST',
+    cookieValidationRequired: false,
+    applicationRequired: false
   },
   CHECK_BEFORE_SENDING: {
     path: '/check-before-sending',

--- a/src/services/recovery.service.js
+++ b/src/services/recovery.service.js
@@ -44,13 +44,15 @@ module.exports = class RecoveryService {
     context.slug = slug
     context.authToken = CookieService.get(request, AUTH_TOKEN)
     context.applicationId = CookieService.get(request, APPLICATION_ID)
-    context.application = await Application.getById(context, context.applicationId)
-    context.applicationLineId = CookieService.get(request, APPLICATION_LINE_ID)
-    context.standardRuleId = CookieService.get(request, STANDARD_RULE_ID)
-    context.standardRuleTypeId = CookieService.get(request, STANDARD_RULE_TYPE_ID)
-    context.permitHolderType = RecoveryService.getPermitHolderType(context.application)
+    if (context.applicationId) {
+      context.application = await Application.getById(context, context.applicationId)
+      context.applicationLineId = CookieService.get(request, APPLICATION_LINE_ID)
+      context.standardRuleId = CookieService.get(request, STANDARD_RULE_ID)
+      context.standardRuleTypeId = CookieService.get(request, STANDARD_RULE_TYPE_ID)
+      context.permitHolderType = RecoveryService.getPermitHolderType(context.application)
 
-    Object.assign(context, await RecoveryService.recoverOptionalData(context, options))
+      Object.assign(context, await RecoveryService.recoverOptionalData(context, options))
+    }
 
     return context
   }

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -68,8 +68,10 @@ class MockData {
   }
 
   get annotation () {
+    const { application } = this
     return {
       id: 'ANNOTATION_ID',
+      applicationId: application.id,
       subject: 'ANNOTATION_NAME',
       filename: 'ANNOTATION_FILENAME'
     }
@@ -80,12 +82,13 @@ class MockData {
       id: 'APPLICATION_ID',
       applicationNumber: 'APPLICATION_NUMBER',
       agentId: 'AGENT_ID',
-      organisationType: 'ORGANISATION_TYPE',
+      applicantType: 910400001, // organisation
+      organisationType: 910400000, // limited company
       permitHolderOrganisationId: 'PERMIT_HOLDER_ORGANISATION_ID',
       confidentiality: true,
       confidentialityDetails: 'CONFIDENTIALITY DETAILS 1\nCONFIDENTIALITY DETAILS 2',
-      drainageType: 910400000,
-      miningWastePlan: 910400000,
+      drainageType: 910400000, // sewer
+      miningWastePlan: 910400000, // water-based
       miningWasteWeight: 'one,hundred-thousand',
       tradingName: 'TRADING_NAME',
       useTradingName: true,
@@ -224,7 +227,7 @@ class MockData {
     return {
       id: 'LOCATION_DETAIL_ID',
       addressId: address.id,
-      gridReference: 'GRID_REFERENCE'
+      gridReference: 'AB1234567890'
     }
   }
 
@@ -243,9 +246,13 @@ class MockData {
   }
 
   get permitHolderType () {
+    const { application } = this
     return {
+      id: 'limited-company',
       type: 'Limited company',
-      canApplyOnline: true
+      canApplyOnline: true,
+      dynamicsApplicantTypeId: application.applicantType,
+      dynamicsOrganisationTypeId: application.organisationType
     }
   }
 
@@ -375,6 +382,7 @@ class Mocks {
       const account = this.account
       const application = this.application
       const applicationLine = this.applicationLine
+      const applicationReturn = this.applicationReturn
       const standardRule = this.standardRule
       const permitHolderType = this.permitHolderType
       this._context = {
@@ -386,6 +394,7 @@ class Mocks {
         standardRuleTypeId: standardRule.standardRuleTypeId,
         application,
         applicationLine,
+        applicationReturn,
         permitHolderType,
         standardRule
       }

--- a/test/routes/applicationReceived.route.test.js
+++ b/test/routes/applicationReceived.route.test.js
@@ -15,9 +15,7 @@ const CookieService = require('../../src/services/cookie.service')
 const RecoveryService = require('../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../src/constants')
 
-const fakeSlug = 'SLUG'
-
-const routePath = `/done/${fakeSlug}`
+const routePath = `/done/slug`
 
 let bacsPayment
 let cardPayment

--- a/test/routes/bespokeOrStandardRules.route.test.js
+++ b/test/routes/bespokeOrStandardRules.route.test.js
@@ -10,8 +10,8 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 
 const Application = require('../../src/persistence/entities/application.entity')
 const DataStore = require('../../src/models/dataStore.model')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const CookieService = require('../../src/services/cookie.service')
+const RecoveryService = require('../../src/services/recovery.service')
 const featureConfig = require('../../src/config/featureConfig')
 const { COOKIE_RESULT } = require('../../src/constants')
 
@@ -67,9 +67,8 @@ lab.beforeEach(() => {
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
   sandbox.stub(DataStore, 'save').value(async () => mocks.dataStore.id)
-  sandbox.stub(Application, 'getById').value(() => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(CharityDetail, 'get').value(() => mocks.charityDetail)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
   // Todo: Remove hasBespokeFeature syub when bespoke is live
   sandbox.stub(featureConfig, 'hasBespokeFeature').value(() => true)
 })
@@ -80,7 +79,11 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Bespoke or standard rules page tests:', () => {
-  new GeneralTestHelper({ lab, routePath }).test()
+  new GeneralTestHelper({ lab, routePath }).test({
+    excludeAlreadySubmittedTest: true,
+    excludeCookieGetTests: true,
+    excludeCookiePostTests: true
+  })
 
   lab.experiment('GET:', () => {
     lab.test('GET returns the Bespoke or Standard Rules page correctly', async () => {

--- a/test/routes/checkBeforeSending.route.test.js
+++ b/test/routes/checkBeforeSending.route.test.js
@@ -12,9 +12,9 @@ const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
 const BaseTaskList = require('../../src/models/taskList/base.taskList')
 const BaseCheck = require('../../src/models/checkList/base.check')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const CheckBeforeSendingController = require('../../src/controllers/checkBeforeSending.controller')
 const CookieService = require('../../src/services/cookie.service')
+const RecoveryService = require('../../src/services/recovery.service')
 
 let fakeValidRuleSetId
 let fakeInvalidRuleSetId
@@ -73,14 +73,13 @@ lab.beforeEach(() => {
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => true)
-  sandbox.stub(Application, 'getById').value(() => mocks.application)
   sandbox.stub(Application.prototype, 'save').value(() => undefined)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(CheckBeforeSendingController.prototype, 'Checks').get(() => [ValidCheck, InvalidCheck])
   sandbox.stub(BaseTaskList, 'getTaskListClass').value(() => TaskList)
   sandbox.stub(BaseTaskList, 'buildTaskList').value(() => new TaskList())
   sandbox.stub(BaseTaskList, 'isComplete').value(() => true)
-  sandbox.stub(CharityDetail, 'get').value(() => mocks.charityDetail)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {

--- a/test/routes/companyNumber.route.test.js
+++ b/test/routes/companyNumber.route.test.js
@@ -141,7 +141,6 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
           })
 
           lab.test('when account is updated', async () => {
-            // Account.getByApplicationId = () => Promise.resolve(new Account(fakeAccount))
             const res = await server.inject(postRequest)
             Code.expect(res.statusCode).to.equal(302)
             Code.expect(res.headers['location']).to.equal(nextPath)

--- a/test/routes/courseRegistration.route.test.js
+++ b/test/routes/courseRegistration.route.test.js
@@ -27,6 +27,7 @@ const paths = {
 const helper = new UploadTestHelper(lab, paths)
 
 let sandbox
+let mocks
 
 lab.beforeEach(() => {
   // Stub methods
@@ -34,7 +35,7 @@ lab.beforeEach(() => {
 
   sandbox.stub(StandardRule, 'getByApplicationLineId').value(() => Promise.resolve({}))
 
-  helper.setStubs(sandbox)
+  mocks = helper.setStubs(sandbox)
 })
 
 lab.afterEach(() => {
@@ -62,14 +63,14 @@ lab.experiment('Company Declare Upload Course registration tests:', () => {
       // Additional tests
       {
         title: 'displays WAMITAB medium or high risk information',
-        stubs: () => (StandardRule.getByApplicationLineId = () => ({ wamitabRiskLevel: WamitabRiskLevel.MEDIUM })),
+        stubs: () => (mocks.standardRule.wamitabRiskLevel = WamitabRiskLevel.MEDIUM),
         test: (doc) => GeneralTestHelper.checkElementsExist(doc, [
           'wamitab-risk-is-medium-or-high',
           'wamitab-risk-is-medium-or-high-abbr'])
       },
       {
         title: 'displays WAMITAB low risk information',
-        stubs: () => (StandardRule.getByApplicationLineId = () => ({ wamitabRiskLevel: WamitabRiskLevel.LOW })),
+        stubs: () => (mocks.standardRule.wamitabRiskLevel = WamitabRiskLevel.LOW),
         test: (doc) => GeneralTestHelper.checkElementsExist(doc, [
           'wamitab-risk-is-low'])
       },

--- a/test/routes/error/alreadySubmitted.test.js
+++ b/test/routes/error/alreadySubmitted.test.js
@@ -5,40 +5,28 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../../helpers/mocks')
 const GeneralTestHelper = require('../generalTestHelper.test')
 
-const Application = require('../../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../../src/models/charityDetail.model')
 const CookieService = require('../../../src/services/cookie.service')
+const RecoveryService = require('../../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../../src/constants')
-
-let sandbox
 
 const routePath = '/errors/order/done-cant-go-back'
 const pageHeading = `You have sent your application so you cannot go back and change it`
 
-const fakeApplication = {
-  id: 'APPLICATION_ID',
-  permitHolderOrganisationId: 'PERMIT_HOLDER_ORGANISATION_ID',
-  tradingName: 'THE TRADING NAME',
-  applicationNumber: 'APPLICATION_REFERENCE'
-}
-
-const getRequest = {
-  method: 'GET',
-  url: routePath,
-  headers: {},
-  payload: {}
-}
+let sandbox
+let mocks
 
 lab.beforeEach(() => {
+  mocks = new Mocks()
+
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -47,10 +35,21 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Already Submitted page tests:', () => {
+  let getRequest
+
   new GeneralTestHelper({ lab, routePath }).test({
     excludeCookieGetTests: true,
     excludeCookiePostTests: true,
     excludeAlreadySubmittedTest: true
+  })
+
+  lab.beforeEach(() => {
+    getRequest = {
+      method: 'GET',
+      url: routePath,
+      headers: {},
+      payload: {}
+    }
   })
 
   lab.test('The page should NOT have a back link', async () => {
@@ -79,6 +78,6 @@ lab.experiment('Already Submitted page tests:', () => {
 
     // Ensure that the application reference is being displayed correctly
     element = doc.getElementById('application-reference')
-    Code.expect(element.textContent).to.equal(fakeApplication.applicationNumber)
+    Code.expect(element.textContent).to.equal(mocks.application.applicationNumber)
   })
 })

--- a/test/routes/error/notSubmitted.test.js
+++ b/test/routes/error/notSubmitted.test.js
@@ -4,35 +4,28 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
-
+const Mocks = require('../../helpers/mocks')
 const GeneralTestHelper = require('../generalTestHelper.test')
 
-const Application = require('../../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../../src/models/charityDetail.model')
 const CookieService = require('../../../src/services/cookie.service')
+const RecoveryService = require('../../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../../src/constants')
-
-let sandbox
 
 const routePath = '/errors/order/check-answers-not-complete'
 const pageHeading = 'You need to check your answers and submit your application'
 
-const getRequest = {
-  method: 'GET',
-  url: routePath,
-  headers: {},
-  payload: {}
-}
+let sandbox
+let mocks
 
 lab.beforeEach(() => {
+  mocks = new Mocks()
+
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application({}))
-  sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -41,10 +34,21 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Not Submitted page tests:', () => {
+  let getRequest
+
   new GeneralTestHelper({ lab, routePath }).test({
     excludeCookieGetTests: true,
     excludeCookiePostTests: true,
     excludeAlreadySubmittedTest: true
+  })
+
+  lab.beforeEach(() => {
+    getRequest = {
+      method: 'GET',
+      url: routePath,
+      headers: {},
+      payload: {}
+    }
   })
 
   lab.test('The page should NOT have a back link', async () => {

--- a/test/routes/managementSystemSelect.route.test.js
+++ b/test/routes/managementSystemSelect.route.test.js
@@ -4,6 +4,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../helpers/mocks')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
@@ -23,10 +24,8 @@ const routePath = '/management-system/select'
 const nextRoutePath = '/management-system/upload'
 const errorPath = '/errors/technical-problem'
 
-let fakeApplication
-let fakeApplicationAnswer
-let fakeRecovery
 let sandbox
+let mocks
 
 const checkCommonElements = (doc) => {
   const pageHeading = 'Which management system will you use?'
@@ -43,34 +42,18 @@ const checkCommonElements = (doc) => {
 }
 
 lab.beforeEach(() => {
-  fakeApplication = {
-    id: 'APPLICATION_ID'
-  }
-
-  fakeApplicationAnswer = {
-    questionCode: 'QUESTION_CODE',
-    answerCode: 'ANSWER_CODE',
-    answerText: 'ANSWER_TEXT'
-  }
-
-  fakeRecovery = () => {
-    return {
-      authToken: 'AUTH_TOKEN',
-      applicationId: fakeApplication.id,
-      application: new Application(fakeApplication)
-    }
-  }
+  mocks = new Mocks()
 
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
+  sandbox.stub(Application, 'getById').value(() => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(ApplicationAnswer, 'getByQuestionCode').value(() => [new ApplicationAnswer(fakeApplicationAnswer)])
+  sandbox.stub(ApplicationAnswer, 'getByQuestionCode').value(() => mocks.applicationAnswers)
   sandbox.stub(ApplicationAnswer.prototype, 'save').value(() => undefined)
-  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => fakeRecovery())
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {

--- a/test/routes/mcpBusinessActivity.route.test.js
+++ b/test/routes/mcpBusinessActivity.route.test.js
@@ -9,9 +9,9 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const LoggingService = require('../../src/services/logging.service')
 const CookieService = require('../../src/services/cookie.service')
+const RecoveryService = require('../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../src/constants')
 
 const McpBusinessType = require('../../src/models/mcpBusinessType.model')
@@ -47,13 +47,12 @@ lab.beforeEach(() => {
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').callsFake(async () => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(Application.prototype, 'save').value(() => {})
-  sandbox.stub(CharityDetail, 'get').value(() => undefined)
   sandbox.stub(McpBusinessType, 'getMcpMainBusinessTypesList').callsFake(() => mocks.mcpMainBusinessTypesList)
   sandbox.stub(McpBusinessType, 'get').callsFake(async () => mocks.mcpBusinessType)
   sandbox.stub(McpBusinessType, 'save').callsFake(async () => null)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -102,10 +101,10 @@ lab.experiment('MCP business or activity page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to get the application ID', async () => {
+      lab.test('redirects to error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
-        Application.getById = () => {
-          throw new Error('read failed')
+        RecoveryService.createApplicationContext = () => {
+          throw new Error('application recovery failed')
         }
 
         const res = await server.inject(request)

--- a/test/routes/mcpTemplate.route.test.js
+++ b/test/routes/mcpTemplate.route.test.js
@@ -4,46 +4,38 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../helpers/mocks')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const StandardRule = require('../../src/persistence/entities/standardRule.entity')
 const McpTemplate = require('../../src/models/taskList/mcpTemplate.task')
 const LoggingService = require('../../src/services/logging.service')
 const CookieService = require('../../src/services/cookie.service')
+const RecoveryService = require('../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/mcp/template/download'
 const nextRoutePath = '/task-list'
 const errorPath = '/errors/technical-problem'
 
-let fakeApplication
-let fakeStandardRule
 let sandbox
+let mocks
 
 lab.beforeEach(() => {
-  fakeApplication = {
-    id: 'APPLICATION_ID',
-    applicationNumber: 'EPR/AB1234CD/A001'
-  }
-
-  fakeStandardRule = {
-    code: 'STANDARD_RULE_CODE'
-  }
+  mocks = new Mocks()
 
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(McpTemplate, 'isComplete').value(() => false)
   sandbox.stub(McpTemplate, 'updateCompleteness').value(() => {})
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
-  sandbox.stub(StandardRule, 'getByApplicationLineId').value(() => new StandardRule(fakeStandardRule))
+  sandbox.stub(StandardRule, 'getByApplicationLineId').value(() => mocks.standardRule)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {

--- a/test/routes/needToConsult.route.test.js
+++ b/test/routes/needToConsult.route.test.js
@@ -9,7 +9,7 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../src/models/charityDetail.model')
+const RecoveryService = require('../../src/services/recovery.service')
 const LoggingService = require('../../src/services/logging.service')
 const CookieService = require('../../src/services/cookie.service')
 const { COOKIE_RESULT } = require('../../src/constants')
@@ -54,12 +54,11 @@ lab.beforeEach(() => {
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').callsFake(async () => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(Application.prototype, 'save').value(() => {})
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(Application.prototype, 'save').value(() => undefined)
   sandbox.stub(NeedToConsult, 'get').callsFake(async () => mocks.needToConsult)
-  sandbox.stub(NeedToConsult.prototype, 'save').callsFake(async () => null)
+  sandbox.stub(NeedToConsult.prototype, 'save').callsFake(async () => undefined)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -105,10 +104,10 @@ lab.experiment('Consultees page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to get the application ID', async () => {
+      lab.test('redirects to error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
-        Application.getById = () => {
-          throw new Error('read failed')
+        RecoveryService.createApplicationContext = () => {
+          throw new Error('application recovery failed')
         }
 
         const res = await server.inject(request)

--- a/test/routes/preApplication.route.test.js
+++ b/test/routes/preApplication.route.test.js
@@ -10,7 +10,7 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
 const CookieService = require('../../src/services/cookie.service')
-const CharityDetail = require('../../src/models/charityDetail.model')
+const RecoveryService = require('../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../src/constants')
 
 let sandbox
@@ -33,9 +33,8 @@ lab.beforeEach(() => {
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => mocks.application)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(CharityDetail, 'get').value(() => mocks.charityDetail)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {

--- a/test/routes/saveAndReturn/emailEnter.route.test.js
+++ b/test/routes/saveAndReturn/emailEnter.route.test.js
@@ -4,15 +4,16 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../../helpers/mocks')
 const GeneralTestHelper = require('../generalTestHelper.test')
 
 const server = require('../../../server')
 
 const Application = require('../../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../../src/models/charityDetail.model')
 const SaveAndReturn = require('../../../src/models/taskList/saveAndReturn.task')
 const CookieService = require('../../../src/services/cookie.service')
 const LoggingService = require('../../../src/services/logging.service')
+const RecoveryService = require('../../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../../src/constants')
 
 const routePath = '/save-return/email'
@@ -20,25 +21,21 @@ const nextRoutePath = '/save-return/confirm'
 const emailSentPath = '/save-return/email-sent-task-check'
 const errorPath = '/errors/technical-problem'
 
-let fakeApplication
 let sandbox
+let mocks
 
 lab.beforeEach(() => {
-  fakeApplication = {
-    id: 'APPLICATION_ID',
-    saveAndReturnEmail: 'valid@email.com'
-  }
+  mocks = new Mocks()
 
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(Application.prototype, 'save').value(() => {})
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(Application.prototype, 'save').value(() => undefined)
   sandbox.stub(SaveAndReturn, 'isComplete').value(() => false)
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -75,7 +72,7 @@ lab.experiment('Save and return email page tests:', () => {
           'submit-button',
           'save-and-return-email-label'
         ])
-        Code.expect(doc.getElementById('save-and-return-email').getAttribute('value')).to.equal(fakeApplication.saveAndReturnEmail)
+        Code.expect(doc.getElementById('save-and-return-email').getAttribute('value')).to.equal(mocks.application.saveAndReturnEmail)
         Code.expect(doc.getElementById('got-email').getAttribute('value')).to.equal('false')
       })
     })
@@ -91,7 +88,7 @@ lab.experiment('Save and return email page tests:', () => {
         headers: {},
         payload: {
           'got-email': 'false',
-          'save-and-return-email': fakeApplication.saveAndReturnEmail
+          'save-and-return-email': mocks.application.saveAndReturnEmail
         }
       }
     })
@@ -117,10 +114,10 @@ lab.experiment('Save and return email page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to get the application ID', async () => {
+      lab.test('redirects to error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
-        Application.getById = () => {
-          throw new Error('read failed')
+        RecoveryService.createApplicationContext = () => {
+          throw new Error('application recovery failed')
         }
 
         const res = await server.inject(postRequest)

--- a/test/routes/siteGridReference.route.test.js
+++ b/test/routes/siteGridReference.route.test.js
@@ -4,70 +4,39 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const Code = require('code')
 const sinon = require('sinon')
+const Mocks = require('../helpers/mocks')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const server = require('../../server')
 const CookieService = require('../../src/services/cookie.service')
+const RecoveryService = require('../../src/services/recovery.service')
 const Application = require('../../src/persistence/entities/application.entity')
 const Location = require('../../src/persistence/entities/location.entity')
 const LocationDetail = require('../../src/persistence/entities/locationDetail.entity')
 const SiteNameAndLocation = require('../../src/models/taskList/siteNameAndLocation.task')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const { COOKIE_RESULT } = require('../../src/constants')
-
-let sandbox
 
 const routePath = '/site/grid-reference'
 const nextRoutePath = '/site/address/postcode'
 
-const getRequest = {
-  method: 'GET',
-  url: routePath,
-  headers: {}
-}
-let postRequest
-
-const fakeApplication = {
-  id: 'APPLICATION_ID',
-  applicationNumber: 'APPLICATION_NUMBER'
-}
-
-const fakeLocation = {
-  id: 'LOCATION_ID',
-  name: 'THE SITE NAME',
-  applicationId: 'APPLICATION_ID',
-  applicationLineId: 'APPLICATION_LINE_ID',
-  save: (authToken) => {}
-}
-
-const fakeLocationDetail = {
-  id: 'LOCATION_DETAIL_ID',
-  gridReference: 'AB1234567890',
-  locationId: 'LOCATION_ID',
-  save: (authToken) => {}
-}
+let sandbox
+let mocks
 
 lab.beforeEach(() => {
-  postRequest = {
-    method: 'POST',
-    url: routePath,
-    headers: {},
-    payload: {}
-  }
+  mocks = new Mocks()
 
   // Create a sinon sandbox to stub methods
   sandbox = sinon.createSandbox()
 
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(Application, 'getById').value(() => new Application(fakeApplication))
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(Location.prototype, 'save').value(() => {})
-  sandbox.stub(LocationDetail.prototype, 'save').value(() => {})
-  sandbox.stub(Location, 'getByApplicationId').value(() => fakeLocation)
-  sandbox.stub(LocationDetail, 'getByLocationId').value(() => fakeLocationDetail)
+  sandbox.stub(Location.prototype, 'save').value(() => undefined)
+  sandbox.stub(LocationDetail.prototype, 'save').value(() => undefined)
+  sandbox.stub(Location, 'getByApplicationId').value(() => mocks.location)
+  sandbox.stub(LocationDetail, 'getByLocationId').value(() => mocks.locationDetail)
   sandbox.stub(SiteNameAndLocation, 'updateCompleteness').value(() => {})
-  sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
+  sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
 })
 
 lab.afterEach(() => {
@@ -99,25 +68,20 @@ const checkPageElements = async (getRequest, expectedValue) => {
   Code.expect(element.nodeValue).to.equal('Continue')
 }
 
-const checkValidationError = async (expectedErrorMessage) => {
-  const doc = await GeneralTestHelper.getDoc(postRequest)
-
-  let element
-
-  // Panel summary error item
-  element = doc.getElementById('error-summary-list-item-0').firstChild
-  Code.expect(element.nodeValue).to.equal(expectedErrorMessage)
-
-  // Location grid reference field error
-  Code.expect(doc.getElementById('site-grid-reference').getAttribute('class')).contains('form-control-error')
-  element = doc.getElementById('site-grid-reference-error').firstChild.firstChild
-  Code.expect(element.nodeValue).to.equal(expectedErrorMessage)
-}
-
 lab.experiment('Site Grid Reference page tests:', () => {
+  let getRequest
+
   new GeneralTestHelper({ lab, routePath }).test()
 
   lab.experiment('GET:', () => {
+    lab.beforeEach(() => {
+      getRequest = {
+        method: 'GET',
+        url: routePath,
+        headers: {}
+      }
+    })
+
     lab.test(`GET ${routePath} returns the Site grid reference page correctly when the grid reference has not been entered yet`, async () => {
       LocationDetail.getByLocationId = () => {
         return undefined
@@ -132,12 +96,38 @@ lab.experiment('Site Grid Reference page tests:', () => {
     })
 
     lab.test(`GET ${routePath} returns the Site Grid Reference page correctly when there is an existing grid reference`, async () => {
-      await checkPageElements(getRequest, fakeLocationDetail.gridReference)
+      await checkPageElements(getRequest, mocks.locationDetail.gridReference)
     })
   })
 
   lab.experiment('POST:', () => {
+    let postRequest
+
+    const checkValidationError = async (expectedErrorMessage) => {
+      const doc = await GeneralTestHelper.getDoc(postRequest)
+
+      let element
+
+      // Panel summary error item
+      element = doc.getElementById('error-summary-list-item-0').firstChild
+      Code.expect(element.nodeValue).to.equal(expectedErrorMessage)
+
+      // Location grid reference field error
+      Code.expect(doc.getElementById('site-grid-reference').getAttribute('class')).contains('form-control-error')
+      element = doc.getElementById('site-grid-reference-error').firstChild.firstChild
+      Code.expect(element.nodeValue).to.equal(expectedErrorMessage)
+    }
+
     lab.experiment('Success:', () => {
+      lab.beforeEach(() => {
+        postRequest = {
+          method: 'POST',
+          url: routePath,
+          headers: {},
+          payload: {}
+        }
+      })
+
       lab.test(`POST ${routePath} shows an error message when the location grid reference is blank`, async () => {
         postRequest.payload['site-grid-reference'] = ''
         await checkValidationError('Enter a grid reference')
@@ -184,7 +174,7 @@ lab.experiment('Site Grid Reference page tests:', () => {
       })
 
       lab.test(`POST ${routePath} success (new grid reference) redirects to the Site Postcode route`, async () => {
-        postRequest.payload['site-grid-reference'] = fakeLocationDetail.gridReference
+        postRequest.payload['site-grid-reference'] = mocks.locationDetail.gridReference
 
         // Empty location details response
         LocationDetail.getByLocationId = () => {
@@ -197,7 +187,7 @@ lab.experiment('Site Grid Reference page tests:', () => {
       })
 
       lab.test(`POST ${routePath}  success (existing grid reference) redirects to the Site Postcode route`, async () => {
-        postRequest.payload['site-grid-reference'] = fakeLocationDetail.gridReference
+        postRequest.payload['site-grid-reference'] = mocks.locationDetail.gridReference
 
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -9,9 +9,9 @@ const fs = require('fs')
 const config = require('../../src/config/config')
 const Annotation = require('../../src/persistence/entities/annotation.entity')
 const Application = require('../../src/persistence/entities/application.entity')
-const CharityDetail = require('../../src/models/charityDetail.model')
 const CookieService = require('../../src/services/cookie.service')
 const LoggingService = require('../../src/services/logging.service')
+const RecoveryService = require('../../src/services/recovery.service')
 const UploadService = require('../../src/services/upload.service')
 const ClamWrapper = require('../../src/utilities/clamWrapper')
 const { COOKIE_RESULT } = require('../../src/constants')
@@ -69,13 +69,14 @@ module.exports = class UploadTestHelper {
     sandbox.stub(Annotation, 'getByApplicationIdSubjectAndFilename').value(() => mocks.annotation)
     sandbox.stub(Annotation.prototype, 'delete').value(() => undefined)
     sandbox.stub(Annotation.prototype, 'save').value(() => undefined)
-    sandbox.stub(Application, 'getById').value(() => mocks.application)
     sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
     sandbox.stub(Application, 'getById').value(() => mocks.application)
     sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-    sandbox.stub(CharityDetail, 'get').value(() => new CharityDetail({}))
     sandbox.stub(ClamWrapper, 'isInfected').value(() => Promise.resolve({ isInfected: false }))
     sandbox.stub(LoggingService, 'logError').value(() => {})
+    sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
+
+    return mocks
   }
 
   getSuccess (options = {}, additionalTests = []) {


### PR DESCRIPTION
Also fixes https://eaflood.atlassian.net/browse/WE-2047 as follows:
The issue was found in the recovery service when a controller (e.g. the check your emails controller).

Fixed by making sure that when the applicationID cookie is not found, the context should not attempt to contain the recovered application details.

All affected unit tests have been changed so they are using the standard mocking library including correctly mocking the recovery service.