### PR TITLE
Implement GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,16 @@ jobs:
       
       - name: Install application dependencies
         run: npm ci
-        
+
+      # Also modifies the test coverage output file to use the path expected by the SonarCloud scanner
+      # More info here: https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
       - name: Unit test
         run: |
           gulp test-ci
           gulp html-hint
           gulp standard
           gulp check-handlebars
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' lcov.info
           
       - name: SonarCloud scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# The main workflow for continuous integration of development changes
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  # A single job that performs all the build steps
+  build:
+    runs-on: ubuntu-latest
+    env:
+      COOKIE_VALIDATION_PASSWORD: 7044a01fe9e9e4960eb9be8c75bc61ca6360b2adb0cd84673f51da0e16b65249c04f5f358b4bfbcc03b64cce6baa95172148b68a5ac354d8153b60804ec09943
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+      
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '10'
+      
+      - name: Install gulp
+        run: npm install -g gulp-cli
+      
+      - name: Install application dependencies
+        run: npm ci
+        
+      - name: Unit test
+        run: |
+          gulp test-ci
+          gulp html-hint
+          gulp standard
+          gulp check-handlebars
+          
+      - name: SonarCloud scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any. This token is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+        with:
+          args: >
+            -Dsonar.organization=defra
+            -Dsonar.projectKey=DEFRA_waste-permits
+            -Dsonar.javascript.lcov.reportPaths=lcov.info


### PR DESCRIPTION
Replicating steps from the existing Travis integration, but excluding Greenkeeper as this service has been switched off and using integration with SonarCloud instead of CodeClimate