### PR TITLE
WE-2855: Provide link to guidance

### DIFF
--- a/src/views/upload/mcp/airDispersionModellingReport.html
+++ b/src/views/upload/mcp/airDispersionModellingReport.html
@@ -19,7 +19,7 @@
         <li>A completed specified generator Tranche B screening tool.</li>
       </ol>
 
-      <p>See the guidance on <a id="guidence-link" href="" target="_blank" rel="noopener noreferrer">how to do detailed air dispersion modelling for emissions from specified generators (opens new tab)</a> and the information you must include in your <a href="">report</a>.</p>
+      <p>See the guidance on <a id="guidance-link" href="https://www.gov.uk/guidance/specified-generators-dispersion-modelling-assessment" target="_blank" rel="noopener noreferrer">how to do detailed air dispersion modelling for emissions from specified generators (opens new tab)</a> and the information you must include in your report.</p>
 
       {{#if annotations.length}}
 

--- a/src/views/upload/mcp/bestAvailableTechniquesAssessment.html
+++ b/src/views/upload/mcp/bestAvailableTechniquesAssessment.html
@@ -25,7 +25,7 @@
       </p>
 
       <p>
-        <a id="guidence-link" href="https://www.gov.uk/guidance/best-available-techniques-environmental-permits" target="_blank" rel="noopener noreferrer">Best available techniques: environmental permits guidance (opens new tab)</a>
+        <a id="guidance-link" href="https://www.gov.uk/guidance/best-available-techniques-environmental-permits" target="_blank" rel="noopener noreferrer">Best available techniques: environmental permits guidance (opens new tab)</a>
       </p>
 
       {{#if annotations.length}}

--- a/src/views/upload/mcp/energyEfficiencyReport.html
+++ b/src/views/upload/mcp/energyEfficiencyReport.html
@@ -11,7 +11,7 @@
 
       {{> common/pageHeading pageHeading }}
 
-      <p>Upload a report which shows how your MCP meets <a id="guidence-link" href="https://www.gov.uk/guidance/energy-efficiency-standards-for-industrial-plants-to-get-environmental-permits#additional-requirements-for-new-and-substantially-refurbished-combustion-plants" target="_blank" rel="noopener noreferrer">energy efficiency standards for industrial plants</a>.</p>
+      <p>Upload a report which shows how your MCP meets <a id="guidance-link" href="https://www.gov.uk/guidance/energy-efficiency-standards-for-industrial-plants-to-get-environmental-permits#additional-requirements-for-new-and-substantially-refurbished-combustion-plants" target="_blank" rel="noopener noreferrer">energy efficiency standards for industrial plants</a>.</p>
       <p>Your report should show how your MCP meets the requirements of Schedule 24 of the Environmental Permitting Regulations which implement the relevant requirements of the Energy Efficiency Directive (2012/27/EU).</p>
       <p>If you believe that Schedule 24 does not apply to your case, you should upload a document explaining your reasons.</p>
 

--- a/src/views/wasteRecoveryPlanApproval.html
+++ b/src/views/wasteRecoveryPlanApproval.html
@@ -13,7 +13,7 @@
 
       <p id="recovery-plan-paragraph-1">Your waste recovery plan must prove that you will be recovering waste and not disposing of waste. We will assess your plan and tell you if we agree that what you are planning is waste recovery.</p>
 
-      <p id="recovery-plan-paragraph-2">Check the <a id="recovery-plan-guidence-link" href="https://www.gov.uk/guidance/waste-recovery-plans-and-permits#waste-recovery-plan" target="_blank">waste recovery plan guidance (opens new tab)</a> to make sure that your plan includes all the information we need.</p>
+      <p id="recovery-plan-paragraph-2">Check the <a id="recovery-plan-guidance-link" href="https://www.gov.uk/guidance/waste-recovery-plans-and-permits#waste-recovery-plan" target="_blank">waste recovery plan guidance (opens new tab)</a> to make sure that your plan includes all the information we need.</p>
 
       <form method="POST" action="{{formAction}}" novalidate="novalidate">
         {{> common/csrfToken token=DefraCsrfToken}}

--- a/test/routes/wasteRecoveryPlanApproval.route.test.js
+++ b/test/routes/wasteRecoveryPlanApproval.route.test.js
@@ -64,7 +64,7 @@ lab.experiment('Waste Recovery Plan Approval page tests:', () => {
           'defra-csrf-token',
           'recovery-plan-paragraph-1',
           'recovery-plan-paragraph-2',
-          'recovery-plan-guidence-link',
+          'recovery-plan-guidance-link',
           'selection-hint-text',
           'selection',
           'selection-yes-input',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-2855

Added link. Noticed 'guidence' was misspelled in the id tag on this page and some others so corrected the typos.