### PR TITLE
WE-3435: Display waste bespoke activities in check your answers

### DIFF
--- a/src/controllers/taskList.controller.js
+++ b/src/controllers/taskList.controller.js
@@ -48,7 +48,7 @@ module.exports = class TaskListController extends BaseController {
         pageContext.isWaste = true
         pageContext.activitiesNumberText = wasteActivities.textForNumberOfWasteActivities
         if (wasteActivities.wasteActivitiesLength) {
-          pageContext.activities = wasteActivities.wasteActivitiesValues
+          pageContext.activities = wasteActivities.wasteActivityNames
         }
         pageContext.assessmentsNumberText = (wasteAssessments.length || 'no') +
           ' assessment' +

--- a/src/models/checkList/base.check.js
+++ b/src/models/checkList/base.check.js
@@ -18,6 +18,7 @@ const WasteWeights = require('../wasteWeights.model')
 const ClimateChangeRiskScreening = require('../climateChangeRiskScreening.model')
 const PreApplication = require('../preApplication.model')
 const WasteTreatmentCapacity = require('../wasteTreatmentCapacity.model')
+const WasteActivities = require('../wasteActivities.model')
 
 const {
   BILLING_INVOICING,
@@ -279,5 +280,13 @@ module.exports = class BaseCheck {
       this.data.wasteTreatmentCapacity = await WasteTreatmentCapacity.listAllAnswers(this.data)
     }
     return this.data.wasteTreatmentCapacity || []
+  }
+
+  async getWasteActivities () {
+    const { wasteActivities } = this.data
+    if (!wasteActivities) {
+      this.data.wasteActivities = await WasteActivities.get(this.data)
+    }
+    return this.data.wasteActivities || []
   }
 }

--- a/src/models/checkList/checkList.js
+++ b/src/models/checkList/checkList.js
@@ -1,8 +1,8 @@
 
 const BaseTaskList = require('../taskList/base.taskList')
 
-const PermitCheck = require('./permit.check')
-const McpBespokeTypeCheck = require('./mcpBespokeType.check')
+const StandardRulesPermitCheck = require('./standardRulesPermit.check')
+const McpBespokePermitCheck = require('./mcpBespokePermit.check')
 const DrainageCheck = require('./drainage.check')
 const SiteCheck = require('./site.check')
 const SitePlanCheck = require('./sitePlan.check')
@@ -38,9 +38,23 @@ const OdourManagementPlanCheck = require('./odourManagementPlan.check')
 const EmissionsManagementPlanCheck = require('./emissionsManagementPlan.check')
 const SiteConditionReportCheck = require('./siteConditionReport.check')
 const TechnicalStandardsCheck = require('./technicalStandards.check')
-const BespokePermitCheck = require('./bespokePermit.check')
+const WasteBespokePermitCheck = require('./wasteBespokePermit.check')
+const WasteActivitesCheck = require('./wasteActivities.check')
 const PreApplicationCheck = require('./preApplication.check')
 const WasteTreatmentCapacityCheck = require('./wasteTreatmentCapacity.check')
