### PR TITLE
Added Content Security Policy

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1817,6 +1817,15 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "blankie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/blankie/-/blankie-4.1.1.tgz",
+      "integrity": "sha512-rV8BLrR5T7UkkSf27mPiRWGn8/peJs2FrcGodbXfxsg9R9fuOITih+balI6c7f2HmitR0Fe3MU5C6YpcUYsWwA==",
+      "requires": {
+        "@hapi/hoek": "^6.2.1",
+        "@hapi/joi": "^15.0.0"
+      }
+    },
     "blipp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/blipp/-/blipp-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@hapi/vision": "^5.5.2",
     "adal-node": "^0.1.28",
     "airbrake-js": "^1.6.8",
+    "blankie": "^4.1.1",
     "blipp": "^4.0.0",
     "clamscan": "^1.0.3",
     "cross-fetch": "^3.0.4",

--- a/server.js
+++ b/server.js
@@ -164,6 +164,21 @@ const registerPlugins = async () => server.register([
   {
     plugin: Crumb,
     options: crumbConfig.options
+  },
+
+  // Plugin for applying content security protection
+  // See https://www.npmjs.com/package/blankie
+  {
+    plugin: require('blankie'),
+    options: {
+      generateNonces: false,
+      defaultSrc: 'self',
+      scriptSrc: [ 'self', 'unsafe-inline', 'unsafe-eval', 'www.googletagmanager.com', 'www.google-analytics.com' , 'ajax.googleapis.com'],
+      imgSrc: [ 'self', 'www.google-analytics.com' ],
+      fontSrc: [ 'self', 'data:' ],
+      connectSrc: [ 'self', 'www.google-analytics.com' ],
+      objectSrc: ['none']
+    }
   }
 ])
 

--- a/test/routes/root.route.test.js
+++ b/test/routes/root.route.test.js
@@ -63,4 +63,10 @@ lab.experiment('Default page tests:', () => {
     Code.expect(res.statusCode).to.equal(302)
     Code.expect(res.headers['location']).to.equal(firstPageRoutePath)
   })
+
+  lab.test(`Get ${routePath} provides a content security policy`, async () => {
+    const res = await server.inject(getRequest)
+    Code.expect(res.statusCode).to.equal(302)
+    Code.expect(res.headers['content-security-policy']).to.exist()
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-3010

A first pass at adding a CSP for the service.

This iteration is intended to introduce CSP without breaking anything else or making wide-ranging changes, so consequently it only implements a very loose policy.

The idea is to get this change into production and then make the policy more stringent over time.