### PR TITLE
Fix for multi-value checkboxes

### DIFF
--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -230,4 +230,21 @@ module.exports = class BaseController {
         }
     }
   }
+
+  static getMultivalueFormValueAsArray (valueFromPayload) {
+    if (!valueFromPayload) {
+      return []
+    }
+    // Older versions of the framework concatenate multiple values into a comma-separated string
+    if (typeof valueFromPayload === 'string') {
+      return valueFromPayload.split(',', 50) // Limit of 50 to guard against rogue values
+    }
+    // Newer versions already provide them as an array
+    if (Array.isArray(valueFromPayload)) {
+      return valueFromPayload
+    }
+    // Anything else that has already been processed into a different data type will just be treated
+    // as a single array entry
+    return [valueFromPayload]
+  }
 }

--- a/src/controllers/wasteAssessment.controller.js
+++ b/src/controllers/wasteAssessment.controller.js
@@ -59,7 +59,7 @@ module.exports = class WasteAssessmentController extends BaseController {
 
     const { assessment: assessments } = request.payload
 
-    const wasteAssessments = assessments ? assessments.split(',') : []
+    const wasteAssessments = BaseController.getMultivalueFormValueAsArray(assessments)
     await taskDeterminants.save({ wasteAssessments })
 
     await DataStore.save(context, { alreadyConfirmedWasteAssessments: true })

--- a/src/controllers/wasteDisposalCodes.controller.js
+++ b/src/controllers/wasteDisposalCodes.controller.js
@@ -36,7 +36,7 @@ module.exports = class WasteDisposalCodesController extends BaseController {
     const context = await RecoveryService.createApplicationContext(h)
     const wasteDisposalAndRecoveryCodes = await getModelForProvidedActivityIndex(context, request)
 
-    const selectedWasteDisposalCodes = request.payload.code ? request.payload.code.split(',', 50) : []
+    const selectedWasteDisposalCodes = BaseController.getMultivalueFormValueAsArray(request.payload.code)
 
     wasteDisposalAndRecoveryCodes.setWasteDisposalCodes(selectedWasteDisposalCodes)
     await wasteDisposalAndRecoveryCodes.save(context)

--- a/src/controllers/wasteRecoveryCodes.controller.js
+++ b/src/controllers/wasteRecoveryCodes.controller.js
@@ -36,7 +36,7 @@ module.exports = class WasteDisposalCodesController extends BaseController {
     const context = await RecoveryService.createApplicationContext(h)
     const wasteDisposalAndRecoveryCodes = await getModelForProvidedActivityIndex(context, request)
 
-    const selectedWasteRecoveryCodes = request.payload.code ? request.payload.code.split(',', 50) : []
+    const selectedWasteRecoveryCodes = BaseController.getMultivalueFormValueAsArray(request.payload.code)
 
     wasteDisposalAndRecoveryCodes.setWasteRecoveryCodes(selectedWasteRecoveryCodes)
     await wasteDisposalAndRecoveryCodes.save(context)

--- a/test/controllers/base.controller.test.js
+++ b/test/controllers/base.controller.test.js
@@ -29,4 +29,31 @@ lab.experiment('Base Controller tests:', () => {
     Code.expect(pageContext.formAction).to.equal(route.path)
     Code.expect(pageContext.browserIsIE).to.equal(true)
   })
+
+  lab.experiment('Handles form parameters as arrays:', () => {
+    lab.test('for array', () => {
+      const result = BaseController.getMultivalueFormValueAsArray(['a', 'b'])
+      Code.expect(result).to.equal(['a', 'b'])
+    })
+    lab.test('for comma-separated string', () => {
+      const result = BaseController.getMultivalueFormValueAsArray('a,b')
+      Code.expect(result).to.equal(['a', 'b'])
+    })
+    lab.test('for single string', () => {
+      const result = BaseController.getMultivalueFormValueAsArray('a')
+      Code.expect(result).to.equal(['a'])
+    })
+    lab.test('for non-text value', () => {
+      const result = BaseController.getMultivalueFormValueAsArray(1)
+      Code.expect(result).to.equal([1])
+    })
+    lab.test('for empty value', () => {
+      const result = BaseController.getMultivalueFormValueAsArray('')
+      Code.expect(result).to.equal([])
+    })
+    lab.test('for missing value', () => {
+      const result = BaseController.getMultivalueFormValueAsArray()
+      Code.expect(result).to.equal([])
+    })
+  })
 })

--- a/test/routes/wasteAssessment.route.test.js
+++ b/test/routes/wasteAssessment.route.test.js
@@ -212,6 +212,24 @@ lab.experiment('Waste assessments', () => {
       Code.expect(res.headers.location).to.equal(nextPath)
     })
 
+    lab.test('POST with multiple waste assessments also redirects to next route', async () => {
+      postRequest.payload.assessment = ['ass-1', 'ass-3']
+      const res = await server.inject(postRequest)
+      Code.expect(saveSpy.called).to.be.true()
+      Code.expect(dataStoreSaveSpy.called).to.be.true()
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers.location).to.equal(nextPath)
+    })
+
+    lab.test('POST with old-style concatenated waste assessments still redirects to next route', async () => {
+      postRequest.payload.assessment = 'ass-1,ass-3'
+      const res = await server.inject(postRequest)
+      Code.expect(saveSpy.called).to.be.true()
+      Code.expect(dataStoreSaveSpy.called).to.be.true()
+      Code.expect(res.statusCode).to.equal(302)
+      Code.expect(res.headers.location).to.equal(nextPath)
+    })
+
     lab.test('POST for waste assessment that cannot be applied for online shows apply offline page', async () => {
       postRequest.payload = { assessment: 'ass-2' }
       mocks.taskDeterminants.wasteAssessments = [mocks.taskDeterminants.allAssessments[1]]

--- a/test/routes/wasteDisposalCodes.controller.test.js
+++ b/test/routes/wasteDisposalCodes.controller.test.js
@@ -83,11 +83,12 @@ lab.experiment('Waste disposal codes controller tests:', () => {
   })
 
   lab.experiment('POST:', () => {
-    const postRequest = { params: { activityIndex: 0 }, payload: { code: 'd01,d02' } }
+    let postRequest
     let redirectSpy
     let setSpy
     let saveSpy
     lab.beforeEach(() => {
+      postRequest = { params: { activityIndex: 0 }, payload: { code: ['d01', 'd02'] } }
       redirectSpy = sandbox.stub(Controller.prototype, 'redirect')
       setSpy = sandbox.stub(WasteDisposalAndRecoveryCodes.prototype, 'setWasteDisposalCodes')
       saveSpy = sandbox.stub(WasteDisposalAndRecoveryCodes.prototype, 'save')
@@ -95,6 +96,14 @@ lab.experiment('Waste disposal codes controller tests:', () => {
     })
 
     lab.test('POST sets the selected codes and saves', async () => {
+      await controller.doPost(postRequest)
+      Code.expect(setSpy.called).to.be.true()
+      Code.expect(setSpy.args[0][0]).to.equal(['d01', 'd02'])
+      Code.expect(saveSpy.called).to.be.true()
+    })
+
+    lab.test('POST still works with old-style concatenated values', async () => {
+      postRequest.payload.code = 'd01,d02'
       await controller.doPost(postRequest)
       Code.expect(setSpy.called).to.be.true()
       Code.expect(setSpy.args[0][0]).to.equal(['d01', 'd02'])

--- a/test/routes/wasteRecoveryCodes.controller.test.js
+++ b/test/routes/wasteRecoveryCodes.controller.test.js
@@ -81,11 +81,12 @@ lab.experiment('Waste recovery codes controller tests:', () => {
   })
 
   lab.experiment('POST:', () => {
-    let postRequest = { params: { activityIndex: 0 }, payload: { code: 'r01,r02' } }
+    let postRequest
     let redirectSpy
     let setSpy
     let saveSpy
     lab.beforeEach(() => {
+      postRequest = { params: { activityIndex: 0 }, payload: { code: ['r01', 'r02'] } }
       redirectSpy = sandbox.stub(Controller.prototype, 'redirect')
       setSpy = sandbox.stub(WasteDisposalAndRecoveryCodes.prototype, 'setWasteRecoveryCodes')
       saveSpy = sandbox.stub(WasteDisposalAndRecoveryCodes.prototype, 'save')
@@ -93,6 +94,14 @@ lab.experiment('Waste recovery codes controller tests:', () => {
     })
 
     lab.test('POST sets the selected codes and saves', async () => {
+      await controller.doPost(postRequest)
+      Code.expect(setSpy.called).to.be.true()
+      Code.expect(setSpy.args[0][0]).to.equal(['r01', 'r02'])
+      Code.expect(saveSpy.called).to.be.true()
+    })
+
+    lab.test('POST still works with old-style concatenated values', async () => {
+      postRequest.payload.code = 'r01,r02'
       await controller.doPost(postRequest)
       Code.expect(setSpy.called).to.be.true()
       Code.expect(setSpy.args[0][0]).to.equal(['r01', 'r02'])


### PR DESCRIPTION
Request payloads no longer concatenate duplicate form field values, instead returning them as an array of values.

Updates to the underlying libraries have caused this change to manifest in the application and were not caught by the unit tests.

These changes:
 - implement a method that can be used by controllers when they are expecting multiple values to be selected
 - use that method in the controllers where this is the case
 - add some explicit tests to those controllers for this scenario