### PR TITLE
Update nock to v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,12 +1855,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -3011,20 +3005,6 @@
         "url-to-options": "^1.0.1"
       }
     },
-    "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -3038,12 +3018,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -3935,15 +3909,6 @@
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -6278,12 +6243,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-intrinsic": {
@@ -10516,6 +10475,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.unset": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
@@ -11209,20 +11174,15 @@
       }
     },
     "nock": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.0.tgz",
+      "integrity": "sha512-3N3DUY8XYrxxzWazQ+nSBpiaJ3q6gcpNh4gXovC/QBxrsvNp4tq+wsLHF6mJ3nrn3lPLn7KCJqKxy/9aD+0fdw==",
       "dev": true,
       "requires": {
-        "chai": "^4.1.2",
         "debug": "^4.1.0",
-        "deep-equal": "^1.0.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.5",
-        "mkdirp": "^0.5.0",
-        "propagate": "^1.0.0",
-        "qs": "^6.5.1",
-        "semver": "^5.5.0"
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -11238,12 +11198,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -12623,12 +12577,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
-    },
     "pdfkit": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.12.1.tgz",
@@ -12967,9 +12915,9 @@
       }
     },
     "propagate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proto-list": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-watch": "^5.0.1",
     "htmlhint": "^0.15.1",
     "inquirer": "^8.1.1",
-    "nock": "^10.0.6",
+    "nock": "^13.1.0",
     "node-sass": "^6.0.1",
     "run-sequence": "^2.2.1",
     "sinon": "^11.1.1",

--- a/test/services/dynamicsDal.service.test.js
+++ b/test/services/dynamicsDal.service.test.js
@@ -142,29 +142,26 @@ lab.experiment('Dynamics Service tests:', () => {
   })
 
   lab.test('search() handles unknown result from Dynamics', async () => {
-    await dynamicsDal.search('__DYNAMICS_KNOWN_BAD_QUERY__')
-      .catch((err) => {
-        Code.expect(dynamicsCallSpy.callCount).to.equal(1)
-        Code.expect(err.query).to.endWith('/__DYNAMICS_KNOWN_BAD_QUERY__')
-        Code.expect(err.dataObject).to.equal(undefined)
-        Code.expect(err.message).to.endWith('KNOWN_BAD_QUERY')
-        Code.expect(loggingSpy.callCount).to.equal(1)
-      })
+    const err = await Code.expect(dynamicsDal.search('__DYNAMICS_KNOWN_BAD_QUERY__')).to.reject()
+
+    Code.expect(dynamicsCallSpy.callCount).to.equal(1)
+    Code.expect(err.query).to.endWith('/__DYNAMICS_KNOWN_BAD_QUERY__')
+    Code.expect(err.dataObject).to.equal(undefined)
+    Code.expect(err.message).to.endWith('KNOWN_BAD_QUERY')
+    Code.expect(loggingSpy.callCount).to.equal(1)
   })
 
   lab.test('search() handles known bad result from Dynamics', async () => {
-    await dynamicsDal.search('__DYNAMICS_UNKNOWN_BAD_QUERY__')
-      .catch((err) => {
-        Code.expect(dynamicsCallSpy.callCount).to.equal(1)
-        Code.expect(err.message).to.endWith('Code: 500, Message: null')
-      })
+    const err = await Code.expect(dynamicsDal.search('__DYNAMICS_UNKNOWN_BAD_QUERY__')).to.reject()
+
+    Code.expect(dynamicsCallSpy.callCount).to.equal(1)
+    Code.expect(err.message).to.endWith('Code: 500, Message: null')
   })
 
   lab.test('search() times out based on app configuration', async () => {
-    await dynamicsDal.search('__DYNAMICS_TIMEOUT_QUERY__')
-      .catch((err) => {
-        Code.expect(dynamicsCallSpy.callCount).to.equal(1)
-        Code.expect(err.message).to.equal('socket hang up')
-      })
+    const err = await Code.expect(dynamicsDal.search('__DYNAMICS_TIMEOUT_QUERY__')).to.reject()
+
+    Code.expect(dynamicsCallSpy.callCount).to.equal(1)
+    Code.expect(err.message).to.equal('socket hang up')
   })
 })

--- a/test/services/dynamicsDal.service.test.js
+++ b/test/services/dynamicsDal.service.test.js
@@ -98,7 +98,7 @@ lab.beforeEach(() => {
 
   nock(`https://${config.dynamicsWebApiHost}`)
     .get(`${config.dynamicsWebApiPath}__DYNAMICS_TIMEOUT_QUERY__`)
-    .socketDelay(7000)
+    .delayConnection(150000)
     .reply(200, {})
 
   // Create a sinon sandbox to stub methods


### PR DESCRIPTION
Updating dev dependency `nock` to v13 causes one of the tests to break due to it using a deprecated method `socketDelay`. This change fixes the test:
- Replaces `socketDelay` with the method `delayConnection`;
- increases the `delayConnection` timeout past the configured timeout value, which causes `nock` to send a timeout response immediately.

While making this change, we discovered that the tests expecting an error to be thrown would pass even if no error was thrown; this was due to the assertions being wrapped in a catch block, so if no error was thrown then the assertions were skipped over and the test would therefore pass. We therefore rewrite the tests so that the assertions are always executed, regardless of whether or not an error is thrown.