### PR TITLE
Save permit category to allow payment config prefix to be calculated correctly

### DIFF
--- a/src/controllers/payment/cardPayment.controller.js
+++ b/src/controllers/payment/cardPayment.controller.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const Dynamics = require('../../dynamics')
-const { MCP_PREFIX, WASTE_PREFIX } = require('../../constants').PAYMENT_CONFIGURATION_PREFIX
-const { MCP } = Dynamics.FACILITY_TYPES
 const { CARD_PROBLEM } = require('../../routes')
 const BaseController = require('../base.controller')
 const Payment = require('../../persistence/entities/payment.entity')
@@ -12,9 +10,7 @@ const RecoveryService = require('../../services/recovery.service')
 module.exports = class CardPaymentController extends BaseController {
   async doGet (request, h) {
     const context = await RecoveryService.createApplicationContext(h, { applicationLine: true, standardRule: true })
-    const { application, applicationLine, standardRule, slug, taskDeterminants } = context
-    const { facilityType } = taskDeterminants
-    const paymentConfigurationPrefix = facilityType === MCP ? MCP_PREFIX : WASTE_PREFIX
+    const { application, applicationLine, standardRule, slug } = context
 
     let { returnUrl } = request.query
 
@@ -31,7 +27,7 @@ module.exports = class CardPaymentController extends BaseController {
     // Note - Gov Pay needs an https address to redirect to, otherwise it throws a runtime error
     LoggingService.logDebug(`Making Gov.UK Pay card payment for Application "${this.applicationNumber}. Will redirect back to: ${returnUrl}`)
 
-    const result = await payment.makeCardPayment(context, payment.description, returnUrl, paymentConfigurationPrefix)
+    const result = await payment.makeCardPayment(context, payment.description, returnUrl)
 
     const paymentStatus = result ? result.PaymentStatus : 'error'
 

--- a/src/controllers/payment/paymentResult.controller.js
+++ b/src/controllers/payment/paymentResult.controller.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const Dynamics = require('../../dynamics')
-const { MCP_PREFIX, WASTE_PREFIX } = require('../../constants').PAYMENT_CONFIGURATION_PREFIX
-const { MCP } = Dynamics.FACILITY_TYPES
 const { APPLICATION_RECEIVED, CARD_PROBLEM } = require('../../routes')
 const BaseController = require('../base.controller')
 const RecoveryService = require('../../services/recovery.service')
@@ -10,11 +7,9 @@ const RecoveryService = require('../../services/recovery.service')
 module.exports = class PaymentResultController extends BaseController {
   async doGet (request, h) {
     const context = await RecoveryService.createApplicationContext(h, { applicationReturn: true, cardPayment: true })
-    const { cardPayment, slug, taskDeterminants } = context
-    const { facilityType } = taskDeterminants
-    const paymentConfigurationPrefix = facilityType === MCP ? MCP_PREFIX : WASTE_PREFIX
+    const { cardPayment, slug } = context
 
-    const paymentStatus = await cardPayment.getCardPaymentResult(context, paymentConfigurationPrefix)
+    const paymentStatus = await cardPayment.getCardPaymentResult(context)
     let path = `${APPLICATION_RECEIVED.path}/${slug}`
 
     // Look at the result of the payment and redirect off to the appropriate result screen

--- a/src/controllers/permitCategory.controller.js
+++ b/src/controllers/permitCategory.controller.js
@@ -42,10 +42,13 @@ module.exports = class PermitCategoryController extends BaseController {
   }
 
   async doPost (request, h) {
+    const { taskDeterminants } = await RecoveryService.createApplicationContext(h)
     CookieService.remove(request, Constants.COOKIE_KEY.STANDARD_RULE_ID)
     // Set the standard rule type ID in the cookie
     const standardRuleTypeId = request.payload['chosen-category']
     CookieService.set(request, Constants.COOKIE_KEY.STANDARD_RULE_TYPE_ID, standardRuleTypeId)
+
+    await taskDeterminants.save({ permitCategory: standardRuleTypeId })
 
     if (PermitCategoryController.isOfflineCategory(standardRuleTypeId)) {
       return this.redirect({ h, route: Routes.APPLY_OFFLINE })

--- a/src/controllers/startOrOpenSaved.controller.js
+++ b/src/controllers/startOrOpenSaved.controller.js
@@ -102,7 +102,7 @@ module.exports = class StartOrOpenSavedController extends BaseController {
         route = Routes.PERMIT_CATEGORY
       }
 
-      const taskDeterminants = new TaskDeterminants({ context: cookie, permitType, facilityType })
+      const taskDeterminants = new TaskDeterminants({ context: cookie, permitType, permitCategory: category, facilityType })
       await taskDeterminants.save()
     }
 

--- a/test/models/taskDeterminants.test.js
+++ b/test/models/taskDeterminants.test.js
@@ -8,6 +8,7 @@ const Mocks = require('../helpers/mocks')
 
 const ApplicationAnswer = require('../../src/persistence/entities/applicationAnswer.entity')
 const Item = require('../../src/persistence/entities/item.entity')
+const StandardRuleType = require('../../src/persistence/entities/standardRuleType.entity')
 const DataStore = require('../../src/models/dataStore.model')
 const TaskDeterminants = require('../../src/models/taskDeterminants.model')
 const { STATIONARY_SG, MOBILE_SG } = require('../../src/dynamics').MCP_TYPES
@@ -50,6 +51,7 @@ lab.beforeEach(() => {
   applicationAnswerSaveStub = sandbox.stub(ApplicationAnswer.prototype, 'save').callsFake(() => undefined)
   sandbox.stub(Item, 'listWasteActivities').callsFake(() => mocks.wasteActivities)
   sandbox.stub(Item, 'listWasteAssessments').callsFake(() => mocks.wasteAssessments)
+  sandbox.stub(StandardRuleType, 'getCategories').value(() => [])
   sandbox.stub(DataStore, 'get').callsFake(() => mocks.dataStore)
   dataSourceSaveStub = sandbox.stub(DataStore.prototype, 'save').callsFake(() => undefined)
 })

--- a/test/persistence/entities/payment.entity.test.js
+++ b/test/persistence/entities/payment.entity.test.js
@@ -52,7 +52,10 @@ lab.beforeEach(() => {
   context = {
     authToken: 'AUTH_TOKEN',
     applicationId: fakePaymentData.applicationId,
-    applicationLineId: fakePaymentData.applicationLineId
+    applicationLineId: fakePaymentData.applicationLineId,
+    taskDeterminants: {
+      facilityType: {}
+    }
   }
 
   dynamicsSearchStub = DynamicsDalService.prototype.search
@@ -150,7 +153,7 @@ lab.experiment('Payment Entity tests:', () => {
       Code.expect(actionDataObject).to.equal(expectedActionDataObject)
       return { Status: true }
     })
-    Code.expect(await testPayment.getCardPaymentResult(context, CONFIGURATION_PREFIX)).to.equal(true)
+    Code.expect(await testPayment.getCardPaymentResult(context)).to.equal(true)
   })
 
   lab.test(`makeCardPayment() method is successful`, async () => {
@@ -174,7 +177,7 @@ lab.experiment('Payment Entity tests:', () => {
       Code.expect(actionDataObject).to.equal(expectedActionDataObject)
       return actionResult
     })
-    Code.expect(await testPayment.makeCardPayment(context, description, returnUrl, CONFIGURATION_PREFIX)).to.equal(actionResult)
+    Code.expect(await testPayment.makeCardPayment(context, description, returnUrl)).to.equal(actionResult)
   })
 
   lab.test('save() method saves a new Payment object', async () => {

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -10,6 +10,7 @@ const GeneralTestHelper = require('./generalTestHelper.test')
 const server = require('../../server')
 const Application = require('../../src/persistence/entities/application.entity')
 const StandardRuleType = require('../../src/persistence/entities/standardRuleType.entity')
+const TaskDeterminants = require('../../src/models/taskDeterminants.model')
 const CookieService = require('../../src/services/cookie.service')
 const LoggingService = require('../../src/services/logging.service')
 const RecoveryService = require('../../src/services/recovery.service')
@@ -53,6 +54,7 @@ lab.beforeEach(() => {
   // Stub methods
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(StandardRuleType, 'getCategories').value(() => [])
+  sandbox.stub(TaskDeterminants.prototype, 'save').value(() => undefined)
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
   sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
   // Todo: Remove useMcpFeature stub when MCP is live


### PR DESCRIPTION
Implements https://eaflood.atlassian.net/browse/WE-1999 for standard rules permits