### PR TITLE
We 3106 refactor error handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -183,7 +183,6 @@ const start = async () => {
         })
         .code(response.output.statusCode)
     } else if (response.isBoom && response.output.statusCode === 403) {
-      // return h.redirect(Routes.COOKIES_DISABLED.path)
       return h
         .view('error/cookiesDisabled', {
           pageHeading: 'You must switch on cookies to use this service',

--- a/server.js
+++ b/server.js
@@ -180,7 +180,7 @@ const start = async () => {
       return h
         .view('error/pageNotFound', {
           pageHeading: 'We cannot find that page',
-          pageTitle: 'We cannot find that page'
+          pageTitle: 'Problem: We cannot find that page'
         })
         .code(404)
     } else if (response.isBoom && response.output.statusCode === 403) {

--- a/server.js
+++ b/server.js
@@ -176,7 +176,13 @@ const start = async () => {
 
     // if the response is a Boom error object and the status code is 404
     if (response.isBoom && response.output.statusCode === 404) {
-      return h.redirect(Routes.PAGE_NOT_FOUND.path)
+      // return h.redirect(Routes.PAGE_NOT_FOUND.path)
+      return h
+        .view('error/pageNotFound', {
+          pageHeading: 'We cannot find that page',
+          pageTitle: 'We cannot find that page'
+        })
+        .code(404)
     } else if (response.isBoom && response.output.statusCode === 403) {
       return h.redirect(Routes.COOKIES_DISABLED.path)
     } else {

--- a/server.js
+++ b/server.js
@@ -176,15 +176,20 @@ const start = async () => {
 
     // if the response is a Boom error object and the status code is 404
     if (response.isBoom && response.output.statusCode === 404) {
-      // return h.redirect(Routes.PAGE_NOT_FOUND.path)
       return h
         .view('error/pageNotFound', {
           pageHeading: 'We cannot find that page',
           pageTitle: 'Problem: We cannot find that page'
         })
-        .code(404)
+        .code(response.output.statusCode)
     } else if (response.isBoom && response.output.statusCode === 403) {
-      return h.redirect(Routes.COOKIES_DISABLED.path)
+      // return h.redirect(Routes.COOKIES_DISABLED.path)
+      return h
+        .view('error/cookiesDisabled', {
+          pageHeading: 'You must switch on cookies to use this service',
+          pageTitle: 'You must switch on cookies to use this service'
+        })
+        .code(response.output.statusCode)
     } else {
       return h.continue
     }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -206,7 +206,13 @@ module.exports = class BaseController {
         }
       } catch (error) {
         LoggingService.logError(error, request)
-        return this.redirect({ h, route: TECHNICAL_PROBLEM, error })
+        return h
+          .view('error/technicalProblem', {
+            pageHeading: 'Something went wrong',
+            pageTitle: 'Something went wrong: ',
+            error: error
+          })
+          .code(500)
       }
     }
 

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -174,7 +174,7 @@ module.exports = class BaseController {
   }
 
   async handler (request, h, errors) {
-    const { START_AT_BEGINNING, TECHNICAL_PROBLEM, TIMEOUT } = Routes
+    const { START_AT_BEGINNING, TIMEOUT } = Routes
     if (this.cookieValidationRequired) {
       // Validate the cookie
       const cookieValidationResult = await CookieService.validateCookie(request)
@@ -186,9 +186,6 @@ module.exports = class BaseController {
           break
         case COOKIE_RESULT.COOKIE_EXPIRED:
           path = TIMEOUT.path
-          break
-        case COOKIE_RESULT.APPLICATION_NOT_FOUND:
-          path = TECHNICAL_PROBLEM.path
           break
       }
 

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -68,6 +68,17 @@ module.exports = class BaseController {
     return pageContext
   }
 
+  handleInternalError (error, request, h, message) {
+    LoggingService.logError(error, request)
+    return h
+      .view('error/technicalProblem', {
+        pageTitle: 'Something went wrong',
+        pageHeading: message || 'Something went wrong',
+        error: error
+      })
+      .code(500)
+  }
+
   async checkRouteAccess (context) {
     const { ALREADY_SUBMITTED, NOT_SUBMITTED, RECOVERY_FAILED, TASK_LIST } = Routes
     const { slug, application } = context
@@ -202,14 +213,7 @@ module.exports = class BaseController {
           return this.redirect({ h, path })
         }
       } catch (error) {
-        LoggingService.logError(error, request)
-        return h
-          .view('error/technicalProblem', {
-            pageHeading: 'Something went wrong',
-            pageTitle: 'Something went wrong: ',
-            error: error
-          })
-          .code(500)
+        return this.handleInternalError(error, request, h)
       }
     }
 
@@ -222,14 +226,7 @@ module.exports = class BaseController {
           const response = await this._handler(request, h, errors)
           return response
         } catch (error) {
-          LoggingService.logError(error, request)
-          return h
-            .view('error/technicalProblem', {
-              pageHeading: 'Something went wrong',
-              pageTitle: 'Something went wrong: ',
-              error: error
-            })
-            .code(500)
+          return this.handleInternalError(error, request, h)
         }
     }
   }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -220,7 +220,13 @@ module.exports = class BaseController {
           return response
         } catch (error) {
           LoggingService.logError(error, request)
-          return this.redirect({ h, route: TECHNICAL_PROBLEM, error })
+          return h
+            .view('error/technicalProblem', {
+              pageHeading: 'Something went wrong',
+              pageTitle: 'Something went wrong: ',
+              error: error
+            })
+            .code(500)
         }
     }
   }

--- a/src/controllers/directorDateOfBirth.controller.js
+++ b/src/controllers/directorDateOfBirth.controller.js
@@ -2,7 +2,6 @@
 
 const moment = require('moment')
 const Constants = require('../constants')
-const Routes = require('../routes')
 const Utilities = require('../utilities/utilities')
 const BaseController = require('./base.controller')
 const LoggingService = require('../services/logging.service')
@@ -51,7 +50,13 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
     if (!account) {
       const message = `Application ${applicationId} does not have an Account`
       LoggingService.logError(message, request)
-      return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error: { message } })
+      return h
+        .view('error/technicalProblem', {
+          pageHeading: { message },
+          pageTitle: 'Something went wrong: ',
+          error: errors
+        })
+        .code(500)
     }
 
     // Get the directors that relate to this application
@@ -101,7 +106,13 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
     if (!account) {
       const message = `Application ${applicationId} does not have an Account`
       LoggingService.logError(message, request)
-      return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error: { message } })
+      return h
+        .view('error/technicalProblem', {
+          pageHeading: { message },
+          pageTitle: 'Something went wrong: ',
+          error: errors
+        })
+        .code(500)
     }
 
     const directors = await this._getDirectors(context, account.id)

