### PR TITLE
Make sure permit holder details are completely filled in before setting as complete

### DIFF
--- a/src/controllers/declaration/base/declarations.controller.js
+++ b/src/controllers/declaration/base/declarations.controller.js
@@ -59,6 +59,10 @@ module.exports = class DeclarationsController extends BaseController {
     Object.assign(application, this.getRequestData(request))
     await application.save(context)
 
+    if (this.updateCompleteness) {
+      await this.updateCompleteness(context)
+    }
+
     return this.redirect({ h })
   }
 

--- a/src/controllers/declaration/company/bankruptcy.controller.js
+++ b/src/controllers/declaration/company/bankruptcy.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const DeclarationsController = require('../base/declarations.controller')
+const PermitHolderDetails = require('../../../models/taskList/permitHolderDetails.task')
 
 module.exports = class BankruptcyController extends DeclarationsController {
   getFormData (data) {
@@ -20,5 +21,9 @@ module.exports = class BankruptcyController extends DeclarationsController {
       declarationDetailsHint: 'Include the dates for the proceedings',
       declarationNotice: 'We may contact a credit reference agency for a report about your business’s finances.'
     }
+  }
+
+  async updateCompleteness (context) {
+    return PermitHolderDetails.updateCompleteness(context)
   }
 }

--- a/src/controllers/permitHolder/base/memberList.controller.js
+++ b/src/controllers/permitHolder/base/memberList.controller.js
@@ -4,6 +4,7 @@ const BaseController = require('../../base.controller')
 const RecoveryService = require('../../../services/recovery.service')
 const CryptoService = require('../../../services/crypto.service')
 const ContactDetail = require('../../../models/contactDetail.model')
+const PermitHolderDetails = require('../../../models/taskList/permitHolderDetails.task')
 const Utilities = require('../../../utilities/utilities')
 const Routes = require('../../../routes')
 
@@ -72,6 +73,9 @@ module.exports = class MemberListController extends BaseController {
     const context = await RecoveryService.createApplicationContext(h)
     const list = await ContactDetail.list(context, { type: this.task.contactType })
     if (list.length < this.route.list.min) {
+      // Make sure the permitHolderDetails task is set to incomplete as not enough members have been added
+      await PermitHolderDetails.clearCompleteness(context)
+
       // In this case the submit button would have been labeled "Add another Member"
       const memberId = await this.createMember(context)
       return this.redirect({ h, path: `${Routes[holderRoute].path}/${memberId}` })

--- a/test/models/taskList/permitHolderDetails.task.test.js
+++ b/test/models/taskList/permitHolderDetails.task.test.js
@@ -12,11 +12,6 @@ const CharityDetail = require('../../../src/models/charityDetail.model')
 const ContactDetail = require('../../../src/models/contactDetail.model')
 const PermitHolderDetails = require('../../../src/models/taskList/permitHolderDetails.task')
 
-const {
-  INDIVIDUAL,
-  LIMITED_COMPANY
-} = require('../../../src/dynamics').PERMIT_HOLDER_TYPES
-
 let request
 let sandbox
 let mocks
@@ -73,47 +68,5 @@ lab.experiment('Model persistence methods:', () => {
     await PermitHolderDetails.saveManualAddress(request, addressDto)
     Code.expect(spy.callCount).to.equal(1)
     spy.restore()
-  })
-})
-
-lab.experiment('Task List: Permit Holder Details Model tests:', () => {
-  lab.test('isComplete() method correctly returns TRUE when the task list item is complete for a company', async () => {
-    mocks.context.permitHolderType = LIMITED_COMPANY
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(true)
-  })
-
-  lab.test('isComplete() method correctly returns TRUE when the task list item is complete for an individual', async () => {
-    mocks.context.permitHolderType = INDIVIDUAL
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(true)
-  })
-
-  lab.test('isComplete() method correctly returns FALSE when the task list item is not complete for a company', async () => {
-    mocks.context.permitHolderType = LIMITED_COMPANY
-    delete mocks.account.accountName
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(false)
-  })
-
-  lab.test('isComplete() method correctly returns FALSE when the task list item is not complete for an individual', async () => {
-    mocks.context.permitHolderType = INDIVIDUAL
-    delete mocks.contactDetail.firstName
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(false)
-  })
-
-  lab.test('isComplete() method correctly returns FALSE when relevant offences have not been completed', async () => {
-    mocks.context.permitHolderType = LIMITED_COMPANY
-    delete mocks.application.relevantOffences
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(false)
-  })
-
-  lab.test('isComplete() method correctly returns FALSE when bankruptcy details have not been completed', async () => {
-    mocks.context.permitHolderType = LIMITED_COMPANY
-    delete mocks.application.bankruptcy
-    const result = await PermitHolderDetails.isComplete(mocks.context)
-    Code.expect(result).to.equal(false)
   })
 })

