### PR TITLE
WE-3141: Climate change task is correctly displayed in tasklist

### DIFF
--- a/src/models/taskList/bespoke.taskList.js
+++ b/src/models/taskList/bespoke.taskList.js
@@ -1,6 +1,7 @@
 const { bespoke,
   tasks: {
     WASTE_WEIGHTS: { shortName: wasteWeightsShortName },
+    CLIMATE_CHANGE_RISK_SCREENING: { shortName: climateChangeRiskScreeningShortName },
     CLINICAL_WASTE_APPENDIX: { shortName: clinicalWasteShortName },
     MANAGE_HAZARDOUS_WASTE: { shortName: hazardousWasteShortName }
   }
@@ -30,6 +31,7 @@ module.exports = class BespokeTaskList extends BaseTaskList {
     if (acceptsClinicalWaste) { taskNames.push(clinicalWasteShortName) }
     if (acceptsHazardousWaste) { taskNames.push(hazardousWasteShortName) }
 
+    taskNames.push(climateChangeRiskScreeningShortName)
     taskNames.push(wasteWeightsShortName)
 
     return task.required || (task.route && taskNames.includes(task.shortName))


### PR DESCRIPTION
A last-minute change I made to the task shortname stopped the climate change risk screening task from showing up in the tasklist. This change adds it to the tasklist in the same way as waste weights.