### PR TITLE
We 2088 route directly to mcp permit types from guidance

### DIFF
--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -86,7 +86,7 @@ module.exports = class StartOrOpenSavedController extends BaseController {
           // set bespoke
           await DataStore.save(cookie, { BESPOKE })
           // set Medium combustion plant or specified generator
-          path = '/select/bespoke/mcp'
+          path = '/mcp-type'
           return this.redirect({ h, path, cookie })
       }
     } else {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1337,6 +1337,7 @@ const Routes = {
   },
   START_OR_OPEN_SAVED: {
     path: '/start/start-or-open-saved',
+    params: ['permitCategory?'],
     view: 'startOrOpenSaved',
     pageHeading: 'Apply for a standard rules environmental permit',
     controller: 'startOrOpenSaved',

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -8,6 +8,9 @@ const server = require('../../server')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const Application = require('../../src/persistence/entities/application.entity')
+const StandardRule = require('../../src/persistence/entities/standardRule.entity')
+const StandardRuleType = require('../../src/persistence/entities/standardRuleType.entity')
+
 const CookieService = require('../../src/services/cookie.service')
 const { COOKIE_RESULT } = require('../../src/constants')
 
@@ -50,6 +53,7 @@ lab.beforeEach(() => {
   sandbox.stub(CookieService, 'generateCookie').value(() => fakeCookie)
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
   sandbox.stub(Application.prototype, 'save').value(async () => undefined)
+  sandbox.stub(StandardRuleType, 'getCategories').value(() => [])
 })
 
 lab.afterEach(() => {

--- a/test/routes/startOrOpenSaved.route.test.js
+++ b/test/routes/startOrOpenSaved.route.test.js
@@ -41,6 +41,8 @@ const invalidParameterQuery = '?invalid-parameter=invalid-value'
 let getRequest
 let postRequest
 let mocks
+let cookeServiceSet
+let dataStoreSave
 
 const fakeCookie = {
   applicationId: 'my_application_id',
@@ -67,8 +69,10 @@ lab.beforeEach(() => {
   // Stub methods
   sandbox.stub(CookieService, 'generateCookie').value(() => fakeCookie)
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
-  sandbox.stub(CookieService, 'set').value(async () => true)
-  sandbox.stub(DataStore, 'save').value(async () => mocks.dataStore.id)
+  cookeServiceSet = sandbox.stub(CookieService, 'set')
+  cookeServiceSet.callsFake(async () => true)
+  dataStoreSave = sandbox.stub(DataStore, 'save')
+  dataStoreSave.callsFake(async () => mocks.dataStore.id)
   sandbox.stub(Application.prototype, 'save').value(async () => undefined)
   sandbox.stub(StandardRuleType, 'getCategories').value(() => [
     { categoryName: 'mcpd-mcp', id: 123 },
@@ -219,6 +223,8 @@ lab.experiment('Start or Open Saved page tests:', () => {
       const res = await server.inject(postRequest)
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal(shortcutPathMCPNext)
+      Code.expect(cookeServiceSet.calledOnce).to.be.true()
+      Code.expect(dataStoreSave.calledOnce).to.be.true()
     })
     lab.test('POST on Start or Open Saved page (with optional permitCategory == generators)', async () => {
       postRequest.payload = {
@@ -228,6 +234,8 @@ lab.experiment('Start or Open Saved page tests:', () => {
       const res = await server.inject(postRequest)
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal(shortcutPathGeneratorsNext)
+      Code.expect(cookeServiceSet.calledOnce).to.be.true()
+      Code.expect(dataStoreSave.calledOnce).to.be.true()
     })
     lab.test('POST on Start or Open Saved page (with optional permitCategory == mcp-bespoke)', async () => {
       postRequest.payload = {
@@ -237,6 +245,8 @@ lab.experiment('Start or Open Saved page tests:', () => {
       const res = await server.inject(postRequest)
       Code.expect(res.statusCode).to.equal(302)
       Code.expect(res.headers['location']).to.equal(shortcutPathMCPBespokeNext)
+      Code.expect(cookeServiceSet.calledOnce).to.be.false()
+      Code.expect(dataStoreSave.calledOnce).to.be.true()
     })
   })
 })


### PR DESCRIPTION
Added optional parameter to `/start/start-or-open-saved` that allows the user to jump/pre-fill steps:

- `/start/start-or-open-saved/mcp` -> `/permit/select`
- `/start/start-or-open-saved/generators` -> `/permit/select`
- `/start/start-or-open-saved/mcp-bespoke` -> `/mcp-type`

Depending on 
