### PR TITLE
WE-3458: Fix issue with PDF

### DIFF
--- a/src/models/checkList/checkList.js
+++ b/src/models/checkList/checkList.js
@@ -44,7 +44,7 @@ const PreApplicationCheck = require('./preApplication.check')
 const WasteTreatmentCapacityCheck = require('./wasteTreatmentCapacity.check')
 
 const STANDARD_RULES_CHECKS = [
-  'PermitCheck'
+  'StandardRulesPermitCheck'
 ]
 
 const MCP_BESPOKE_CHECKS = [


### PR DESCRIPTION
Additional payment error was being caused by the PDF creation failing, due to `PermitCheck` checklist item being renamed to `StandardRulesPermitCheck` but not renamed everywhere.