### PR TITLE
We 1770 back to select standard or bespoke bug

### DIFF
--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -25,10 +25,10 @@ module.exports = class TaskListController extends BaseController {
     }
 
     pageContext.taskList = await TaskList.buildTaskList(context)
+    pageContext.permitCategoryRoute = Routes.BESPOKE_OR_STANDARD_RULES.path
 
     if (TaskList.isStandardRules) {
       pageContext.standardRule = await StandardRule.getByApplicationLineId(context, context.applicationLineId)
-      pageContext.permitCategoryRoute = Routes.PERMIT_CATEGORY.path
     } else {
       const { airDispersionModellingRequired } = context.taskDeterminants
 
@@ -42,8 +42,6 @@ module.exports = class TaskListController extends BaseController {
         description: 'Total',
         cost: context.application.lineItemsTotalAmount
       })
-
-      pageContext.permitCategoryRoute = Routes.BESPOKE_OR_STANDARD_RULES.path
     }
 
     pageContext.formValues = request.payload

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -254,6 +254,10 @@ lab.experiment('Task List page tests:', () => {
     checkElement(doc.getElementById('task-list-heading-visually-hidden'))
     checkElement(doc.getElementById('activity-name'), `Medium combustion plant site - requires dispersion modelling`)
     checkElement(doc.getElementById('select-a-different-permit'))
+    code.expect(doc.getElementById('select-a-different-permit')
+      .getAttribute('href'))
+      .to
+      .equal('/bespoke-or-standard-rules')
   })
 
   lab.test('Task list page contains the correct heading and Bespoke info when dispersion modelling is not required', async () => {
@@ -268,6 +272,10 @@ lab.experiment('Task List page tests:', () => {
     checkElement(doc.getElementById('task-list-heading-visually-hidden'))
     checkElement(doc.getElementById('activity-name'), `Medium combustion plant site - does not require dispersion modelling`)
     checkElement(doc.getElementById('select-a-different-permit'))
+    code.expect(doc.getElementById('select-a-different-permit')
+      .getAttribute('href'))
+      .to
+      .equal('/bespoke-or-standard-rules')
   })
 
   lab.test(`GET ${routePath} redirects to the Already Submitted route ${alreadySubmittedRoutePath} if the application has been submitted`, async () => {

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -254,7 +254,7 @@ lab.experiment('Task List page tests:', () => {
     checkElement(doc.getElementById('task-list-heading-visually-hidden'))
     checkElement(doc.getElementById('activity-name'), `Medium combustion plant site - requires dispersion modelling`)
     checkElement(doc.getElementById('select-a-different-permit'))
-    code.expect(doc.getElementById('select-a-different-permit')
+    Code.expect(doc.getElementById('select-a-different-permit')
       .getAttribute('href'))
       .to
       .equal('/bespoke-or-standard-rules')
@@ -272,7 +272,7 @@ lab.experiment('Task List page tests:', () => {
     checkElement(doc.getElementById('task-list-heading-visually-hidden'))
     checkElement(doc.getElementById('activity-name'), `Medium combustion plant site - does not require dispersion modelling`)
     checkElement(doc.getElementById('select-a-different-permit'))
-    code.expect(doc.getElementById('select-a-different-permit')
+    Code.expect(doc.getElementById('select-a-different-permit')
       .getAttribute('href'))
       .to
       .equal('/bespoke-or-standard-rules')


### PR DESCRIPTION
Updated url for "Select a different permit" to be `/bespoke-or-standard-rules` and update tests