### PR TITLE
WE-3093 Correct redirect for Mobile MCP permits fixing bug with application lines missing

### DIFF
--- a/src/controllers/mcpEnergyReportRequired.controller.js
+++ b/src/controllers/mcpEnergyReportRequired.controller.js
@@ -3,7 +3,7 @@
 const BaseController = require('./base.controller')
 const RecoveryService = require('../services/recovery.service')
 const { STATIONARY_MCP, MOBILE_MCP } = require('../dynamics').MCP_TYPES
-const { BURNING_WASTE_BIOMASS, CONFIRM_COST } = require('../routes')
+const { BURNING_WASTE_BIOMASS, MAINTAIN_APPLICATION_LINES } = require('../routes')
 
 module.exports = class EnergyReportRequiredController extends BaseController {
   async doGet (request, h, errors) {
@@ -30,7 +30,7 @@ module.exports = class EnergyReportRequiredController extends BaseController {
       case STATIONARY_MCP:
         return this.redirect({ h, route: BURNING_WASTE_BIOMASS })
       case MOBILE_MCP:
-        return this.redirect({ h, route: CONFIRM_COST })
+        return this.redirect({ h, route: MAINTAIN_APPLICATION_LINES })
     }
 
     return this.redirect({ h })

--- a/test/routes/mcpEnergyReportRequired.route.test.js
+++ b/test/routes/mcpEnergyReportRequired.route.test.js
@@ -17,7 +17,7 @@ const routePath = '/mcp-check/energy-report'
 
 const nextRoutePath = '/mcp-check/best-available-techniques/sg'
 const stationaryMcpRoutePath = '/mcp-check/best-available-techniques/mcp'
-const confirmCostRoutePath = '/confirm-cost'
+const maintainApplicationLinesRoutePath = '/maintain-application-lines'
 
 let sandbox
 let mocks
@@ -107,13 +107,13 @@ lab.experiment('Energy efficiency report page tests:', () => {
         Code.expect(res.headers['location']).to.equal(stationaryMcpRoutePath)
       })
 
-      lab.test(`Redirects correctly to ${confirmCostRoutePath} when ${MOBILE_MCP.id}`, async () => {
+      lab.test(`Redirects correctly to ${maintainApplicationLinesRoutePath} when ${MOBILE_MCP.id}`, async () => {
         mocks.taskDeterminants.mcpType = MOBILE_MCP
         // Make selections and click 'Continue'
         postRequest.payload['new-or-refurbished'] = 'yes'
         const res = await server.inject(postRequest)
         Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(confirmCostRoutePath)
+        Code.expect(res.headers['location']).to.equal(maintainApplicationLinesRoutePath)
       })
 
       lab.test('New or refurbished, thermal input over 20MW, boiler', async () => {


### PR DESCRIPTION
Fix for https://eaflood.atlassian.net/browse/WE-3093