--- a/src/controllers/directorDateOfBirth.controller.js
+++ b/src/controllers/directorDateOfBirth.controller.js
@@ -4,7 +4,6 @@ const moment = require('moment')
 const Constants = require('../constants')
 const Utilities = require('../utilities/utilities')
 const BaseController = require('./base.controller')
-const LoggingService = require('../services/logging.service')
 const RecoveryService = require('../services/recovery.service')
 const ContactDetail = require('../models/contactDetail.model')
 const Contact = require('../persistence/entities/contact.entity')
@@ -49,14 +48,7 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
 
     if (!account) {
       const message = `Application ${applicationId} does not have an Account`
-      LoggingService.logError(message, request)
-      return h
-        .view('error/technicalProblem', {
-          pageHeading: { message },
-          pageTitle: 'Something went wrong: ',
-          error: errors
-        })
-        .code(500)
+      return this.handleInternalError(errors, request, h, message)
     }
 
     // Get the directors that relate to this application
@@ -105,14 +97,7 @@ module.exports = class DirectorDateOfBirthController extends BaseController {
     const { applicationId, account, permitHolderType } = context
     if (!account) {
       const message = `Application ${applicationId} does not have an Account`
-      LoggingService.logError(message, request)
-      return h
-        .view('error/technicalProblem', {
-          pageHeading: { message },
-          pageTitle: 'Something went wrong: ',
-          error: errors
-        })
-        .code(500)
+      return this.handleInternalError(errors, request, h, message)
     }
 
     const directors = await this._getDirectors(context, account.id)

--- a/src/controllers/upload.controller.js
+++ b/src/controllers/upload.controller.js
@@ -2,7 +2,6 @@
 
 const Constants = require('../constants')
 const { UploadSubject } = Constants
-const Routes = require('../routes')
 const BaseController = require('./base.controller')
 const CookieService = require('../services/cookie.service')
 const LoggingService = require('../services/logging.service')
@@ -61,7 +60,13 @@ module.exports = class UploadController extends BaseController {
       if (!CookieService.validateCookie(request)) {
         const message = 'Upload failed validating cookie'
         LoggingService.logError(message, request)
-        return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error: { message } })
+        return h
+          .view('error/technicalProblem', {
+            pageHeading: message,
+            pageTitle: 'Something went wrong: ',
+            error: errors
+          })
+          .code(500)
       }
 
       // Post if it's not an attempt to upload a file
@@ -100,7 +105,13 @@ module.exports = class UploadController extends BaseController {
       return this.redirect({ h, path: this.path })
     } catch (error) {
       LoggingService.logError(error, request)
-      return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error })
+      return h
+        .view('error/technicalProblem', {
+          pageHeading: 'Something went wrong',
+          pageTitle: 'Something went wrong: ',
+          error: error
+        })
+        .code(500)
     }
   }
 
@@ -109,7 +120,13 @@ module.exports = class UploadController extends BaseController {
     if (!CookieService.validateCookie(request)) {
       const message = 'Remove failed validating cookie'
       LoggingService.logError(message, request)
-      return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error: { message } })
+      return h
+        .view('error/technicalProblem', {
+          pageHeading: message,
+          pageTitle: 'Something went wrong: ',
+          error: { message }
+        })
+        .code(500)
     }
 
     const context = await RecoveryService.createApplicationContext(h)
