### PR TITLE
WE-2773: Amend Change links on 'Check your answers'

### DIFF
--- a/src/models/checkList/mcpBespokeType.check.js
+++ b/src/models/checkList/mcpBespokeType.check.js
@@ -1,6 +1,6 @@
 const BaseCheck = require('./base.check')
 
-const { path } = require('../../routes').MCP_TYPE
+const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
 
 module.exports = class McpBespokeTypeCheck extends BaseCheck {
   get prefix () {

--- a/src/models/checkList/permit.check.js
+++ b/src/models/checkList/permit.check.js
@@ -1,6 +1,6 @@
 const BaseCheck = require('./base.check')
 
-const { path } = require('../../routes').PERMIT_CATEGORY
+const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
 
 module.exports = class PermitCheck extends BaseCheck {
   get prefix () {

--- a/test/models/checkList/mcpBespokeType.check.test.js
+++ b/test/models/checkList/mcpBespokeType.check.test.js
@@ -44,7 +44,7 @@ lab.experiment('MCP Bespoke Type Check tests:', () => {
     Code.expect(answerId).to.equal(`${prefix}-answer`)
 
     const { link, linkId, linkType } = links.pop()
-    Code.expect(link).to.equal('/mcp-type')
+    Code.expect(link).to.equal('/bespoke-or-standard-rules')
     Code.expect(linkType).to.equal('contact details')
     Code.expect(linkId).to.equal(`${prefix}-link`)
   })

--- a/test/models/checkList/permit.check.test.js
+++ b/test/models/checkList/permit.check.test.js
@@ -41,7 +41,7 @@ lab.experiment('Permit Check tests:', () => {
     Code.expect(answerId).to.equal(`${prefix}-answer`)
 
     const { link, linkId, linkType } = links.pop()
-    Code.expect(link).to.equal('/permit/category')
+    Code.expect(link).to.equal('/bespoke-or-standard-rules')
     Code.expect(linkType).to.equal('contact details')
     Code.expect(linkId).to.equal(`${prefix}-link`)
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-2773

As per point 1, the permit Change links on 'Check your answers' should point to the 'Standard or bespoke' page