### PR TITLE
We 3132 file extensions and mime types

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,7 +21,9 @@ Constants.FILE_TYPES = {
   ODS: { mimeType: 'application/vnd.oasis.opendocument.spreadsheet' },
   ODT: { mimeType: 'application/vnd.oasis.opendocument.text' },
   PDF: { mimeType: 'application/pdf' },
-  XLS: { mimeType: 'application/vnd.ms-excel' },
+  XLS: {
+    mimeType: ['application/vnd.ms-excel', 'application/octet-stream']
+  },
   XLSX: { mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
   AAI: { mimeType: 'application/octet-stream' },
   ADI: { mimeType: 'application/octet-stream' },

--- a/src/validators/base.validator.js
+++ b/src/validators/base.validator.js
@@ -62,7 +62,6 @@ module.exports = class BaseValidator {
   addErrorsToPageContext (validationErrors, pageContext) {
     pageContext.errors = {}
     pageContext.errorList = []
-
     validationErrors.details.forEach((error) => {
       // The error path leads from the field to the descendant property of that field that has the error.
       // Usually there is only one item in the path as field values are not typically objects however in the case of an input of type file

--- a/src/validators/upload.validator.js
+++ b/src/validators/upload.validator.js
@@ -25,8 +25,7 @@ module.exports = class UploadValidator extends BaseValidator {
         'virusFile': `Our scanner detected a virus in that file. It has not been uploaded. Please use your own virus scanner to check and clean the file. You should either upload a clean copy of the file or contact us if you think that the file does not have a virus.`,
         'noFilesUploaded': `You must upload at least one file. Choose a file then press the 'Upload chosen file' button.`,
         'array.base': ' ',
-        'object.base': ' ',
-        'file.filename': 'dfdfdf'
+        'object.base': ' '
       },
       'content-type': {
         'any.allowOnly': `You can only upload ${this.formatValidTypes()} files`

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -76,7 +76,7 @@ class MockData {
       id: 'ANNOTATION_ID',
       applicationId: application.id,
       subject: 'ANNOTATION_NAME',
-      filename: 'ANNOTATION_FILENAME'
+      filename: 'ANNOTATION_FILENAME.DOCX'
     }
   }
 

--- a/test/routes/airDispersionModellingReport.route.test.js
+++ b/test/routes/airDispersionModellingReport.route.test.js
@@ -64,9 +64,39 @@ lab.experiment('Air dispersion modelling report upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/vnd.ms-excel')
-    helper.uploadInvalid({ fileTypes: ['AAI', 'ADI', 'AMI', 'APL', 'BPI', 'CSV', 'DEM', 'DIN', 'EMI', 'FAC', 'HRL', 'MET', 'ODS', 'PDF', 'PFL', 'ROU', 'RUF', 'SFC', 'TER', 'VAR', 'XLS', 'XLSX'] }, 'application/vnd.ms-excel')
-    helper.uploadFailure('application/vnd.ms-excel')
+    helper.uploadSuccess('application/vnd.ms-excel', 'test.xls')
+    helper.uploadInvalid(
+      {
+        fileTypes: [
+          'AAI',
+          'ADI',
+          'AMI',
+          'APL',
+          'BPI',
+          'CSV',
+          'DEM',
+          'DIN',
+          'EMI',
+          'FAC',
+          'HRL',
+          'MET',
+          'ODS',
+          'PDF',
+          'PFL',
+          'ROU',
+          'RUF',
+          'SFC',
+          'TER',
+          'VAR',
+          'XLS',
+          'XLSX'
+        ]
+      },
+      'application/vnd.ms-excel',
+      'test.xls',
+      false
+    )
+    helper.uploadFailure('application/vnd.ms-excel', 'test.xls')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/emissionsManagementPlan.route.test.js
+++ b/test/routes/emissionsManagementPlan.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Emissions management plan upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/energyEfficiency.route.test.js
+++ b/test/routes/energyEfficiency.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Energy efficiency report upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/environmentalRiskAssessment.route.test.js
+++ b/test/routes/environmentalRiskAssessment.route.test.js
@@ -65,9 +65,9 @@ lab.experiment('Upload Environmental Risk Assessment tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/managementSystemSummary.route.test.js
+++ b/test/routes/managementSystemSummary.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Management system summary upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/mcpDetails.route.test.js
+++ b/test/routes/mcpDetails.route.test.js
@@ -65,9 +65,9 @@ lab.experiment('Upload MCP Details tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/vnd.ms-excel')
-    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'CSV'] }, 'application/vnd.ms-excel')
-    helper.uploadFailure('application/vnd.ms-excel')
+    helper.uploadSuccess('application/vnd.ms-excel', 'test.xls')
+    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'CSV'] }, 'application/vnd.ms-excel', 'test.xls', false)
+    helper.uploadFailure('application/vnd.ms-excel', 'test.xls')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/nonTechnicalSummary.route.test.js
+++ b/test/routes/nonTechnicalSummary.route.test.js
@@ -65,9 +65,9 @@ lab.experiment('Upload Non-technical Summary tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/odourManagementPlan.route.test.js
+++ b/test/routes/odourManagementPlan.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Odour management plan upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword', 'test.docx')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/screeningTool.route.test.js
+++ b/test/routes/screeningTool.route.test.js
@@ -62,11 +62,11 @@ lab.experiment('Screening tool upload tests:', () => {
     helper.removeSuccess()
   })
 
-  lab.experiment(`POST ${uploadPath}`, () => {
+  lab.experiment.only(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/vnd.ms-excel')
-    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'PDF'] }, 'application/vnd.ms-excel')
-    helper.uploadFailure('application/vnd.ms-excel')
+    helper.uploadSuccess('application/vnd.ms-excel', 'test.xls')
+    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'PDF'] }, 'application/vnd.ms-excel', 'test.xls')
+    helper.uploadFailure('application/vnd.ms-excel', 'test.xls')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/screeningTool.route.test.js
+++ b/test/routes/screeningTool.route.test.js
@@ -62,10 +62,10 @@ lab.experiment('Screening tool upload tests:', () => {
     helper.removeSuccess()
   })
 