+
+const STANDARD_RULES_CHECKS = [
+  'PermitCheck'
+]
+
+const MCP_BESPOKE_CHECKS = [
+  'McpBespokePermitCheck'
+]
+
+const BESPOKE_CHECKS = [
+  'WasteBespokePermitCheck',
+  'WasteActivitiesCheck'
+]
 
 module.exports = class CheckList {
   constructor () {
@@ -51,7 +65,7 @@ module.exports = class CheckList {
       DrainageCheck,
       ContactCheck,
       PermitHolderCheck,
-      PermitCheck,
+      StandardRulesPermitCheck,
       ConfidentialityCheck,
       InvoiceCheck,
       NeedToConsult,
@@ -60,8 +74,9 @@ module.exports = class CheckList {
       AirQualityManagementAreaCheck,
       SiteConditionReportCheck,
       NonTechnicalSummaryCheck,
-      McpBespokeTypeCheck,
-      BespokePermitCheck,
+      McpBespokePermitCheck,
+      WasteBespokePermitCheck,
+      WasteActivitesCheck,
       McpDetailsCheck,
       McpBusinessActivityCheck,
       MiningWasteCheck,
@@ -100,9 +115,9 @@ module.exports = class CheckList {
 
     // Only include the permit/MCP bespoke type check and those checks that are available for this application
     const availableFlags = await Promise.all(this.Checks.map((Check) => {
-      return (TaskList.isStandardRules && Check.name === 'PermitCheck') ||
-      (TaskList.isMcpBespoke && Check.name === 'McpBespokeTypeCheck') ||
-      (TaskList.isBespoke && Check.name === 'BespokePermitCheck') ||
+      return (TaskList.isStandardRules && STANDARD_RULES_CHECKS.includes(Check.name)) ||
+      (TaskList.isMcpBespoke && MCP_BESPOKE_CHECKS.includes(Check.name)) ||
+      (TaskList.isBespoke && BESPOKE_CHECKS.includes(Check.name)) ||
       taskList.isAvailable(Check.task)
     }))
     const availableChecks = this.Checks.filter((Check, index) => availableFlags[index])

--- a/src/models/checkList/mcpBespokePermit.check.js
+++ b/src/models/checkList/mcpBespokePermit.check.js
@@ -2,16 +2,16 @@ const BaseCheck = require('./base.check')
 
 const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
 
-module.exports = class McpBespokeTypeCheck extends BaseCheck {
+module.exports = class McpBespokePermitCheck extends BaseCheck {
   get prefix () {
     return `${super.prefix}-permit`
   }
 
   async buildLines () {
-    return [await this.getMcpBespokeTypeLine()]
+    return [await this.getMcpBespokePermitLine()]
   }
 
-  async getMcpBespokeTypeLine () {
+  async getMcpBespokePermitLine () {
     const mcpType = await this.getMcpType()
 
     return this.buildLine({

--- a/src/models/checkList/standardRulesPermit.check.js
+++ b/src/models/checkList/standardRulesPermit.check.js
@@ -2,19 +2,20 @@ const BaseCheck = require('./base.check')
 
 const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
 
-module.exports = class BespokePermitCheck extends BaseCheck {
+module.exports = class StandardRulesPermitCheck extends BaseCheck {
   get prefix () {
     return `${super.prefix}-permit`
   }
 
   async buildLines () {
-    return [await this.getBespokeTypeLine()]
+    return [await this.getPermitLine()]
   }
 
-  async getBespokeTypeLine () {
+  async getPermitLine () {
+    const { code = '', permitName = '' } = await this.getStandardRule()
     return this.buildLine({
       heading: 'Permit',
-      answers: ['Bespoke environmental permit'],
+      answers: [`${permitName} ${code}`],
       links: [{ path, type: 'contact details' }]
     })
   }

--- a/src/models/checkList/wasteActivities.check.js
+++ b/src/models/checkList/wasteActivities.check.js
@@ -1,0 +1,23 @@
+const BaseCheck = require('./base.check')
+
+const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
+
+module.exports = class WasteActivitiesCheck extends BaseCheck {
+  get prefix () {
+    return `${super.prefix}-activity`
+  }
+
+  async buildLines () {
+    return [await this.getWasteActivitiesLine()]
+  }
+
+  async getWasteActivitiesLine () {
+    const wasteActivities = await this.getWasteActivities()
+
+    return this.buildLine({
+      heading: 'Activities',
+      answers: wasteActivities.wasteActivityNames,
+      links: [{ path, type: 'waste activities' }]
+    })
+  }
+}

--- a/src/models/checkList/wasteActivities.check.js
+++ b/src/models/checkList/wasteActivities.check.js
@@ -1,6 +1,6 @@
 const BaseCheck = require('./base.check')
 
-const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
+const { path } = require('../../routes').WASTE_ACTIVITY_CONTINUE
 
 module.exports = class WasteActivitiesCheck extends BaseCheck {
   get prefix () {

--- a/src/models/checkList/wasteBespokePermit.check.js
+++ b/src/models/checkList/wasteBespokePermit.check.js
@@ -2,20 +2,19 @@ const BaseCheck = require('./base.check')
 
 const { path } = require('../../routes').BESPOKE_OR_STANDARD_RULES
 
-module.exports = class PermitCheck extends BaseCheck {
+module.exports = class WasteBespokePermitCheck extends BaseCheck {
   get prefix () {
     return `${super.prefix}-permit`
   }
 
   async buildLines () {
-    return [await this.getPermitLine()]
+    return [await this.getBespokeTypeLine()]
   }
 
-  async getPermitLine () {
-    const { code = '', permitName = '' } = await this.getStandardRule()
+  async getBespokeTypeLine () {
     return this.buildLine({
       heading: 'Permit',
-      answers: [`${permitName} ${code}`],
+      answers: ['Bespoke environmental permit'],
       links: [{ path, type: 'contact details' }]
     })
   }

--- a/src/models/checkList/wasteBespokePermit.check.js
+++ b/src/models/checkList/wasteBespokePermit.check.js
@@ -15,7 +15,7 @@ module.exports = class WasteBespokePermitCheck extends BaseCheck {
     return this.buildLine({
       heading: 'Permit',
       answers: ['Bespoke environmental permit'],
-      links: [{ path, type: 'contact details' }]
+      links: [{ path, type: 'bespoke environmental permit' }]
     })
   }
 }

--- a/src/models/wasteActivities.model.js
+++ b/src/models/wasteActivities.model.js
@@ -93,6 +93,15 @@ module.exports = class WasteActivities {
     return selectedWasteActivity
   }
 
+  // Provides activity name in required format
+  // Reference name of an activity is included if there is one
+  // Note that the – is an en-dash
+  formattedActivityName (activity) {
+    console.log(activity)
+    const { item, referenceName } = activity
+    return referenceName ? `${item.itemName} – ${referenceName}` : item.itemName
+  }
+
   // Data in a form suitable for persisting
   get wasteActivitiesData () {
     return this.selectedWasteActivities.map(({ id, referenceName }) => ({ id, referenceName }))
@@ -102,6 +111,11 @@ module.exports = class WasteActivities {
   get wasteActivitiesValues () {
     const copy = this.selectedWasteActivities.map(({ id, referenceName }) => ({ id, referenceName }))
     return addMatchingItemsToList(copy, this.allWasteActivities)
+  }
+
+  // Return array of formatted names of selected activities
+  get wasteActivityNames () {
+    return this.wasteActivitiesValues.map(activity => this.formattedActivityName(activity))
   }
 
   get wasteActivitiesLength () {

--- a/src/models/wasteActivities.model.js
+++ b/src/models/wasteActivities.model.js
@@ -97,7 +97,6 @@ module.exports = class WasteActivities {
   // Reference name of an activity is included if there is one
   // Note that the – is an en-dash
   formattedActivityName (activity) {
-    console.log(activity)
     const { item, referenceName } = activity
     return referenceName ? `${item.itemName} – ${referenceName}` : item.itemName
   }

--- a/test/models/checkList/mcpBespokePermit.check.test.js
+++ b/test/models/checkList/mcpBespokePermit.check.test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 const Mocks = require('../../helpers/mocks')
 
 const BaseCheck = require('../../../src/models/checkList/base.check')
-const McpBespokeTypeCheck = require('../../../src/models/checkList/mcpBespokeType.check')
+const McpBespokePermitCheck = require('../../../src/models/checkList/mcpBespokePermit.check')
 
 const prefix = 'section-permit'
 
@@ -27,9 +27,9 @@ lab.afterEach(() => {
   sandbox.restore()
 })
 
-lab.experiment('MCP Bespoke Type Check tests:', () => {
+lab.experiment('MCP Bespoke Permit Check tests:', () => {
   lab.test('buildlines works correctly', async () => {
-    const check = new McpBespokeTypeCheck()
+    const check = new McpBespokePermitCheck()
     const lines = await check.buildLines()
 
     const { heading, headingId, answers, links } = lines.pop()

--- a/test/models/checkList/standardRulesPermit.check.test.js
+++ b/test/models/checkList/standardRulesPermit.check.test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 const Mocks = require('../../helpers/mocks')
 
 const BaseCheck = require('../../../src/models/checkList/base.check')
-const PermitCheck = require('../../../src/models/checkList/permit.check')
+const PermitCheck = require('../../../src/models/checkList/standardRulesPermit.check')
 
 const prefix = 'section-permit'
 let sandbox
@@ -26,7 +26,7 @@ lab.afterEach(() => {
   sandbox.restore()
 })
 
-lab.experiment('Permit Check tests:', () => {
+lab.experiment('Standard Rules Permit Check tests:', () => {
   lab.test('buildlines works correctly', async () => {
     const check = new PermitCheck()
     const lines = await check.buildLines()

--- a/test/models/checkList/wasteActivities.check.test.js
+++ b/test/models/checkList/wasteActivities.check.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const Lab = require('@hapi/lab')
+const lab = exports.lab = Lab.script()
+const Code = require('@hapi/code')
+const sinon = require('sinon')
+
+const BaseCheck = require('../../../src/models/checkList/base.check')
+const WasteActivitiesCheck = require('../../../src/models/checkList/wasteActivities.check')
+const { path } = require('../../../src/routes').WASTE_ACTIVITY_CONTINUE
+
+const fakeWasteActivities = { wasteActivityNames: [
+  'ACTIVITY_1',
+  'ACTIVITY_2',
+  'ACTIVITY_3'
+] }
+
+const prefix = 'section-activity'
+
+let sandbox
+
+lab.beforeEach(() => {
+  // Create a sinon sandbox
+  sandbox = sinon.createSandbox()
+
+  // Stub the asynchronous base methods
+  sandbox.stub(BaseCheck.prototype, 'getWasteActivities').value(() => fakeWasteActivities)
+})
+
+lab.afterEach(() => {
+  // Restore the sandbox to make sure the spies are removed correctly
+  sandbox.restore()
+})
+
+lab.experiment('WasteActivities Check tests:', () => {
+  lab.experiment('buildlines', () => {
+    let check
+    let lines
+
+    lab.beforeEach(async () => {
+      check = new WasteActivitiesCheck()
+      lines = await check.buildLines()
+    })
+
+    lab.test(`(waste activities line) works correctly`, async () => {
+      const { heading, headingId, answers, links } = lines.pop()
+      Code.expect(heading).to.equal(heading)
+      Code.expect(headingId).to.equal(`${prefix}-heading`)
+
+      answers.forEach(({ answer, answerId }, answerIndex) => {
+        Code.expect(answerId).to.equal(`${prefix}-answer-${answerIndex + 1}`)
+        const activity = fakeWasteActivities.wasteActivityNames[answerIndex]
+        Code.expect(answer).to.equal(activity)
+      })
+
+      const { link, linkId, linkType } = links.pop()
+      Code.expect(link).to.equal(path)
+      Code.expect(linkType).to.equal('waste activities')
+      Code.expect(linkId).to.equal(`${prefix}-link`)
+    })
+  })
+})

--- a/test/models/checkList/wasteBespokePermit.check.test.js
+++ b/test/models/checkList/wasteBespokePermit.check.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const Lab = require('@hapi/lab')
+const lab = exports.lab = Lab.script()
+const Code = require('@hapi/code')
+const sinon = require('sinon')
+
+const WasteBespokePermitCheck = require('../../../src/models/checkList/wasteBespokePermit.check')
+const { path } = require('../../../src/routes').BESPOKE_OR_STANDARD_RULES
+
+const prefix = 'section-permit'
+
+let sandbox
+
+lab.beforeEach(() => {
+  // Create a sinon sandbox
+  sandbox = sinon.createSandbox()
+})
+
+lab.afterEach(() => {
+  // Restore the sandbox to make sure the spies are removed correctly
+  sandbox.restore()
+})
+
+lab.experiment('WasteBespokePermit Check tests:', () => {
+  lab.experiment('buildlines', () => {
+    let check
+    let lines
+
+    lab.beforeEach(async () => {
+      check = new WasteBespokePermitCheck()
+      lines = await check.buildLines()
+    })
+
+    lab.test(`(waste bespoke permit line) works correctly`, async () => {
+      const { heading, headingId, answers, links } = lines.pop()
+      Code.expect(heading).to.equal(heading)
+      Code.expect(headingId).to.equal(`${prefix}-heading`)
+
+      const { answerId, answer } = answers.pop()
+      Code.expect(answerId).to.equal(`${prefix}-answer`)
+      Code.expect(answer).to.equal('Bespoke environmental permit')
+
+      const { link, linkId, linkType } = links.pop()
+      Code.expect(link).to.equal(path)
+      Code.expect(linkType).to.equal('bespoke environmental permit')
+      Code.expect(linkId).to.equal(`${prefix}-link`)
+    })
+  })
+})

--- a/test/models/wasteActivities.model.test.js
+++ b/test/models/wasteActivities.model.test.js
@@ -88,6 +88,26 @@ lab.experiment('WasteActivities test:', () => {
     Code.expect(wasteActivitiesData[0].item).to.not.exist()
   })
 
+  lab.experiment('get wasteActivityNames:', () => {
+    lab.test('Correct list when there is a reference name', async () => {
+      const allWasteActivities = await WasteActivities.getAllWasteActivities()
+      const wasteActivities = new WasteActivities(allWasteActivities, [{ id: 'FAKE_ACTIVITY_ID', referenceName: 'Fake name' }])
+      const wasteActivityNames = wasteActivities.wasteActivityNames
+      Code.expect(wasteActivityNames).to.exist()
+      Code.expect(wasteActivityNames.length).to.equal(1)
+      Code.expect(wasteActivityNames[0]).to.equal('Fake activity text – Fake name')
+    })
+
+    lab.test('Correct list when there is no reference name', async () => {
+      const allWasteActivities = await WasteActivities.getAllWasteActivities()
+      const wasteActivities = new WasteActivities(allWasteActivities, [{ id: 'FAKE_ACTIVITY_ID' }])
+      const wasteActivityNames = wasteActivities.wasteActivityNames
+      Code.expect(wasteActivityNames).to.exist()
+      Code.expect(wasteActivityNames.length).to.equal(1)
+      Code.expect(wasteActivityNames[0]).to.equal('Fake activity text')
+    })
+  })
+
   lab.experiment('hasDuplicateWasteActivities:', () => {
     lab.test('false when no activities', async () => {
       const wasteActivities = new WasteActivities([], [])
@@ -96,9 +116,9 @@ lab.experiment('WasteActivities test:', () => {
 
     lab.test('false when no duplicates', async () => {
       const wasteActivities = new WasteActivities([], [
-          { id: 'FAKE_ACTIVITY_ID', referenceName: '' },
-          { id: 'FAKE_ACTIVITY_ID2', referenceName: '' }
-        ])
+        { id: 'FAKE_ACTIVITY_ID', referenceName: '' },
+        { id: 'FAKE_ACTIVITY_ID2', referenceName: '' }
+      ])
       Code.expect(wasteActivities.hasDuplicateWasteActivities).to.be.false()
     })
 
@@ -138,9 +158,9 @@ lab.experiment('WasteActivities test:', () => {
       ])
       const duplicateValues = wasteActivities.duplicateWasteActivitiesValues
       const duplicateIndexes = duplicateValues.map(({ index }) => index)
-      Code.expect(duplicateIndexes).to.equal([1,2,4,5])
+      Code.expect(duplicateIndexes).to.equal([1, 2, 4, 5])
       const duplicateOrders = duplicateValues.map(({ order }) => order)
-      Code.expect(duplicateOrders).to.equal([1,2,1,2])
+      Code.expect(duplicateOrders).to.equal([1, 2, 1, 2])
     })
   })
 
@@ -243,7 +263,7 @@ lab.experiment('WasteActivities test:', () => {
     lab.test(`Doesn't add if the list is full`, async () => {
       mocks.dataStore.data.wasteActivities = []
       for (let i = 0; i < 50; i++) {
-        mocks.dataStore.data.wasteActivities.push({ id: 'FAKE_ACTIVITY_ID', referenceName: 'Fake 1' },)
+        mocks.dataStore.data.wasteActivities.push({ id: 'FAKE_ACTIVITY_ID', referenceName: 'Fake 1' })
       }
       const wasteActivities = await WasteActivities.get(mocks.context)
       Code.expect(wasteActivities.selectedWasteActivities.length).to.equal(50)

--- a/test/routes/taskList.route.test.js
+++ b/test/routes/taskList.route.test.js
@@ -200,6 +200,7 @@ lab.beforeEach(() => {
   sandbox.stub(StandardRulesTaskList, 'buildTaskList').value(() => fakeTaskList)
   sandbox.stub(BespokeTaskList, 'buildTaskList').value(() => fakeTaskList)
   sandbox.stub(McpBespokeTaskList, 'buildTaskList').value(() => fakeTaskList)
+  sandbox.stub(WasteActivities.prototype, 'formattedActivityName').value(() => 'ACTIVITY_NAME')
 })
 
 lab.afterEach(() => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-3435

Additional changes made:
- Amended`taskList.controller` to display activity names consistent with Check Your Answers.
- Renamed `permit.check` to be clearer about the regime it applies to.
- Renamed `mcpBespokeType.check` to be clearer about what it displays.