@@ -121,7 +138,13 @@ module.exports = class UploadController extends BaseController {
     if (annotation.applicationId !== applicationId) {
       const message = 'Annotation and application mismatch'
       LoggingService.logError(message, request)
-      return this.redirect({ h, route: Routes.TECHNICAL_PROBLEM, error: { message } })
+      return h
+        .view('error/technicalProblem', {
+          pageHeading: message,
+          pageTitle: 'Something went wrong: ',
+          error: { message }
+        })
+        .code(500)
     }
     await annotation.delete(context, annotationId)
     return this.redirect({ h, path: this.path })

--- a/test/routes/airQualityManagementArea.route.test.js
+++ b/test/routes/airQualityManagementArea.route.test.js
@@ -109,8 +109,7 @@ lab.experiment('Air Quality Management Area page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/airQualityManagementArea.route.test.js
+++ b/test/routes/airQualityManagementArea.route.test.js
@@ -19,7 +19,6 @@ const AirQualityManagementAreaTask = require('../../src/models/taskList/airQuali
 
 const routePath = '/mcp/aqma/name'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks

--- a/test/routes/applyOffline.route.test.js
+++ b/test/routes/applyOffline.route.test.js
@@ -47,7 +47,6 @@ const offlineStandardRule = {
 }
 
 const routePath = '/start/apply-offline'
-const errorPath = '/errors/technical-problem'
 const startPath = '/errors/order/start-at-beginning'
 
 let mocks

--- a/test/routes/applyOffline.route.test.js
+++ b/test/routes/applyOffline.route.test.js
@@ -135,8 +135,7 @@ lab.experiment('Apply Offline: Download and fill in these forms to apply for tha
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to start screen when cookie does not contain an offline category id and the permit holder can apply online', async () => {

--- a/test/routes/bespokeApplyOffline.route.test.js
+++ b/test/routes/bespokeApplyOffline.route.test.js
@@ -123,8 +123,7 @@ Object.entries(routesToTest).forEach(([route, { path: routePath, itemType, pageH
 
             const res = await server.inject(getRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
 

--- a/test/routes/bespokeApplyOffline.route.test.js
+++ b/test/routes/bespokeApplyOffline.route.test.js
@@ -25,8 +25,6 @@ for (const key in Routes) {
   }
 }
 
-const errorPath = '/errors/technical-problem'
-
 const ACTIVITY_ITEMS = [
   {
     id: 'ITEM_1',

--- a/test/routes/companyCheckStatus.route.test.js
+++ b/test/routes/companyCheckStatus.route.test.js
@@ -32,19 +32,17 @@ const routes = {
     pageHeading: 'We cannot issue a permit to that company because it',
     routePath: '/permit-holder/company/status-not-active',
     nextPath: '/permit-holder/company/check-name',
-    errorPath: '/errors/technical-problem',
     requiredOfficers: 'directors'
   },
   'Limited Liability Partnership': {
     pageHeading: 'We cannot issue a permit to that limited liability partnership (LLP) because it',
     routePath: '/permit-holder/limited-liability-partnership/status-not-active',
     nextPath: '/permit-holder/limited-liability-partnership/check-name',
-    errorPath: '/errors/technical-problem',
     requiredOfficers: 'designated members'
   }
 }
 
-Object.entries(routes).forEach(([companyType, { pageHeading, routePath, nextPath, errorPath, requiredOfficers }]) => {
+Object.entries(routes).forEach(([companyType, { pageHeading, routePath, nextPath, requiredOfficers }]) => {
   lab.experiment(companyType, () => {
     let mocks
     let sandbox

--- a/test/routes/companyCheckStatus.route.test.js
+++ b/test/routes/companyCheckStatus.route.test.js
@@ -146,8 +146,7 @@ Object.entries(routes).forEach(([companyType, { pageHeading, routePath, nextPath
 
             const res = await server.inject(getRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })

--- a/test/routes/companyCheckType.route.test.js
+++ b/test/routes/companyCheckType.route.test.js
@@ -114,8 +114,7 @@ lab.experiment('Check company type page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/companyCheckType.route.test.js
+++ b/test/routes/companyCheckType.route.test.js
@@ -24,7 +24,6 @@ const VALID_TYPE = 'valid type'
 
 const routePath = '/permit-holder/company/wrong-type'
 const nextRoutePath = '/permit-holder/company/status-not-active'
-const errorPath = '/errors/technical-problem'
 
 let mocks
 let sandbox

--- a/test/routes/companyNumber.route.test.js
+++ b/test/routes/companyNumber.route.test.js
@@ -20,7 +20,6 @@ const routes = {
     pageHeading: 'What is the UK company registration number?',
     routePath: '/permit-holder/company/number',
     nextPath: '/permit-holder/company/wrong-type',
-    errorPath: '/errors/technical-problem',
     validCompanyNumber: '01234567',
     invalidCompanyNumberMessage: 'Enter a valid company registration number with either 8 digits or 2 letters and 6 digits'
   },
@@ -29,7 +28,6 @@ const routes = {
     pageHeading: `What is the company or Charitable Incorporated Organisation registration number?`,
     routePath: '/permit-holder/company/number',
     nextPath: '/permit-holder/company/wrong-type',
-    errorPath: '/errors/technical-problem',
     validCompanyNumber: '01234567',
     invalidCompanyNumberMessage: 'Enter a valid company registration number with either 8 digits or 2 letters and 6 digits'
   },
@@ -37,13 +35,12 @@ const routes = {
     pageHeading: 'What is the company number for the  limited liability partnership?',
     routePath: '/permit-holder/limited-liability-partnership/number',
     nextPath: '/permit-holder/limited-liability-partnership/status-not-active',
-    errorPath: '/errors/technical-problem',
     validCompanyNumber: 'OC234567',
     invalidCompanyNumberMessage: 'Enter a valid company registration number with 2 letters and 6 digits'
   }
 }
 
-Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder, routePath, nextPath, errorPath, validCompanyNumber, invalidCompanyNumberMessage }]) => {
+Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder, routePath, nextPath, validCompanyNumber, invalidCompanyNumberMessage }]) => {
   lab.experiment(companyType, () => {
     let sandbox
     let mocks
@@ -105,7 +102,7 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
         })
 
         lab.experiment('failure', () => {
-          lab.test('redirects to error screen when failing to recover the application', async () => {
+          lab.test('error screen when failing to recover the application', async () => {
             const spy = sandbox.spy(LoggingService, 'logError')
             RecoveryService.createApplicationContext = () => {
               throw new Error('recovery failed')
@@ -113,8 +110,7 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
 
             const res = await server.inject(getRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })
@@ -187,7 +183,7 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
             delete mocks.account.companyNumber
           })
 
-          lab.test('redirects to error screen when failing to get the account by the company number', async () => {
+          lab.test('error screen when failing to get the account by the company number', async () => {
             const spy = sandbox.spy(LoggingService, 'logError')
             Account.getByCompanyNumber = () => {
               throw new Error('read failed')
@@ -197,11 +193,10 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
             delete mocks.account.id
             const res = await server.inject(postRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
 
-          lab.test('redirects to error screen when save fails', async () => {
+          lab.test('error screen when save fails', async () => {
             const spy = sandbox.spy(LoggingService, 'logError')
             Account.prototype.save = () => Promise.reject(new Error('save failed'))
 
@@ -209,8 +204,7 @@ Object.entries(routes).forEach(([companyType, { pageHeading, charityPermitHolder
 
             const res = await server.inject(postRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })

--- a/test/routes/confirmMiningWastePlan.route.test.js
+++ b/test/routes/confirmMiningWastePlan.route.test.js
@@ -16,7 +16,6 @@ const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/mining-waste/plan'
 const nextRoutePath = '/mining-waste/weight'
-const errorPath = '/errors/technical-problem'
 
 const checkCommonElements = async (doc) => {
   Code.expect(doc.getElementById('page-heading').firstChild.nodeValue).to.equal('Which mining waste plan will you use?')
@@ -77,7 +76,7 @@ lab.experiment('Which mining waste plan will you use? page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('recovery failed')
@@ -85,8 +84,7 @@ lab.experiment('Which mining waste plan will you use? page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/confirmRules.route.test.js
+++ b/test/routes/confirmRules.route.test.js
@@ -18,7 +18,6 @@ const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/confirm-rules'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let mocks
 let sandbox
@@ -102,7 +101,7 @@ lab.experiment('Confirm your operation meets the rules page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when isComplete fails', async () => {
+      lab.test('error screen when isComplete fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         ConfirmRules.isComplete = () => {
           throw new Error('read failed')
@@ -110,8 +109,7 @@ lab.experiment('Confirm your operation meets the rules page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -135,7 +133,7 @@ lab.experiment('Confirm your operation meets the rules page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when updateCompletenesss fails', async () => {
+      lab.test('error screen when updateCompletenesss fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         ConfirmRules.updateCompleteness = () => {
           throw new Error('update failed')
@@ -143,8 +141,7 @@ lab.experiment('Confirm your operation meets the rules page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/costTime.route.test.js
+++ b/test/routes/costTime.route.test.js
@@ -19,7 +19,6 @@ const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/costs-times'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let mocks
 let sandbox
@@ -118,7 +117,7 @@ lab.experiment('Cost and time for this permit page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when updateCompleteness fails', async () => {
+      lab.test('error screen when updateCompleteness fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         CostTime.updateCompleteness = () => {
           throw new Error('update failed')
@@ -126,8 +125,7 @@ lab.experiment('Cost and time for this permit page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/declaration/company/bankruptcy.route.test.js
+++ b/test/routes/declaration/company/bankruptcy.route.test.js
@@ -156,8 +156,7 @@ Object.entries(routes).forEach(([operator, {
 
           const res = await server.inject(getRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
       })
     })
@@ -225,8 +224,7 @@ Object.entries(routes).forEach(([operator, {
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
 
         lab.test('redirects to error screen when save fails', async () => {
@@ -235,8 +233,7 @@ Object.entries(routes).forEach(([operator, {
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
       })
     })

--- a/test/routes/declaration/company/offences.route.test.js
+++ b/test/routes/declaration/company/offences.route.test.js
@@ -71,7 +71,6 @@ Object.entries(routes).forEach(([operator, {
   permitHolderType,
   routePath = '/permit-holder/company/declare-offences',
   nextPath = '/permit-holder/company/bankruptcy-insolvency',
-  errorPath = '/errors/technical-problem'
 }]) => {
   lab.experiment(`${operator} Declare Offences tests:`, () => {
     new GeneralTestHelper({ lab, routePath }).test()
@@ -144,7 +143,7 @@ Object.entries(routes).forEach(([operator, {
       })
 
       lab.experiment('failure', () => {
-        lab.test('redirects to error screen when failing to recover the application', async () => {
+        lab.test('error screen when failing to recover the application', async () => {
           const spy = sandbox.spy(LoggingService, 'logError')
           RecoveryService.createApplicationContext = () => {
             throw new Error('recovery failed')
@@ -152,8 +151,7 @@ Object.entries(routes).forEach(([operator, {
 
           const res = await server.inject(getRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
       })
     })
@@ -213,7 +211,7 @@ Object.entries(routes).forEach(([operator, {
       })
 
       lab.experiment('failure', () => {
-        lab.test('redirects to error screen when failing to recover the application', async () => {
+        lab.test('error screen when failing to recover the application', async () => {
           const spy = sandbox.spy(LoggingService, 'logError')
           RecoveryService.createApplicationContext = () => {
             throw new Error('recovery failed')
@@ -221,18 +219,16 @@ Object.entries(routes).forEach(([operator, {
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
 
-        lab.test('redirects to error screen when save fails', async () => {
+        lab.test('error screen when save fails', async () => {
           const spy = sandbox.spy(LoggingService, 'logError')
           Application.prototype.save = () => Promise.reject(new Error('save failed'))
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
       })
     })

--- a/test/routes/declaration/confidentiality/confidentiality.route.test.js
+++ b/test/routes/declaration/confidentiality/confidentiality.route.test.js
@@ -17,7 +17,6 @@ const { COOKIE_RESULT } = require('../../../../src/constants')
 
 const routePath = '/confidentiality'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -78,7 +77,7 @@ lab.experiment('Is part of your application commercially confidential? page test
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('recovery failed')
@@ -86,8 +85,7 @@ lab.experiment('Is part of your application commercially confidential? page test
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -147,7 +145,7 @@ lab.experiment('Is part of your application commercially confidential? page test
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('recovery failed')
@@ -155,18 +153,16 @@ lab.experiment('Is part of your application commercially confidential? page test
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
-      lab.test('redirects to error screen when save fails', async () => {
+      lab.test('error screen when save fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         Application.prototype.save = () => Promise.reject(new Error('save failed'))
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/directorDateOfBirth.route.test.js
+++ b/test/routes/directorDateOfBirth.route.test.js
@@ -24,7 +24,6 @@ const routes = {
     permitHolderType: LIMITED_COMPANY,
     routePath: '/permit-holder/company/director-date-of-birth',
     nextPath: '/permit-holder/company/director-email',
-    errorPath: '/errors/technical-problem'
   },
   'Limited Liability Partnership': {
     singleDirectorPageHeading: `What is the member's date of birth?`,
@@ -33,7 +32,6 @@ const routes = {
     pageHeading: 'What is the company number for the  limited liability partnership?',
     routePath: '/permit-holder/limited-liability-partnership/member-date-of-birth',
     nextPath: '/permit-holder/limited-liability-partnership/designated-member-email',
-    errorPath: '/errors/technical-problem'
   }
 }
 

--- a/test/routes/drainageTypeDrain.route.test.js
+++ b/test/routes/drainageTypeDrain.route.test.js
@@ -27,7 +27,6 @@ const DRAINAGE_FAIL_PERMIT = 'SR2015 No 13'
 const routePath = '/drainage-type/drain'
 const nextRoutePath = '/task-list'
 const failRoutePath = '/drainage-type/contact-us'
-const errorPath = '/errors/technical-problem'
 
 const checkCommonElements = async (doc) => {
   const pageHeading = 'Where does the vehicle storage area drain to?'
@@ -101,7 +100,7 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('recovery failed')
@@ -109,8 +108,7 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -187,7 +185,7 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when save fails', async () => {
+      lab.test('error screen when save fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         DrainageTypeDrain.updateCompleteness = () => {
           throw new Error('update failed')
@@ -195,18 +193,16 @@ lab.experiment('Where does the vehicle storage area drain to? page tests:', () =
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
-      lab.test('redirects to error screen when unknown drainage-type is selected', async () => {
+      lab.test('error screen when unknown drainage-type is selected', async () => {
         postRequest.payload['drainage-type'] = '999999999'
         const spy = sandbox.spy(LoggingService, 'logError')
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/drainageTypeFail.route.test.js
+++ b/test/routes/drainageTypeFail.route.test.js
@@ -27,7 +27,6 @@ const DRAINAGE_FAIL_PERMIT = 'SR2015 No 13'
 
 const routePath = '/drainage-type/contact-us'
 const redirectPath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 const checkCommonElements = async (doc) => {
   const pageHeading = 'Your drainage system is not suitable - please contact us'
@@ -133,8 +132,7 @@ lab.experiment('Your drainage system is not suitable - please contact us page te
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when unknown drainage-type is selected', async () => {
@@ -142,8 +140,7 @@ lab.experiment('Your drainage system is not suitable - please contact us page te
         const spy = sandbox.spy(LoggingService, 'logError')
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/error/pageNotFound.route.test.js
+++ b/test/routes/error/pageNotFound.route.test.js
@@ -84,7 +84,6 @@ lab.experiment('Page Not Found (404) page tests:', () => {
   lab.test('GET /an-invalid-route shows the 404 page when the user has a valid cookie', async () => {
     getRequest.url = '/an-invalid-route'
     const res = await server.inject(getRequest)
-    Code.expect(res.statusCode).to.equal(302)
-    Code.expect(res.headers['location']).to.equal(routePath)
+    Code.expect(res.statusCode).to.equal(404)
   })
 })

--- a/test/routes/managementSystemSelect.route.test.js
+++ b/test/routes/managementSystemSelect.route.test.js
@@ -22,7 +22,6 @@ const { questionCode } = MANAGEMENT_SYSTEM
 
 const routePath = '/management-system/select'
 const nextRoutePath = '/management-system/upload'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -118,14 +117,13 @@ lab.experiment('Management system select tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when an unknown management system is selected', async () => {
+      lab.test('error screen when an unknown management system is selected', async () => {
         postRequest.payload[questionCode] = 'UNKNOWN'
         const spy = sandbox.spy(LoggingService, 'logError')
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/mcpBusinessActivity.route.test.js
+++ b/test/routes/mcpBusinessActivity.route.test.js
@@ -18,7 +18,6 @@ const McpBusinessType = require('../../src/models/mcpBusinessType.model')
 
 const routePath = '/mcp/business-activity'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -101,7 +100,7 @@ lab.experiment('MCP business or activity page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('application recovery failed')
@@ -109,8 +108,7 @@ lab.experiment('MCP business or activity page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/mcpTemplate.route.test.js
+++ b/test/routes/mcpTemplate.route.test.js
@@ -21,7 +21,6 @@ const { STATIONARY_MCP, MOBILE_SG } = require('../../src/dynamics').MCP_TYPES
 
 const routePath = '/mcp/template/download'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -123,8 +122,7 @@ lab.experiment('MCP template download page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -156,8 +154,7 @@ lab.experiment('MCP template download page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/miningWasteWeight.route.test.js
+++ b/test/routes/miningWasteWeight.route.test.js
@@ -18,7 +18,6 @@ const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/mining-waste/weight'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -78,7 +77,7 @@ lab.experiment('How much extractive waste will you produce? page tests:', () => 
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('application recovery failed')
@@ -86,8 +85,7 @@ lab.experiment('How much extractive waste will you produce? page tests:', () => 
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -133,7 +131,7 @@ lab.experiment('How much extractive waste will you produce? page tests:', () => 
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when save fails', async () => {
+      lab.test('error screen when save fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         sinon.stub(Application.prototype, 'save').value(() => {
           throw new Error('update failed')
@@ -141,8 +139,7 @@ lab.experiment('How much extractive waste will you produce? page tests:', () => 
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/needToConsult.route.test.js
+++ b/test/routes/needToConsult.route.test.js
@@ -18,7 +18,6 @@ const NeedToConsult = require('../../src/models/needToConsult.model')
 
 const routePath = '/consultation/names'
 const nextRoutePath = '/task-list'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -104,7 +103,7 @@ lab.experiment('Consultees page tests:', () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to recover the application', async () => {
+      lab.test('error screen when failing to recover the application', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('application recovery failed')
@@ -112,8 +111,7 @@ lab.experiment('Consultees page tests:', () => {
 
         const res = await server.inject(request)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/operatingUnder500Hours.route.test.js
+++ b/test/routes/operatingUnder500Hours.route.test.js
@@ -26,7 +26,6 @@ const {
 const routePath = '/mcp-check/under-500-hours'
 const yesRoutePath = '/maintain-application-lines'
 const noRoutePath = '/mcp-check/air-dispersion-modelling-report'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -98,8 +97,7 @@ lab.experiment('Operating under 500 hours page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/payment/bacsProof.route.test.js
+++ b/test/routes/payment/bacsProof.route.test.js
@@ -22,7 +22,6 @@ const fakeSlug = 'SLUG'
 
 const routePath = '/pay/bacs-proof'
 const nextRoutePath = `/done/${fakeSlug}`
-const errorPath = '/errors/technical-problem'
 
 let mocks
 let sandbox
@@ -115,8 +114,7 @@ lab.experiment(`Give proof of your Bacs payment:`, () => {
 
       const res = await server.inject(getRequest)
       Code.expect(spy.callCount).to.equal(1)
-      Code.expect(res.statusCode).to.equal(302)
-      Code.expect(res.headers['location']).to.equal(errorPath)
+      Code.expect(res.statusCode).to.equal(500)
     })
   })
 
@@ -145,34 +143,31 @@ lab.experiment(`Give proof of your Bacs payment:`, () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to get the payment details', async () => {
+      lab.test('error screen when failing to get the payment details', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         getBacsPaymentStub.rejects(new Error('read failed'))
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
-      lab.test('redirects to error screen when no payment details', async () => {
+      lab.test('error screen when no payment details', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         getBacsPaymentStub.resolves(undefined)
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
-      lab.test('redirects to error screen when save fails', async () => {
+      lab.test('error screen when save fails', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         saveBacsPaymentStub.rejects(new Error('save failed'))
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
 

--- a/test/routes/payment/cardPayment.route.test.js
+++ b/test/routes/payment/cardPayment.route.test.js
@@ -21,7 +21,6 @@ const slug = 'SLUG'
 const paymentErrorStatus = 'error'
 
 const routePath = `/pay/card`
-const errorPath = '/errors/technical-problem'
 const cardProblemPath = `/pay/card-problem/${slug}?status=${paymentErrorStatus}`
 const returnFromGovPayUrl = '/return/from/govr/pay/url'
 
@@ -93,7 +92,7 @@ lab.experiment(`How do you want to pay?:`, () => {
     })
 
     lab.experiment('failure', () => {
-      lab.test('redirects to error screen when failing to get the applicationContext', async () => {
+      lab.test('500 error screen when failing to get the applicationContext', async () => {
         const spy = sandbox.spy(LoggingService, 'logError')
         RecoveryService.createApplicationContext = () => {
           throw new Error('recovery failed')
@@ -101,8 +100,7 @@ lab.experiment(`How do you want to pay?:`, () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/payment/cardProblem.route.test.js
+++ b/test/routes/payment/cardProblem.route.test.js
@@ -27,7 +27,6 @@ let sandbox
 const fakeSlug = 'SLUG'
 
 const routePath = `/pay/card-problem/${fakeSlug}`
-const errorPath = '/errors/technical-problem'
 
 lab.beforeEach(() => {
   mocks = new Mocks()
@@ -107,8 +106,7 @@ lab.experiment(`Your card payment failed:`, () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -156,8 +154,7 @@ lab.experiment(`Your card payment failed:`, () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/payment/paymentBacs.route.test.js
+++ b/test/routes/payment/paymentBacs.route.test.js
@@ -22,7 +22,6 @@ const fakeSlug = 'SLUG'
 
 const routePath = '/pay/bacs'
 const nextRoutePath = '/pay/bacs-proof'
-const errorPath = '/errors/technical-problem'
 
 let mocks
 let sandbox
@@ -110,8 +109,7 @@ lab.experiment(`You have chosen to pay by bank transfer using Bacs:`, () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when save fails', async () => {
@@ -120,8 +118,7 @@ lab.experiment(`You have chosen to pay by bank transfer using Bacs:`, () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/payment/paymentResult.route.test.js
+++ b/test/routes/payment/paymentResult.route.test.js
@@ -23,7 +23,6 @@ const fakeSlug = 'SLUG'
 
 const routePath = `/pay/result`
 const nextRoutePath = `/done/${fakeSlug}`
-const errorPath = '/errors/technical-problem'
 const problemRoutePath = '/pay/card-problem/SLUG'
 
 lab.beforeEach(() => {
@@ -95,8 +94,7 @@ lab.experiment(`Payment result:`, () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/payment/paymentType.route.test.js
+++ b/test/routes/payment/paymentType.route.test.js
@@ -27,7 +27,6 @@ let mocks
 const fakeSlug = 'SLUG'
 
 const routePath = `/pay/type`
-const errorPath = '/errors/technical-problem'
 
 lab.beforeEach(() => {
   mocks = new Mocks()
@@ -109,8 +108,7 @@ lab.experiment(`How do you want to pay?:`, () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitCategory.route.test.js
+++ b/test/routes/permitCategory.route.test.js
@@ -21,7 +21,6 @@ const PermitCategoryController = require('../../src/controllers/permitCategory.c
 const routePath = '/permit/category'
 const nextRoutePath = '/permit/select'
 const offlineRoutePath = '/start/apply-offline'
-const errorPath = '/errors/technical-problem'
 
 const offlineCategories = [
   {
@@ -160,8 +159,7 @@ lab.experiment('What do you want the permit for? (permit category) page tests:',
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when failing to get the list of categories', async () => {
@@ -172,8 +170,7 @@ lab.experiment('What do you want the permit for? (permit category) page tests:',
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitHolder/memberContactDetails.route.test.js
+++ b/test/routes/permitHolder/memberContactDetails.route.test.js
@@ -20,18 +20,16 @@ const routes = {
   'partner': {
     routePath: `/permit-holder/partners/details/${memberId}`,
     nextPath: `/permit-holder/partners/address/postcode/${memberId}`,
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/partnerDetails.task')
   },
   'postholder': {
     routePath: `/permit-holder/group/post-holder/contact-details/${memberId}`,
     nextPath: `/permit-holder/group/post-holder/address/postcode/${memberId}`,
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/postholderDetails.task')
   }
 }
 
-Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, PermitHolderTask }]) => {
+Object.entries(routes).forEach(([member, { routePath, nextPath, PermitHolderTask }]) => {
   lab.experiment(capitalizeFirstLetter(member), () => {
     let mocks
     let sandbox
@@ -132,8 +130,7 @@ Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, Permi
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(getRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })
@@ -152,8 +149,7 @@ Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, Permi
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(postRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
 

--- a/test/routes/permitHolder/memberDelete.route.test.js
+++ b/test/routes/permitHolder/memberDelete.route.test.js
@@ -21,18 +21,16 @@ const routes = {
   'partner': {
     routePath: `/permit-holder/partners/delete/${memberId}`,
     nextPath: '/permit-holder/partners/list',
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/partnerDetails.task')
   },
   'postholder': {
     routePath: `/permit-holder/group/post-holder/delete/${memberId}`,
     nextPath: '/permit-holder/group/list',
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/postholderDetails.task')
   }
 }
 
-Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, PermitHolderTask }]) => {
+Object.entries(routes).forEach(([member, { routePath, nextPath, PermitHolderTask }]) => {
   lab.experiment(capitalizeFirstLetter(member), () => {
     let mocks
     let sandbox
@@ -107,8 +105,7 @@ Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, Permi
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(getRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })
@@ -127,8 +124,7 @@ Object.entries(routes).forEach(([member, { routePath, nextPath, errorPath, Permi
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(postRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })

--- a/test/routes/permitHolder/memberList.route.test.js
+++ b/test/routes/permitHolder/memberList.route.test.js
@@ -26,7 +26,6 @@ const routes = {
     heading: 'Business partners you have added to this application',
     routePath: `/permit-holder/partners/list`,
     nextPath: '/permit-holder/company/declare-offences',
-    errorPath: '/errors/technical-problem',
     editMemberPath: `/permit-holder/partners/name/${memberId}`,
     deleteMemberPath: `/permit-holder/partners/delete/${memberId}`
   },
@@ -35,13 +34,12 @@ const routes = {
     heading: 'Postholders you have added',
     routePath: `/permit-holder/group/list`,
     nextPath: '/permit-holder/group/post-holder/declare-offences',
-    errorPath: '/errors/technical-problem',
     editMemberPath: `/permit-holder/group/post-holder/name/${memberId}`,
     deleteMemberPath: `/permit-holder/group/post-holder/delete/${memberId}`
   }
 }
 
-Object.entries(routes).forEach(([member, { includesJobTitle, heading, routePath, nextPath, errorPath, editMemberPath, deleteMemberPath }]) => {
+Object.entries(routes).forEach(([member, { includesJobTitle, heading, routePath, nextPath, editMemberPath, deleteMemberPath }]) => {
   lab.experiment(capitalizeFirstLetter(member), () => {
     let mocks
     let sandbox
@@ -171,8 +169,7 @@ Object.entries(routes).forEach(([member, { includesJobTitle, heading, routePath,
 
             const res = await server.inject(getRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })
@@ -212,8 +209,7 @@ Object.entries(routes).forEach(([member, { includesJobTitle, heading, routePath,
 
             const res = await server.inject(postRequest)
             Code.expect(spy.callCount).to.equal(1)
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })

--- a/test/routes/permitHolder/memberNameAndDateOfBirth.route.test.js
+++ b/test/routes/permitHolder/memberNameAndDateOfBirth.route.test.js
@@ -21,19 +21,17 @@ const routes = {
   'partner': {
     routePath: `/permit-holder/partners/name/${memberId}`,
     nextPath: `/permit-holder/partners/details/${memberId}`,
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/partnerDetails.task')
   },
   'postholder': {
     includesJobTitle: true,
     routePath: `/permit-holder/group/post-holder/name/${memberId}`,
     nextPath: `/permit-holder/group/post-holder/contact-details/${memberId}`,
-    errorPath: '/errors/technical-problem',
     PermitHolderTask: require('../../../src/models/taskList/postholderDetails.task')
   }
 }
 
-Object.entries(routes).forEach(([member, { includesJobTitle, routePath, nextPath, errorPath, PermitHolderTask }]) => {
+Object.entries(routes).forEach(([member, { includesJobTitle, routePath, nextPath, PermitHolderTask }]) => {
   lab.experiment(capitalizeFirstLetter(member), () => {
     let mocks
     let sandbox
@@ -174,8 +172,7 @@ Object.entries(routes).forEach(([member, { includesJobTitle, routePath, nextPath
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(getRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
       })
@@ -194,8 +191,7 @@ Object.entries(routes).forEach(([member, { includesJobTitle, routePath, nextPath
             const stub = sinon.stub(PermitHolderTask, 'getContactDetail').value(() => undefined)
             const res = await server.inject(postRequest)
             stub.restore()
-            Code.expect(res.statusCode).to.equal(302)
-            Code.expect(res.headers['location']).to.equal(errorPath)
+            Code.expect(res.statusCode).to.equal(500)
           })
         })
 

--- a/test/routes/permitHolder/partnershipTradingName.route.test.js
+++ b/test/routes/permitHolder/partnershipTradingName.route.test.js
@@ -16,7 +16,6 @@ const Account = require('../../../src/persistence/entities/account.entity')
 const { COOKIE_RESULT } = require('../../../src/constants')
 
 const routePath = '/permit-holder/partners/trading-name'
-const errorPath = '/errors/technical-problem'
 const nextRoutePath = '/permit-holder/partners/list'
 
 let sandbox
@@ -100,8 +99,7 @@ lab.experiment('Partnership Trading Name page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -145,8 +143,7 @@ lab.experiment('Partnership Trading Name page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitHolder/permitHolderTradingName.route.test.js
+++ b/test/routes/permitHolder/permitHolderTradingName.route.test.js
@@ -18,7 +18,6 @@ let sandbox
 let mocks
 
 const routePath = '/permit-holder/trading-name'
-const errorPath = '/errors/technical-problem'
 const nextRoutePath = '/permit-holder/contact-details'
 
 // Trading name used
@@ -122,8 +121,7 @@ lab.experiment('Permit Holder Trading Name page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -181,8 +179,7 @@ lab.experiment('Permit Holder Trading Name page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitHolder/permitHolderType.route.test.js
+++ b/test/routes/permitHolder/permitHolderType.route.test.js
@@ -20,7 +20,6 @@ const { MCP_TYPES } = require('../../../src/dynamics')
 
 const routePath = '/permit-holder/type'
 const nextRoutePath = '/permit-holder/details'
-const errorPath = '/errors/technical-problem'
 let sandbox
 let mocks
 
@@ -117,8 +116,7 @@ lab.experiment('Permit holder type: Who will be the permit holder? page tests:',
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitHolder/tradingName.route.test.js
+++ b/test/routes/permitHolder/tradingName.route.test.js
@@ -17,7 +17,6 @@ const { COOKIE_RESULT } = require('../../../src/constants')
 let sandbox
 
 const routePath = '/permit-holder/public-body/name'
-const errorPath = '/errors/technical-problem'
 const nextRoutePath = '/permit-holder/public-body/address/postcode'
 
 let fakeRecovery
@@ -114,8 +113,7 @@ lab.experiment('Partnership Trading Name page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -159,8 +157,7 @@ lab.experiment('Partnership Trading Name page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/permitSelect.route.test.js
+++ b/test/routes/permitSelect.route.test.js
@@ -24,7 +24,6 @@ const routePath = '/permit/select'
 const nextRoutePath = '/task-list'
 const offlineRoutePath = '/start/apply-offline'
 const existingPermitRoutePath = '/existing-permit'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -141,8 +140,7 @@ lab.experiment('Select a permit page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when failing to get the permits', async () => {
@@ -153,8 +151,7 @@ lab.experiment('Select a permit page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when failing to get the category', async () => {
@@ -165,8 +162,7 @@ lab.experiment('Select a permit page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/saveAndReturn/checkYourEmail.route.test.js
+++ b/test/routes/saveAndReturn/checkYourEmail.route.test.js
@@ -7,6 +7,5 @@ emailSentTests(lab, {
   routePath: '/save-return/check-your-email',
   nextPath: '/save-return/check-your-email',
   resentPath: '/save-return/email-sent-resent',
-  errorPath: '/errors/technical-problem',
   excludeAlreadySubmittedTest: true
 })

--- a/test/routes/saveAndReturn/checkYourEmailTests.js
+++ b/test/routes/saveAndReturn/checkYourEmailTests.js
@@ -14,7 +14,7 @@ const { COOKIE_RESULT } = require('../../../src/constants')
 
 let numberOfMatchingEmails
 
-module.exports = (lab, { routePath, nextPath, errorPath, pageHeading, excludeAlreadySubmittedTest }) => {
+module.exports = (lab, { routePath, nextPath, pageHeading, excludeAlreadySubmittedTest }) => {
   let mocks
   let sandbox
 

--- a/test/routes/saveAndReturn/emailConfirm.route.test.js
+++ b/test/routes/saveAndReturn/emailConfirm.route.test.js
@@ -18,7 +18,6 @@ const { COOKIE_RESULT } = require('../../../src/constants')
 
 const routePath = '/save-return/confirm'
 const nextRoutePath = '/save-return/email-sent-check'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -133,8 +132,7 @@ lab.experiment('Save and return confirm page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when save fails', async () => {
@@ -143,8 +141,7 @@ lab.experiment('Save and return confirm page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/saveAndReturn/emailEnter.route.test.js
+++ b/test/routes/saveAndReturn/emailEnter.route.test.js
@@ -19,7 +19,6 @@ const { COOKIE_RESULT } = require('../../../src/constants')
 const routePath = '/save-return/email'
 const nextRoutePath = '/save-return/confirm'
 const emailSentPath = '/save-return/email-sent-task-check'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -122,8 +121,7 @@ lab.experiment('Save and return email page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when save fails', async () => {
@@ -132,8 +130,7 @@ lab.experiment('Save and return email page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/saveAndReturn/emailSentCheck.route.test.js
+++ b/test/routes/saveAndReturn/emailSentCheck.route.test.js
@@ -7,6 +7,5 @@ emailSentTests(lab, {
   routePath: '/save-return/email-sent-check',
   nextRoutePath: '/task-list',
   resentPath: '/save-return/email-sent-resent',
-  errorPath: '/errors/technical-problem',
   firstTime: true
 })

--- a/test/routes/saveAndReturn/emailSentComplete.route.test.js
+++ b/test/routes/saveAndReturn/emailSentComplete.route.test.js
@@ -6,6 +6,5 @@ emailSentTests(lab, {
   pageHeading: 'You have saved your application',
   routePath: '/save-return/email-sent-task-check',
   nextRoutePath: '/task-list',
-  resentPath: '/save-return/email-sent-resent',
-  errorPath: '/errors/technical-problem'
+  resentPath: '/save-return/email-sent-resent'
 })

--- a/test/routes/saveAndReturn/emailSentResent.route.test.js
+++ b/test/routes/saveAndReturn/emailSentResent.route.test.js
@@ -6,6 +6,5 @@ emailSentTests(lab, {
   pageHeading: 'We have resent the email - check again',
   routePath: '/save-return/email-sent-resent',
   nextRoutePath: '/task-list',
-  resentPath: '/save-return/email-sent-resent',
-  errorPath: '/errors/technical-problem'
+  resentPath: '/save-return/email-sent-resent'
 })

--- a/test/routes/saveAndReturn/emailSentTests.js
+++ b/test/routes/saveAndReturn/emailSentTests.js
@@ -21,7 +21,7 @@ let fakeAppUrl
 let fakeRecoveryLink
 let origin
 
-module.exports = (lab, { routePath, nextRoutePath, resentPath, errorPath, pageHeading, firstTime }) => {
+module.exports = (lab, { routePath, nextRoutePath, resentPath, pageHeading, firstTime }) => {
   let sandbox
   let mocks
 
@@ -200,8 +200,7 @@ module.exports = (lab, { routePath, nextRoutePath, resentPath, errorPath, pageHe
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
 
         lab.test('redirects to error screen when save fails', async () => {
@@ -216,8 +215,7 @@ module.exports = (lab, { routePath, nextRoutePath, resentPath, errorPath, pageHe
 
           const res = await server.inject(postRequest)
           Code.expect(spy.callCount).to.equal(1)
-          Code.expect(res.statusCode).to.equal(302)
-          Code.expect(res.headers['location']).to.equal(errorPath)
+          Code.expect(res.statusCode).to.equal(500)
         })
       })
     })

--- a/test/routes/saveAndReturn/recover.route.test.js
+++ b/test/routes/saveAndReturn/recover.route.test.js
@@ -29,7 +29,6 @@ const nextRoutePath = '/task-list'
 const nextRouteNoLinesPath = '/bespoke-or-standard-rules'
 const nextPathForBacs = '/pay/bacs-proof'
 const recoveryFailedPath = '/errors/recovery-failed'
-const errorPath = '/errors/technical-problem'
 
 let sandbox
 let mocks
@@ -163,8 +162,7 @@ lab.experiment('We found your application:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/saveAndReturn/searchYourEmail.route.test.js
+++ b/test/routes/saveAndReturn/searchYourEmail.route.test.js
@@ -7,6 +7,5 @@ emailSentTests(lab, {
   routePath: '/save-return/search-your-email',
   nextPath: '/save-return/check-your-email',
   resentPath: '/save-return/email-sent-resent',
-  errorPath: '/errors/technical-problem',
   excludeAlreadySubmittedTest: true
 })

--- a/test/routes/technicalQualification.route.test.js
+++ b/test/routes/technicalQualification.route.test.js
@@ -21,7 +21,6 @@ const nextRoutePath = {
   DEEMED_COMPETENCE: '/technical-competence/upload-deemed-evidence',
   ESA_EU_SKILLS: '/technical-competence/upload-esa-eu-skills'
 }
-const errorPath = '/errors/technical-problem'
 
 const Qualification = {
   WAMITAB_QUALIFICATION: {
@@ -159,8 +158,7 @@ lab.experiment('Technical Management Qualification tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -213,8 +211,7 @@ lab.experiment('Technical Management Qualification tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when save fails', async () => {
@@ -223,8 +220,7 @@ lab.experiment('Technical Management Qualification tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when an unexpected qualification is selected', async () => {
@@ -233,8 +229,7 @@ lab.experiment('Technical Management Qualification tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -53,7 +53,6 @@ module.exports = class UploadTestHelper {
     this.uploadPath = uploadPath
     this.removePath = removePath
     this.nextRoutePath = nextRoutePath
-    this.errorPath = '/errors/technical-problem'
   }
 
   setStubs (sandbox) {
@@ -271,7 +270,7 @@ module.exports = class UploadTestHelper {
   }
 
   uploadFailure (contentType = 'image/jpeg') {
-    const { lab, errorPath } = this
+    const { lab } = this
     lab.experiment('failure', () => {
       lab.test('redirects to error screen when save fails', async () => {
         const spy = sinon.spy(LoggingService, 'logError')
@@ -281,8 +280,7 @@ module.exports = class UploadTestHelper {
         const req = this._uploadRequest({ contentType })
         const res = await server.inject(req)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
         spy.restore()
       })
     })

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -141,8 +141,7 @@ module.exports = class UploadTestHelper {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(this.errorPath)
+        Code.expect(res.statusCode).to.equal(500)
         spy.restore()
       })
     })

--- a/test/routes/wasteRecoveryPlanApproval.route.test.js
+++ b/test/routes/wasteRecoveryPlanApproval.route.test.js
@@ -16,7 +16,6 @@ const { COOKIE_RESULT } = require('../../src/constants')
 
 const routePath = '/waste-recovery-plan/approval'
 const nextRoutePath = '/waste-recovery-plan'
-const errorPath = '/errors/technical-problem'
 
 const ALREADY_ASSESSED = 910400000
 const PLAN_HAS_CHANGED = 910400001
@@ -126,8 +125,7 @@ lab.experiment('Waste Recovery Plan Approval page tests:', () => {
 
         const res = await server.inject(getRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })
@@ -169,8 +167,7 @@ lab.experiment('Waste Recovery Plan Approval page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
 
       lab.test('redirects to error screen when save fails', async () => {
@@ -179,8 +176,7 @@ lab.experiment('Waste Recovery Plan Approval page tests:', () => {
 
         const res = await server.inject(postRequest)
         Code.expect(spy.callCount).to.equal(1)
-        Code.expect(res.statusCode).to.equal(302)
-        Code.expect(res.headers['location']).to.equal(errorPath)
+        Code.expect(res.statusCode).to.equal(500)
       })
     })
   })


### PR DESCRIPTION
**THIS WILL BE MERGED AS PART OF AN ISOLATED RELEASE, CAREFUL**

These changes alter the handling of errors in the application and therefore significantly alter the basic running of the routing process.

Currently errors are caught, swallowed, and the request is redirected (302) to an error screen (200). This creates confusion in the logs and analytics, it is also non-standard HTTP behavior.

These changes catch the error and return the error screen "in place" with a 4xx or 5xx error code.