### PR TITLE
WE-3232: Add note to Add activity screen that activities could be installations

### DIFF
--- a/src/controllers/wasteActivity.controller.js
+++ b/src/controllers/wasteActivity.controller.js
@@ -5,9 +5,6 @@ const RecoveryService = require('../services/recovery.service')
 const WasteActivities = require('../models/wasteActivities.model')
 const ItemEntity = require('../persistence/entities/item.entity')
 const Routes = require('../routes')
-const couldBeInstallations = {
-  '1-16-9': true
-}
 
 module.exports = class WasteActivityController extends BaseController {
   async doGet (request, h, errors) {
@@ -24,7 +21,7 @@ module.exports = class WasteActivityController extends BaseController {
 
     pageContext.activities = onlyOnlineWasteActivitiesForFacilityTypes
       .sort((a, b) => (a.itemName > b.itemName) ? 1 : ((b.itemName > a.itemName) ? -1 : 0))
-      .map(({ shortName, itemName }) => ({ id: shortName, text: itemName, couldBeAnInstallation: couldBeInstallations[shortName] }))
+      .map(({ shortName, itemName }) => ({ id: shortName, text: itemName }))
 
     pageContext.previousLink = Routes[this.route.previousRoute].path
 

--- a/src/views/wasteActivity.html
+++ b/src/views/wasteActivity.html
@@ -12,8 +12,13 @@
       {{> common/pageHeading pageHeading }}
 
       <p>
-        These activities are for waste operations.
-        <a id="change-facility" href="{{previousLink}}">Change facility type</a>.
+        The below activities are for waste operations.
+        Any of these activities could also be an installation.
+        To check you’re applying for the correct type of permit,
+        <a id="activity-{{this.id}}-link" target="_blank" rel="noopener noreferrer"
+          href="https://www.gov.uk/guidance/check-if-you-need-an-environmental-permit#what-you-need-a-permit-for">
+          read the guidance on installations (opens new tab)
+        </a>
       </p>
 
       <form id="form" method="POST" action="{{formAction}}" novalidate="novalidate">
@@ -29,15 +34,6 @@
               <input id="activity-{{this.id}}-input" type="radio" name="activity" value="{{this.id}}" {{#if this.isSelected}}checked="checked"{{/if}}>
               <label id="activity-{{this.id}}-label" for="activity-{{this.id}}-input" class="selection-button-radio">
                 <span id="activity-{{this.id}}-text">{{this.text}}</span>
-                {{#if this.couldBeAnInstallation}}
-                  <span id="activity-{{this.id}}-hint" class="panel panel-border-narrow js-hidden">
-                    This activity could be an installation. To check you’re applying for the correct type of permit,
-                    <a id="activity-{{this.id}}-link" target="_blank" rel="noopener noreferrer"
-                       href="https://www.gov.uk/guidance/check-if-you-need-an-environmental-permit#what-you-need-a-permit-for">
-                      read the guidance on installations (opens new tab)
-                    </a>
-                  </span>
-                {{/if}}
               </label>
             </div>
             {{/each}}
@@ -46,7 +42,7 @@
         </fieldset>
 
         <div class="form-group">
-          <p><span id="helpline-text">Not sure? Call our helpline on</span> <a id="helpline-number" href="tel:+443708506506">03708 506 506.</a></p>
+          <p><a id="change-facility" href="{{previousLink}}">Change facility type</a>.</p>
         </div>
 
         {{> common/submitButton }}

--- a/test/routes/wasteActivity.controller.test.js
+++ b/test/routes/wasteActivity.controller.test.js
@@ -81,13 +81,6 @@ lab.experiment('Waste activity controller tests:', () => {
       // Code.expect(pageContext.activities.length).to.equal(3)
       Code.expect(pageContext.activities.length).to.equal(4)
     })
-
-    lab.test('GET supplies correct installation flags to view', async () => {
-      await controller.doGet()
-      const activities = showViewSpy.args[0][0].pageContext.activities
-      const flaggedAsCouldBeAnInstallation = activities.filter(({ couldBeAnInstallation }) => couldBeAnInstallation)
-      Code.expect(flaggedAsCouldBeAnInstallation.length).to.equal(1)
-    })
   })
 
   lab.experiment('POST:', () => {
@@ -97,7 +90,7 @@ lab.experiment('Waste activity controller tests:', () => {
     let request
     lab.beforeEach(() => {
       request = { payload: { activity: 'FAKE_ACTIVITY_ID' } }
-      sandbox.stub(WasteActivities, 'get').resolves(new WasteActivities(fakeActivities,[]))
+      sandbox.stub(WasteActivities, 'get').resolves(new WasteActivities(fakeActivities, []))
       redirectSpy = sandbox.stub(Controller.prototype, 'redirect')
       addWasteActivitySpy = sandbox.stub(WasteActivities.prototype, 'addWasteActivity')
       saveWasteActivitySpy = sandbox.stub(WasteActivities.prototype, 'save')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-3232

Amended view to reflect the wireframe, so that information is always displayed rather than only displayed when certain activities selected. This means the couldBeAnInstallation flag is no longer needed so this has been removed.