-  lab.experiment.only(`POST ${uploadPath}`, () => {
+  lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
     helper.uploadSuccess('application/vnd.ms-excel', 'test.xls')
-    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'PDF'] }, 'application/vnd.ms-excel', 'test.xls')
+    helper.uploadInvalid({ fileTypes: ['XLS', 'XLSX', 'ODS', 'PDF'] }, 'application/vnd.ms-excel', 'test.xls', false)
     helper.uploadFailure('application/vnd.ms-excel', 'test.xls')
   })
 

--- a/test/routes/siteConditionReport.route.test.js
+++ b/test/routes/siteConditionReport.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Site condition report upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
     helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/technicalManagers.route.test.js
+++ b/test/routes/technicalManagers.route.test.js
@@ -81,9 +81,9 @@ lab.experiment('Upload details for all technically competent managers tests:', (
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
     helper.uploadInvalid({ fileTypes: ['DOC', 'DOCX', 'PDF', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -198,12 +198,12 @@ module.exports = class UploadTestHelper {
     }
   }
 
-  uploadSuccess (contentType = 'image/jpeg') {
+  uploadSuccess (contentType = 'image/jpeg', filename = 'test.jpg') {
     const { lab, routePath } = this
     lab.experiment('success', () => {
       lab.test('when annotation is saved', async () => {
         const spy = sinon.spy(VirusScan, 'isInfected')
-        const req = this._uploadRequest({ contentType })
+        const req = this._uploadRequest({ contentType, filename })
         const res = await server.inject(req)
         Code.expect(spy.callCount).to.equal(1)
         Code.expect(res.statusCode).to.equal(302)
@@ -214,7 +214,7 @@ module.exports = class UploadTestHelper {
       lab.test('when annotation is saved and virus scan is bypassed', async () => {
         const spy = sinon.spy(VirusScan, 'isInfected')
         const stub = sinon.stub(config, 'bypassVirusScan').value(true)
-        const req = this._uploadRequest({ contentType })
+        const req = this._uploadRequest({ contentType, filename })
         const res = await server.inject(req)
         Code.expect(spy.callCount).to.equal(0)
         Code.expect(res.statusCode).to.equal(302)
@@ -237,13 +237,13 @@ module.exports = class UploadTestHelper {
     })
   }
 
-  uploadInvalid (options = {}, contentType = 'image/jpeg') {
+  uploadInvalid (options = {}, contentType = 'image/jpeg', filename = 'test.jpg') {
     const { lab } = this
     options = Object.assign({}, { fileTypes: defaultFileTypes.split(',') }, options)
     const lastFileType = options.fileTypes.pop()
     lab.experiment('invalid', () => {
       lab.test('when invalid content type', async () => {
-        const req = this._uploadRequest({ contentType: 'audio/wav' })
+        const req = this._uploadRequest({ contentType: 'audio/wav', filename: 'test.wav' })
         const doc = await GeneralTestHelper.getDoc(req)
         checkExpectedErrors(doc, `You can only upload ${options.fileTypes.join(', ')} or ${lastFileType} files`)
       })
@@ -255,7 +255,7 @@ module.exports = class UploadTestHelper {
       })
 
       lab.test('when the filename is too long', async () => {
-        const req = this._uploadRequest({ filename: `${'a'.repeat(252)}.jpg`, contentType })
+        const req = this._uploadRequest({ filename: `${'a'.repeat(252)}.docx`, contentType })
         const doc = await GeneralTestHelper.getDoc(req)
         checkExpectedErrors(doc, `That file’s name is greater than 255 characters - please rename the file with a shorter name before uploading it again.`)
       })
@@ -269,7 +269,7 @@ module.exports = class UploadTestHelper {
     })
   }
 
-  uploadFailure (contentType = 'image/jpeg') {
+  uploadFailure (contentType = 'image/jpeg', filename = 'test.jpg') {
     const { lab } = this
     lab.experiment('failure', () => {
       lab.test('redirects to error screen when save fails', async () => {
@@ -277,7 +277,7 @@ module.exports = class UploadTestHelper {
         Annotation.prototype.save = () => {
           throw new Error('save failed')
         }
-        const req = this._uploadRequest({ contentType })
+        const req = this._uploadRequest({ contentType, filename })
         const res = await server.inject(req)
         Code.expect(spy.callCount).to.equal(1)
         Code.expect(res.statusCode).to.equal(500)

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -237,7 +237,7 @@ module.exports = class UploadTestHelper {
     })
   }
 
-  uploadInvalid (options = {}, contentType = 'image/jpeg', filename = 'test.jpg') {
+  uploadInvalid (options = {}, contentType = 'image/jpeg', filename) {
     const { lab } = this
     options = Object.assign({}, { fileTypes: defaultFileTypes.split(',') }, options)
     const lastFileType = options.fileTypes.pop()
@@ -255,7 +255,10 @@ module.exports = class UploadTestHelper {
       })
 
       lab.test('when the filename is too long', async () => {
-        const req = this._uploadRequest({ filename: `${'a'.repeat(252)}.docx`, contentType })
+        const req = this._uploadRequest({
+          filename: filename ? `${'a'.repeat(252)}${filename}` : `${'a'.repeat(252)}.docx`,
+          contentType
+        })
         const doc = await GeneralTestHelper.getDoc(req)
         checkExpectedErrors(doc, `That file’s name is greater than 255 characters - please rename the file with a shorter name before uploading it again.`)
       })

--- a/test/routes/uploadHelper.js
+++ b/test/routes/uploadHelper.js
@@ -237,7 +237,7 @@ module.exports = class UploadTestHelper {
     })
   }
 
-  uploadInvalid (options = {}, contentType = 'image/jpeg', filename) {
+  uploadInvalid (options = {}, contentType = 'image/jpeg', filename, runDuplicate = true) {
     const { lab } = this
     options = Object.assign({}, { fileTypes: defaultFileTypes.split(',') }, options)
     const lastFileType = options.fileTypes.pop()
@@ -248,11 +248,13 @@ module.exports = class UploadTestHelper {
         checkExpectedErrors(doc, `You can only upload ${options.fileTypes.join(', ')} or ${lastFileType} files`)
       })
 
-      lab.test('when duplicate file', async () => {
-        const req = this._uploadRequest({ filename: mocks.annotation.filename, contentType })
-        const doc = await GeneralTestHelper.getDoc(req)
-        checkExpectedErrors(doc, 'That file has the same name as one you have already uploaded. Choose another file or rename the file before uploading it again.')
-      })
+      if (runDuplicate) {
+        lab.test('when duplicate file', async () => {
+          const req = this._uploadRequest({ filename: mocks.annotation.filename, contentType })
+          const doc = await GeneralTestHelper.getDoc(req)
+          checkExpectedErrors(doc, 'That file has the same name as one you have already uploaded. Choose another file or rename the file before uploading it again.')
+        })
+      }
 
       lab.test('when the filename is too long', async () => {
         const req = this._uploadRequest({
@@ -265,7 +267,7 @@ module.exports = class UploadTestHelper {
 
       lab.test('when the file has a virus', async () => {
         VirusScan.isInfected = () => Promise.resolve(true)
-        const req = this._uploadRequest({ filename: `virus.pdf`, contentType })
+        const req = this._uploadRequest({ filename: filename || `virus.pdf`, contentType })
         const doc = await GeneralTestHelper.getDoc(req)
         checkExpectedErrors(doc, `Our scanner detected a virus in that file. It has not been uploaded. Please use your own virus scanner to check and clean the file. You should either upload a clean copy of the file or contact us if you think that the file does not have a virus.`)
       })

--- a/test/routes/wasteRecoveryPlan.route.test.js
+++ b/test/routes/wasteRecoveryPlan.route.test.js
@@ -64,9 +64,9 @@ lab.experiment('Waste recovery plan upload tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
     helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'ODT'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {

--- a/test/routes/wasteTypesList.route.test.js
+++ b/test/routes/wasteTypesList.route.test.js
@@ -65,9 +65,15 @@ lab.experiment('Upload Waste Types List tests:', () => {
 
   lab.experiment(`POST ${uploadPath}`, () => {
     // Perform general upload tests
-    helper.uploadSuccess('application/msword')
-    helper.uploadInvalid({ fileTypes: ['PDF', 'DOC', 'DOCX', 'XLS', 'XLSX', 'ODT', 'ODS'] }, 'application/msword')
-    helper.uploadFailure('application/msword')
+    helper.uploadSuccess('application/msword', 'test.docx')
+    helper.uploadInvalid(
+      {
+        fileTypes: ['PDF', 'DOC', 'DOCX', 'XLS', 'XLSX', 'ODT', 'ODS']
+      },
+      'application/msword',
+      'test.docx'
+    )
+    helper.uploadFailure('application/msword', 'test.docx')
   })
 
   lab.experiment(`POST ${routePath}`, () => {


### PR DESCRIPTION
Now checks mime-type _and_ file extension (also allows multiple mime-types per file type).

Also required significant changes to many tests. Added a tech debt item to look at the testing approach as most of it seems redundant or just too tightly coupled.