### PR TITLE
Change &mdash; to &#8212; to prevent xmldom errors

### DIFF
--- a/src/views/wasteDisposalCodes.html
+++ b/src/views/wasteDisposalCodes.html
@@ -34,7 +34,7 @@
             <div class="multiple-choice">
               <input id="code-{{this.id}}-input" type="checkbox" name="code" value="{{this.id}}" {{#if this.selected}}checked="checked"{{/if}}>
               <label id="code-{{this.id}}-label" for="code-{{this.id}}-input">
-                <span id="code-{{this.id}}-text">{{this.code}} &mdash; {{this.description}}</span>
+                <span id="code-{{this.id}}-text">{{this.code}} &#8212; {{this.description}}</span>
               </label>
             </div>
             {{/each}}

--- a/src/views/wasteRecoveryCodes.html
+++ b/src/views/wasteRecoveryCodes.html
@@ -34,7 +34,7 @@
             <div class="multiple-choice">
               <input id="code-{{this.id}}-input" type="checkbox" name="code" value="{{this.id}}" {{#if this.selected}}checked="checked"{{/if}}>
               <label id="code-{{this.id}}-label" for="code-{{this.id}}-input">
-                <span id="code-{{this.id}}-text">{{this.code}} &mdash; {{this.description}}</span>
+                <span id="code-{{this.id}}-text">{{this.code}} &#8212; {{this.description}}</span>
               </label>
             </div>
             {{/each}}


### PR DESCRIPTION
This stops `[xmldom error]   entity not found:&mdash;` errors appearing when running the tests.