### PR TITLE
The Contacts section of the application form contains out-of-date data

### DIFF
--- a/src/controllers/invoiceContact.controller.js
+++ b/src/controllers/invoiceContact.controller.js
@@ -30,7 +30,7 @@ module.exports = class InvoiceContactController extends BaseController {
 
   async doPost (request, h) {
     const context = await RecoveryService.createApplicationContext(h)
-    const { applicationId, application } = context
+    const { applicationId } = context
     const {
       'first-name': firstName,
       'last-name': lastName,
@@ -43,9 +43,6 @@ module.exports = class InvoiceContactController extends BaseController {
 
     Object.assign(contactDetail, { firstName, lastName, telephone, email })
     await contactDetail.save(context)
-
-    application.contactId = contactDetail.customerId
-    await application.save(context)
 
     return this.redirect({ h })
   }

--- a/test/routes/invoiceContact.route.test.js
+++ b/test/routes/invoiceContact.route.test.js
@@ -31,7 +31,6 @@ lab.beforeEach(() => {
   // Stub methods
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
-  sandbox.stub(Application.prototype, 'save').value(() => undefined)
   sandbox.stub(ContactDetail, 'get').value(() => mocks.contactDetail)
   sandbox.stub(ContactDetail.prototype, 'save').value(() => undefined)
   sandbox.stub(ContactDetails, 'updateCompleteness').value(() => undefined)


### PR DESCRIPTION
This fixes: https://eaflood.atlassian.net/browse/WE-2058
Prevent entering and updating the invoicing contact from overriding the primary contact associated with the application.