--- a/test/routes/companyNumber.route.test.js
+++ b/test/routes/companyNumber.route.test.js
@@ -183,6 +183,10 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
         })
 
         lab.experiment('failure', () => {
+          lab.beforeEach(() => {
+            delete mocks.account.companyNumber
+          })
+
           lab.test('redirects to error screen when failing to get the account by the company number', async () => {
             const spy = sandbox.spy(LoggingService, 'logError')
             Account.getByCompanyNumber = () => {

--- a/test/routes/permitHolder/memberList.route.test.js
+++ b/test/routes/permitHolder/memberList.route.test.js
@@ -14,6 +14,7 @@ const RecoveryService = require('../../../src/services/recovery.service')
 const CryptoService = require('../../../src/services/crypto.service')
 const ContactDetail = require('../../../src/models/contactDetail.model')
 const Application = require('../../../src/persistence/entities/application.entity')
+const PermitHolderDetails = require('../../../src/models/taskList/permitHolderDetails.task')
 const { capitalizeFirstLetter } = require('../../../src/utilities/utilities')
 const { COOKIE_RESULT } = require('../../../src/constants')
 
@@ -75,6 +76,7 @@ Object.entries(routes).forEach(([member, { includesJobTitle, heading, routePath,
       sandbox.stub(ContactDetail, 'list').value(() => mocks.contactDetailList)
       sandbox.stub(ContactDetail.prototype, 'save').value(() => mocks.contactDetail.id)
       sandbox.stub(ContactDetail.prototype, 'delete').value(() => true)
+      sandbox.stub(PermitHolderDetails, 'clearCompleteness').value(() => true)
     })
 
     lab.afterEach(() => {

--- a/test/routes/permitHolder/permitHolderType.route.test.js
+++ b/test/routes/permitHolder/permitHolderType.route.test.js
@@ -14,6 +14,7 @@ const CookieService = require('../../../src/services/cookie.service')
 const LoggingService = require('../../../src/services/logging.service')
 const RecoveryService = require('../../../src/services/recovery.service')
 const PermitHolderTypeController = require('../../../src/controllers/permitHolder/permitHolderType.controller')
+const PermitHolderDetails = require('../../../src/models/taskList/permitHolderDetails.task')
 const { COOKIE_RESULT } = require('../../../src/constants')
 const { MCP_TYPES } = require('../../../src/dynamics')
 
@@ -35,6 +36,7 @@ lab.beforeEach(() => {
   sandbox.stub(CharityDetail.prototype, 'delete').value(() => undefined)
   sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
   sandbox.stub(CookieService, 'validateCookie').value(() => COOKIE_RESULT.VALID_COOKIE)
+  sandbox.stub(PermitHolderDetails, 'clearCompleteness').value(() => true)
 })
 
 lab.afterEach(() => {
@@ -123,8 +125,10 @@ lab.experiment('Permit holder type: Who will be the permit holder? page tests:',
 
   lab.experiment(`POST ${routePath}`, () => {
     let postRequest
+    let prevPermitHolderType
 
     lab.beforeEach(() => {
+      prevPermitHolderType = Object.assign({}, mocks.permitHolderType, { id: 'prev-permit-holder-type' })
       postRequest = {
         method: 'POST',
         url: routePath,
@@ -144,7 +148,8 @@ lab.experiment('Permit holder type: Who will be the permit holder? page tests:',
       }
 
       lab.beforeEach(() => {
-        sandbox.stub(PermitHolderTypeController, 'getHolderTypes').value(() => [mocks.permitHolderType])
+        mocks.recovery.permitHolderType = prevPermitHolderType
+        sandbox.stub(PermitHolderTypeController, 'getHolderTypes').value(() => [mocks.permitHolderType, prevPermitHolderType])
       })
 
       lab.test('when holder type can apply online and is an individual', async () => {


### PR DESCRIPTION
Also Fixes company number issue and Directors' date of birth issues.
Implements fixes for https://eaflood.atlassian.net/browse/WE-2492 but only on the permit holder details task.
Note that permit holder details completeness calculations will now be derived from the base task class and will not be based on the data entered, only that the user has successfully completed all the pages within the task. 