### PR TITLE
WE-2929: Incorrect cost shown when switching standard rules to bespoke

### DIFF
--- a/src/controllers/bespokeOrStandardRules.controller.js
+++ b/src/controllers/bespokeOrStandardRules.controller.js
@@ -2,8 +2,14 @@
 
 const BaseController = require('./base.controller')
 const featureConfig = require('../config/featureConfig')
+const CookieService = require('../services/cookie.service')
 const RecoveryService = require('../services/recovery.service')
-const { BESPOKE: { id: BESPOKE }, STANDARD_RULES: { id: STANDARD_RULES } } = require('../constants').PermitTypes
+const ApplicationLine = require('../persistence/entities/applicationLine.entity')
+
+const {
+  COOKIE_KEY: { APPLICATION_LINE_ID },
+  PermitTypes: { BESPOKE: { id: BESPOKE }, STANDARD_RULES: { id: STANDARD_RULES } }
+} = require('../constants')
 
 module.exports = class BespokeOrStandardRulesController extends BaseController {
   async doGet (request, h, errors) {
@@ -25,21 +31,30 @@ module.exports = class BespokeOrStandardRulesController extends BaseController {
   }
 
   async doPost (request, h) {
-    const { taskDeterminants } = await RecoveryService.createApplicationContext(h)
+    const context = await RecoveryService.createApplicationContext(h)
+    const { applicationId, taskDeterminants } = context
+
     // Save the permit type in the Data store
     const permitType = request.payload['permit-type']
 
     if (![BESPOKE, STANDARD_RULES].includes(permitType)) {
       throw new Error(`Unexpected permitType: ${permitType}`)
     } else {
-      await taskDeterminants.save({ permitType })
+      await taskDeterminants.save({ permitType, facilityType: undefined })
+    }
 
-      if (permitType === BESPOKE) {
-        // Enter the triage steps for bespoke
-        return this.redirect({ h, route: this.route.bespokeRoute })
-      } else {
-        return this.redirect({ h })
-      }
+    // delete all existing application lines
+    const applicationLines = await ApplicationLine.listBy(context, { applicationId })
+    for await (const applicationLine of applicationLines) {
+      await applicationLine.delete(context)
+    }
+    CookieService.remove(request, APPLICATION_LINE_ID)
+
+    if (permitType === BESPOKE) {
+      // Enter the triage steps for bespoke
+      return this.redirect({ h, route: this.route.bespokeRoute })
+    } else {
+      return this.redirect({ h })
     }
   }
 }

--- a/src/services/recovery.service.js
+++ b/src/services/recovery.service.js
@@ -40,7 +40,7 @@ module.exports = class RecoveryService {
       options.account && !context.charityDetail.isIndividual ? Account.getByApplicationId(context) : Promise.resolve(undefined),
       options.contact && context.charityDetail.isIndividual ? Contact.getByApplicationId(context) : Promise.resolve(undefined),
       options.cardPayment ? Payment.getCardPaymentDetails(context, context.applicationLineId) : Promise.resolve(undefined),
-      options.standardRule && context.isStandardRule ? StandardRule.getByApplicationLineId(context, context.applicationLineId) : Promise.resolve(undefined)
+      options.standardRule && context.isStandardRule && context.applicationLineId ? StandardRule.getByApplicationLineId(context, context.applicationLineId) : Promise.resolve(undefined)
     ])
 
     return { applicationLine, applicationReturn, account, contact, cardPayment, standardRule }
@@ -89,7 +89,9 @@ module.exports = class RecoveryService {
       context.applicationId = context.applicationReturn.applicationId
       context.application = await Application.getById(context, context.applicationId)
       context.applicationLine = await ApplicationLine.getByApplicationId(context)
-      context.applicationLineId = context.applicationLine.id
+      if (context.applicationLine) {
+        context.applicationLineId = context.applicationLine.id
+      }
       context.permitHolderType = RecoveryService.getPermitHolderType(context.application)
 
       // Don't attempt to get the applicationLine and applicationReturn again

--- a/src/views/saveAndReturn/recover.html
+++ b/src/views/saveAndReturn/recover.html
@@ -9,6 +9,7 @@
       <div class="form-group">
         <p id="reference-number">Reference number: <span id="application-number">{{applicationNumber}}</span></p>
         <p id="permit-name-and-code"><span id="permit-name">{{permitName}}</span> <span id="code">{{code}}</span></p>
+        <p id="pre-application-notice">If you've returned to answer all the pre-application questions, you'll have to start from the beginning. All your other tasks have been saved, so you won't need to complete them again.</p>
       </div>
 
       <form method="POST" action="{{formAction}}" novalidate="novalidate">

--- a/test/routes/bespokeOrStandardRules.route.test.js
+++ b/test/routes/bespokeOrStandardRules.route.test.js
@@ -9,6 +9,7 @@ const Mocks = require('../helpers/mocks')
 const GeneralTestHelper = require('./generalTestHelper.test')
 
 const Application = require('../../src/persistence/entities/application.entity')
+const ApplicationLine = require('../../src/persistence/entities/applicationLine.entity')
 const TaskDeterminants = require('../../src/models/taskDeterminants.model')
 const CookieService = require('../../src/services/cookie.service')
 const RecoveryService = require('../../src/services/recovery.service')
@@ -49,6 +50,7 @@ let mocks
 
 lab.beforeEach(() => {
   mocks = new Mocks()
+  mocks.applicationLines = []
 
   getRequest = {
     method: 'GET',
@@ -69,6 +71,7 @@ lab.beforeEach(() => {
   sandbox.stub(TaskDeterminants.prototype, 'save').value(async () => undefined)
   sandbox.stub(Application.prototype, 'isSubmitted').value(() => false)
   sandbox.stub(RecoveryService, 'createApplicationContext').value(() => mocks.recovery)
+  sandbox.stub(ApplicationLine, 'listBy').value(async () => mocks.applicationLines)
   // Todo: Remove hasBespokeFeature syub when bespoke is live
   sandbox.stub(featureConfig, 'hasBespokeFeature').value(() => true)
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-2929

Existing application lines were being retained when changing permit type, hence the incorrect cost. These lines are now removed when changing permit type, and other existing permit details cleared as well since they were causing issues later.