### PR TITLE
Remove MCP bespoke feature flag. Amend apply-offline heading.

### DIFF
--- a/src/config/featureConfig.js
+++ b/src/config/featureConfig.js
@@ -3,7 +3,6 @@ const config = {}
 // Add feature switches here such as the example hasLLPFeature below
 // config.hasLLPFeature = process.env.LLP_FEATURE === 'TRUE' || false
 config.hasBespokeFeature = process.env.BESPOKE_FEATURE === 'TRUE' || false
-config.hasMcpBespokeFeature = process.env.MCP_BESPOKE_FEATURE === 'TRUE' || false
 config.hasDisplayRecoveryLinkFeature = process.env.DISPLAY_RECOVERY_LINK_FEATURE === 'TRUE' || false
 config.hasMcpFeature = process.env.MCP_FEATURE === 'TRUE' || false
 

--- a/src/controllers/bespokeOrStandardRules.controller.js
+++ b/src/controllers/bespokeOrStandardRules.controller.js
@@ -1,17 +1,11 @@
 'use strict'
 
 const BaseController = require('./base.controller')
-const featureConfig = require('../config/featureConfig')
 const RecoveryService = require('../services/recovery.service')
 const { BESPOKE: { id: BESPOKE }, STANDARD_RULES: { id: STANDARD_RULES } } = require('../constants').PermitTypes
 
 module.exports = class BespokeOrStandardRulesController extends BaseController {
   async doGet (request, h, errors) {
-    // Todo: Remove this redirect when Bespoke is live
-    if (!featureConfig.hasBespokeFeature && !featureConfig.hasMcpBespokeFeature) {
-      return this.redirect({ h })
-    }
-
     const pageContext = this.createPageContext(h, errors)
 
     pageContext.formValues = request.payload || request.query

--- a/src/routes.js
+++ b/src/routes.js
@@ -918,7 +918,7 @@ const Routes = {
   FACILITY_APPLY_OFFLINE: {
     path: '/facility-type/apply-offline',
     view: 'bespokeApplyOffline',
-    pageHeading: 'Apply for a bespoke permit for an installation, landfill, mine or water discharge',
+    pageHeading: 'Apply for a bespoke permit for an installation, landfill, mine, waste or water discharge',
     pageDescription: 'You cannot apply online yet for that type of facility. We hope to add them soon.',
     controller: 'bespokeApplyOffline',
     nextRoute: 'FACILITY_TYPE',


### PR DESCRIPTION
Flag to enable/disable MCP bespoke is to be removed ahead of MCP bespoke going live as it's no longer required.