### PR TITLE
Fix the bespoke check your answers so it works when bypassing the completeness check

### DIFF
--- a/src/models/taskList/bespoke.taskList.js
+++ b/src/models/taskList/bespoke.taskList.js
@@ -1,4 +1,3 @@
-
 const { bespoke } = require('../../tasks')
 const BaseTaskList = require('./base.taskList')
 const Task = require('../../persistence/entities/task.entity')
@@ -8,16 +7,10 @@ module.exports = class BespokeTaskList extends BaseTaskList {
     return bespoke
   }
 
-  async getSections () {
-    const { context } = this
-    // preload available tasks for use in isAvailable
-    await Task.getAvailableTasks(context)
-    return super.getSections()
-  }
-
   async isAvailable (task = {}) {
     const { context } = this
-    const availableTasks = context.availableTasks.map(({ shortName }) => shortName)
-    return task.required || (task.route && availableTasks.includes(task.shortName))
+    const availableTasks = await Task.getAvailableTasks(context)
+    const taskNames = availableTasks.map(({ shortName }) => shortName)
+    return task.required || (task.route && taskNames.includes(task.shortName))
   }
 }


### PR DESCRIPTION
getSections doesn't get called before isAvailable is the completeness check is bypassed, causing isAvailable to fail as getSections hadn't set up availableTasks. As it happens the attempted performance improvement isn't required as availableTasks is cached within getAvailableTasks. 

Removing the setting up of availableTasks in getSections left getSections just calling through to the base class so I removed it.