### PR TITLE
WE-2914: Fix tasklist not showing complete

### DIFF
--- a/src/controllers/clinicalWasteDocuments/storeTreat.controller.js
+++ b/src/controllers/clinicalWasteDocuments/storeTreat.controller.js
@@ -2,7 +2,7 @@
 
 const BaseController = require('../base.controller')
 const RecoveryService = require('../../services/recovery.service')
-const StoreTreatModel = require('../../models/clinicalWasteDocuments/storeTreat.model')
+const StoreTreatModel = require('../../models/storeTreat.model')
 
 const {
   CLINICAL_WASTE_DOCUMENTS_JUSTIFICATION_UPLOAD,

--- a/src/models/storeTreat.model.js
+++ b/src/models/storeTreat.model.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const ApplicationAnswer = require('../../persistence/entities/applicationAnswer.entity')
+const ApplicationAnswer = require('../persistence/entities/applicationAnswer.entity')
 
-const { CLINICAL_WASTE_DOCUMENTS } = require('../../dynamics').ApplicationQuestions
+const { CLINICAL_WASTE_DOCUMENTS } = require('../dynamics').ApplicationQuestions
 const { STORE_TREAT } = CLINICAL_WASTE_DOCUMENTS
 
 const YES = 'yes'

--- a/src/models/taskList/clinicalWasteAppendix.task.js
+++ b/src/models/taskList/clinicalWasteAppendix.task.js
@@ -9,14 +9,13 @@ const {
 
 const BaseTask = require('./base.task')
 const Annotation = require('../../persistence/entities/annotation.entity')
-const StoreTreat = require('../../models/clinicalWasteDocuments/storeTreat.model')
+const StoreTreat = require('../storeTreat.model')
 
 module.exports = class ClinicalWasteAppendix extends BaseTask {
   static async checkComplete (context) {
     const { storeTreat: justificationRequired } = await StoreTreat.get(context)
 
     if (justificationRequired === undefined) {
-      console.log('justificationRequired undefined')
       return false
     }
 

--- a/src/models/taskList/clinicalWasteAppendix.task.js
+++ b/src/models/taskList/clinicalWasteAppendix.task.js
@@ -9,11 +9,20 @@ const {
 
 const BaseTask = require('./base.task')
 const Annotation = require('../../persistence/entities/annotation.entity')
+const StoreTreat = require('../../models/clinicalWasteDocuments/storeTreat.model')
 
 module.exports = class ClinicalWasteAppendix extends BaseTask {
   static async checkComplete (context) {
+    const { storeTreat: justificationRequired } = await StoreTreat.get(context)
+
+    if (justificationRequired === undefined) {
+      console.log('justificationRequired undefined')
+      return false
+    }
+
     const clinicalWasteJustification = await Annotation.listByApplicationIdAndSubject(context, CLINICAL_WASTE_JUSTIFICATION)
-    if (!clinicalWasteJustification.length) {
+
+    if (justificationRequired && !clinicalWasteJustification.length) {
       return false
     }
 
@@ -26,6 +35,7 @@ module.exports = class ClinicalWasteAppendix extends BaseTask {
     if (!clinicalWasteLayoutPlans.length) {
       return false
     }
+
     return true
   }
 }

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -30,7 +30,7 @@ const NeedToConsult = require('../../src/models/needToConsult.model')
 const AirQualityManagementArea = require('../../src/models/airQualityManagementArea.model')
 const OperatingUnder500Hours = require('../../src/models/operatingUnder500Hours.model')
 
-const StoreTreat = require('../../src/models/clinicalWasteDocuments/storeTreat.model')
+const StoreTreat = require('../../src/models/storeTreat.model')
 
 // ************* Data used by exported mocks ************* //
 class MockData {

--- a/test/models/storeTreat.model.test.js
+++ b/test/models/storeTreat.model.test.js
@@ -4,16 +4,16 @@ const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const Code = require('@hapi/code')
 const sinon = require('sinon')
-const Mocks = require('../../helpers/mocks')
+const Mocks = require('../helpers/mocks')
 
-const ApplicationAnswer = require('../../../src/persistence/entities/applicationAnswer.entity')
+const ApplicationAnswer = require('../../src/persistence/entities/applicationAnswer.entity')
 
 const context = { }
 
 const YES = 'yes'
 const NO = 'no'
 
-const TestModel = require('../../../src/models/clinicalWasteDocuments/storeTreat.model')
+const TestModel = require('../../src/models/storeTreat.model')
 const questionCode = 'clinical-waste-store-treat'
 const testItem = 'storeTreat'
 

--- a/test/models/taskList/clinicalWasteAppendix.task.test.js
+++ b/test/models/taskList/clinicalWasteAppendix.task.test.js
@@ -4,19 +4,25 @@ const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const Code = require('@hapi/code')
 const sinon = require('sinon')
+const Mocks = require('../../helpers/mocks')
 
 const Annotation = require('../../../src/persistence/entities/annotation.entity')
 const ClinicalWasteAppendix = require('../../../src/models/taskList/clinicalWasteAppendix.task')
+const StoreTreatModel = require('../../../src/models/clinicalWasteDocuments/storeTreat.model')
 
 let sandbox
+let mocks
 let listAnnotationsStub
 
 lab.beforeEach(() => {
+  mocks = new Mocks()
+
   // Create a sinon sandbox
   sandbox = sinon.createSandbox()
 
   // Stub the asynchronous model methods
   listAnnotationsStub = sandbox.stub(Annotation, 'listByApplicationIdAndSubject')
+  sandbox.stub(StoreTreatModel, 'get').callsFake(async () => mocks.storeTreat)
   listAnnotationsStub.resolves([{}])
 })
 
@@ -26,25 +32,42 @@ lab.afterEach(() => {
 })
 
 lab.experiment('Task List: ClinicalWasteAppendix Model tests:', () => {
-  lab.test('checkComplete() method correctly returns FALSE when no justification provided', async () => {
+  lab.test('checkComplete() method correctly returns FALSE when justifcation question is not answered', async () => {
+    mocks.storeTreat.storeTreat = undefined
+    const result = await ClinicalWasteAppendix.checkComplete(mocks.context)
+    Code.expect(result).to.equal(false)
+  })
+
+  lab.test('checkComplete() method correctly returns FALSE when justification needed and not provided', async () => {
+    mocks.storeTreat.storeTreat = true
     listAnnotationsStub.withArgs({}, 'clinical waste non-standard justification').resolves([])
     const result = await ClinicalWasteAppendix.checkComplete({})
     Code.expect(result).to.equal(false)
   })
 
   lab.test('checkComplete() method correctly returns FALSE when no treatment summary provided', async () => {
+    mocks.storeTreat.storeTreat = false
     listAnnotationsStub.withArgs({}, 'clinical waste treatment summary').resolves([])
     const result = await ClinicalWasteAppendix.checkComplete({})
     Code.expect(result).to.equal(false)
   })
 
   lab.test('checkComplete() method correctly returns FALSE when no layout plan provided', async () => {
+    mocks.storeTreat.storeTreat = false
     listAnnotationsStub.withArgs({}, 'clinical waste layout plans and process flows').resolves([])
     const result = await ClinicalWasteAppendix.checkComplete({})
     Code.expect(result).to.equal(false)
   })
 
+  lab.test('checkComplete() method correctly returns TRUE when all uploads provided, except justification when not required', async () => {
+    mocks.storeTreat.storeTreat = false
+    listAnnotationsStub.withArgs({}, 'clinical waste non-standard justification').resolves([])
+    const result = await ClinicalWasteAppendix.checkComplete({})
+    Code.expect(result).to.equal(true)
+  })
+
   lab.test('checkComplete() method correctly returns TRUE when all uploads provided', async () => {
+    mocks.storeTreat.storeTreat = true
     const result = await ClinicalWasteAppendix.checkComplete({})
     Code.expect(result).to.equal(true)
   })

--- a/test/models/taskList/clinicalWasteAppendix.task.test.js
+++ b/test/models/taskList/clinicalWasteAppendix.task.test.js
@@ -8,7 +8,7 @@ const Mocks = require('../../helpers/mocks')
 
 const Annotation = require('../../../src/persistence/entities/annotation.entity')
 const ClinicalWasteAppendix = require('../../../src/models/taskList/clinicalWasteAppendix.task')
-const StoreTreatModel = require('../../../src/models/clinicalWasteDocuments/storeTreat.model')
+const StoreTreatModel = require('../../../src/models/storeTreat.model')
 
 let sandbox
 let mocks

--- a/test/routes/clinicalWasteDocuments/storeTreat.route.test.js
+++ b/test/routes/clinicalWasteDocuments/storeTreat.route.test.js
@@ -15,7 +15,7 @@ const RecoveryService = require('../../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../../src/constants')
 const TaskDeterminants = require('../../../src/models/taskDeterminants.model')
 
-const StoreTreat = require('../../../src/models/clinicalWasteDocuments/storeTreat.model')
+const StoreTreat = require('../../../src/models/storeTreat.model')
 
 const routePath = '/clinical-waste-documents/store-treat-waste-type'
 const yesRoutePath = '/clinical-waste-documents/justification/upload'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-2914

The tasklist was just looking at whether all documents were uploaded when reporting it as complete, without taking into account whether a justification document was required. So if the applicant didn't upload one because it wasn't necessary, the task was incorrectly showing as not completed in the tasklist.

I also moved storeTreat.model out of the clinicalWasteDocuments folder and removed it -- I originally created the folder in anticipation of needing multiple models for this feature and wanting to keep them organised in their own folder, but as it turned out only one model was needed.