### PR TITLE
Refactor AQMA to pull in constants from dynamics.js

### DIFF
--- a/src/dynamics.js
+++ b/src/dynamics.js
@@ -56,6 +56,20 @@ const Dynamics = {
     }
   },
   ApplicationQuestions: {
+    AQMA: {
+      IS_IN_AQMA: {
+        questionCode: 'aqma-is-in-aqma'
+      },
+      AQMA_NAME: {
+        questionCode: 'aqma-name'
+      },
+      NO2_LEVEL: {
+        questionCode: 'aqma-nitrogen-dioxide-level'
+      },
+      AUTH_NAME: {
+        questionCode: 'aqma-local-authority-name'
+      }
+    },
     CHARITY_DETAILS: {
       NAME: {
         questionCode: 'general-charity-name'

--- a/src/models/airQualityManagementArea.model.js
+++ b/src/models/airQualityManagementArea.model.js
@@ -38,7 +38,6 @@ module.exports = class AirQualityManagementArea {
     }]
 
     applicationAnswers.forEach(async (item) => {
-      console.log(item)
       const applicationAnswer = new ApplicationAnswer(item)
       await applicationAnswer.save(context)
     })

--- a/src/models/airQualityManagementArea.model.js
+++ b/src/models/airQualityManagementArea.model.js
@@ -1,12 +1,15 @@
 'use strict'
 
 const ApplicationAnswer = require('../persistence/entities/applicationAnswer.entity')
-
-const IS_IN_AQMA = 'aqma-is-in-aqma'
-const AQMA_NAME = 'aqma-name'
-const NO2_LEVEL = 'aqma-nitrogen-dioxide-level'
-const AUTH_NAME = 'aqma-local-authority-name'
-const answerIds = [IS_IN_AQMA, AQMA_NAME, NO2_LEVEL, AUTH_NAME]
+const { ApplicationQuestions } = require('../dynamics')
+const { AQMA } = ApplicationQuestions
+const { IS_IN_AQMA, AQMA_NAME, NO2_LEVEL, AUTH_NAME } = AQMA
+const answerIds = [
+  IS_IN_AQMA.questionCode,
+  AQMA_NAME.questionCode,
+  NO2_LEVEL.questionCode,
+  AUTH_NAME.questionCode
+]
 const YES = 'yes'
 const NO = 'no'
 
@@ -21,24 +24,21 @@ module.exports = class AirQualityManagementArea {
     let applicationAnswers
 
     applicationAnswers = [{
-      questionCode: IS_IN_AQMA,
+      questionCode: IS_IN_AQMA.questionCode,
       answerText: this.isInAqma ? YES : NO
+    }, {
+      questionCode: AQMA_NAME.questionCode,
+      answerText: this.name
+    }, {
+      questionCode: NO2_LEVEL.questionCode,
+      answerText: this.nitrogenDioxideLevel
+    }, {
+      questionCode: AUTH_NAME.questionCode,
+      answerText: this.localAuthorityName
     }]
 
-    if (this.isInAqma) {
-      applicationAnswers.push({
-        questionCode: AQMA_NAME,
-        answerText: this.name
-      }, {
-        questionCode: NO2_LEVEL,
-        answerText: this.nitrogenDioxideLevel
-      }, {
-        questionCode: AUTH_NAME,
-        answerText: this.localAuthorityName
-      })
-    }
-
     applicationAnswers.forEach(async (item) => {
+      console.log(item)
       const applicationAnswer = new ApplicationAnswer(item)
       await applicationAnswer.save(context)
     })
@@ -48,10 +48,10 @@ module.exports = class AirQualityManagementArea {
 
   static async get (context) {
     const applicationAnswers = await ApplicationAnswer.listByMultipleQuestionCodes(context, answerIds)
-    const isInAqmaAnswer = applicationAnswers.find(({ questionCode }) => questionCode === IS_IN_AQMA)
-    const nameAnswer = applicationAnswers.find(({ questionCode }) => questionCode === AQMA_NAME)
-    const nitrogenDioxideLevelAnswer = applicationAnswers.find(({ questionCode }) => questionCode === NO2_LEVEL)
-    const localAuthorityNameAnswer = applicationAnswers.find(({ questionCode }) => questionCode === AUTH_NAME)
+    const isInAqmaAnswer = applicationAnswers.find(({ questionCode }) => questionCode === IS_IN_AQMA.questionCode)
+    const nameAnswer = applicationAnswers.find(({ questionCode }) => questionCode === AQMA_NAME.questionCode)
+    const nitrogenDioxideLevelAnswer = applicationAnswers.find(({ questionCode }) => questionCode === NO2_LEVEL.questionCode)
+    const localAuthorityNameAnswer = applicationAnswers.find(({ questionCode }) => questionCode === AUTH_NAME.questionCode)
 
     const aqma = {
       isInAqma: isInAqmaAnswer && isInAqmaAnswer.answerText === YES,

--- a/test/models/airQualityManagementArea.model.test.js
+++ b/test/models/airQualityManagementArea.model.test.js
@@ -44,7 +44,9 @@ lab.experiment('AirQualityManagementArea test:', () => {
     lab.test('AQMA is set as no', async () => {
       mocks.applicationAnswers[0].questionCode = 'aqma-is-in-aqma'
       mocks.applicationAnswers[0].answerText = NO
+
       const airQualityManagementArea = await AirQualityManagementArea.get(context)
+
       Code.expect(airQualityManagementArea.isInAqma).to.be.false()
       Code.expect(airQualityManagementArea.name).to.not.exist()
       Code.expect(airQualityManagementArea.nitrogenDioxideLevel).to.not.exist()
@@ -75,7 +77,7 @@ lab.experiment('AirQualityManagementArea test:', () => {
       const airQualityManagementArea = new AirQualityManagementArea()
       airQualityManagementArea.isInAqma = false
       await airQualityManagementArea.save(context)
-      Code.expect(saveSpy.callCount).to.equal(1)
+      Code.expect(saveSpy.callCount).to.equal(4)
     })
 
     lab.test('with AQMA set to Yes', async () => {


### PR DESCRIPTION
AQMA question codes moved to dynamics.js

Saving now overwrites AQMA name, background level and local authority name regardless of whether AQMA is set as 'yes' or 'no'. This ensures that the fields are emptied in Dynamics if they change from 'yes' to 'no'.