### PR TITLE
WE-3335: Amend Confirm Activities screen for multiple activities

### DIFF
--- a/src/controllers/confirmCost.controller.js
+++ b/src/controllers/confirmCost.controller.js
@@ -12,7 +12,10 @@ module.exports = class ConfirmCostController extends BaseController {
     const context = await RecoveryService.createApplicationContext(h)
     const { taskDeterminants: { facilityType } } = context
 
-    pageContext.calculatedCosts = await ApplicationCost.getApplicationCostForApplicationId(context)
+    const calculatedCosts = await ApplicationCost.getApplicationCostForApplicationId(context)
+
+    pageContext.calculatedCosts = calculatedCosts
+    pageContext.includesMultipleActivities = calculatedCosts.includesMultipleActivities
 
     if (facilityType !== MCP) {
       pageContext.wasteActivitiesLink = WASTE_ACTIVITY_CONTINUE.path

--- a/src/dynamics.js
+++ b/src/dynamics.js
@@ -55,6 +55,10 @@ const Dynamics = {
       NAME: 'Postholder contact details'
     }
   },
+  DiscountTypes: {
+    DUPLICATE_ACTIVITY: 910400000,
+    MULTIPLE_ACTIVITY: 910400001
+  },
   ApplicationQuestions: {
     AQMA: {
       IS_IN_AQMA: {

--- a/src/models/applicationCost.model.js
+++ b/src/models/applicationCost.model.js
@@ -21,6 +21,12 @@ module.exports = class ApplicationCost {
     return this.totalCostItem
   }
 
+  get includesMultipleActivities () {
+    return this.items
+      .map(item => item.isMultipleActivity)
+      .includes(true)
+  }
+
   static async getApplicationCostForApplicationId (entityContextToUse) {
     const { applicationId } = entityContextToUse
 
@@ -67,7 +73,8 @@ module.exports = class ApplicationCost {
       const description = line.lineName
       const cost = line.value
       const displayOrder = line.displayOrder
-      return new ApplicationCostItem({ description, cost, displayOrder })
+      const discountType = line.discountType
+      return new ApplicationCostItem({ description, cost, displayOrder, discountType })
     })
     const wasteAssessmentApplicationCostItems = wasteAssessmentLineEntities.map((line) => {
       const wasteAssessment = wasteAssessmentItemEntities.find(({ id }) => id === line.itemId)

--- a/src/models/applicationCostItem.model.js
+++ b/src/models/applicationCostItem.model.js
@@ -1,12 +1,19 @@
 'use strict'
 
+const { MULTIPLE_ACTIVITY } = require('../dynamics').DiscountTypes
+
 module.exports = class ApplicationCostItem {
-  constructor ({ wasteActivity, wasteAssessment, description, cost, displayOrder }) {
+  constructor ({ wasteActivity, wasteAssessment, description, cost, displayOrder, discountType }) {
     this.wasteActivity = wasteActivity
     this.wasteAssessment = wasteAssessment
     this.description = description
     this.cost = cost
     this.displayOrder = displayOrder
+    this.discountType = discountType
+  }
+
+  get isMultipleActivity () {
+    return this.discountType === MULTIPLE_ACTIVITY
   }
 
   get costValue () {

--- a/src/persistence/entities/applicationLine.entity.js
+++ b/src/persistence/entities/applicationLine.entity.js
@@ -11,7 +11,8 @@ const mapping = [
   { field: 'value', dynamics: 'defra_value', readOnly: true },
   { field: 'permitType', dynamics: 'defra_permittype' },
   { field: 'lineName', dynamics: 'defra_name' },
-  { field: 'displayOrder', dynamics: 'defra_displayorder' }
+  { field: 'displayOrder', dynamics: 'defra_displayorder' },
+  { field: 'discountType', dynamics: 'defra_discounttype' }
 ]
 
 const queryFieldNames = mapping.map(({ field, dynamics, bind }) => {

--- a/src/views/confirmCost.html
+++ b/src/views/confirmCost.html
@@ -40,19 +40,19 @@
         You do not pay VAT on these costs.
       </p>
 
-      <p>
-        We automatically apply discounts for additional activities, because we assume they’re reasonably associated.
-      </p>
-
-      <p>
-        We will validate these discounts during the duly making process and will charge 100% for any activity we find is not reasonably associated. 
-      </p>
+      {{#if includesMultipleActivities}}
+      <div id="multiple-activity-text">
+        <p>
+          Discounts for multiple activities are based on the assumption that it is reasonably associated to the first activity.
+          Should we deem that it isn’t reasonably associated, then we will charge 100% of the base fee.
+        </p>
+      </div>
+      {{/if}}
 
       <p>
         You can find out more about our charges in the 
         <a id="charges-guidance" rel="noopener noreferrer" href="https://www.gov.uk/government/publications/environmental-permitting-charges-guidance">
-          Environmental permitting charges guidance (opens new tab)
-        </a>.
+          Environmental permitting charges guidance (opens new tab)</a>.
       </p>
 
       {{#if wasteActivitiesLink}}

--- a/test/models/applicationCost.model.test.js
+++ b/test/models/applicationCost.model.test.js
@@ -15,7 +15,7 @@ const context = { }
 const ACTIVITY_ITEM_TYPE_ID = 'ACTIVITY_ITEM_TYPE_ID'
 const ASSESSMENT_ITEM_TYPE_ID = 'ASSESSMENT_ITEM_TYPE_ID'
 
-const { PERMIT_HOLDER_TYPES: DYNAMICS_PERMIT_HOLDER_TYPES } = require('../../src/dynamics')
+const { PERMIT_HOLDER_TYPES: DYNAMICS_PERMIT_HOLDER_TYPES, DiscountTypes } = require('../../src/dynamics')
 
 const ITEMS = {
   wasteActivities: [{
@@ -204,6 +204,25 @@ lab.experiment('Application Cost Model test:', () => {
         .getApplicationCostForApplicationId(context, fakeApplicationEntity.id)
       const allDescriptionText = applicationCost.items.map(({ description }) => description)
       Code.expect(allDescriptionText).to.equal(DESCRIPTION_TEXT)
+      Code.expect(spy.callCount).to.equal(2)
+    })
+    lab.test('includesMultipleActivities returns true if there is a multiple activity', async () => {
+      const spy = sinon.spy(dynamicsDal, 'callAction')
+      fakeApplicationLineEntities[0].discountType = DiscountTypes.MULTIPLE_ACTIVITY
+
+      const applicationCost = await ApplicationCostModel
+        .getApplicationCostForApplicationId(context, fakeApplicationEntity.id)
+
+      Code.expect(applicationCost.includesMultipleActivities).to.equal(true)
+      Code.expect(spy.callCount).to.equal(2)
+    })
+    lab.test('includesMultipleActivities returns false if there are no multiple activities', async () => {
+      const spy = sinon.spy(dynamicsDal, 'callAction')
+
+      const applicationCost = await ApplicationCostModel
+        .getApplicationCostForApplicationId(context, fakeApplicationEntity.id)
+
+      Code.expect(applicationCost.includesMultipleActivities).to.equal(false)
       Code.expect(spy.callCount).to.equal(2)
     })
   })

--- a/test/routes/confirmCost.route.test.js
+++ b/test/routes/confirmCost.route.test.js
@@ -10,6 +10,7 @@ const Mocks = require('../helpers/mocks')
 const CookieService = require('../../src/services/cookie.service')
 const RecoveryService = require('../../src/services/recovery.service')
 const { COOKIE_RESULT } = require('../../src/constants')
+const { DiscountTypes } = require('../../src/dynamics')
 
 const ApplicationCost = require('../../src/models/applicationCost.model')
 
@@ -65,6 +66,22 @@ lab.experiment('Triage confirm costs page tests:', () => {
       const doc = await GeneralTestHelper.getDoc(getRequest)
       Code.expect(doc.getElementById('change-waste-activities')).to.exist()
       Code.expect(doc.getElementById('change-waste-activities').getAttribute('href')).to.equal(expectedWasteActivitiesPath)
+    })
+
+    lab.experiment('GET displays correct multiple activity text', () => {
+      lab.test('displayed when there are multiple activities', async () => {
+        mocks.applicationCostModel.items[0].discountType = DiscountTypes.MULTIPLE_ACTIVITY
+
+        const doc = await GeneralTestHelper.getDoc(getRequest)
+
+        Code.expect(doc.getElementById('multiple-activity-text')).to.exist()
+      })
+
+      lab.test('not displayed when there are no multiple activities', async () => {
+        const doc = await GeneralTestHelper.getDoc(getRequest)
+
+        Code.expect(doc.getElementById('multiple-activity-text')).to.not.exist()
+      })
     })
 
     lab.experiment('GET displays the correct costs', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-3335

- Adds conditionality to the Confirm Activities screen so that the relevant "Discounts for multiple activities..." text is only displayed when the application includes multiple activities.
- Updates content as per design document.